### PR TITLE
Change RainbowMod's name to Fabeline

### DIFF
--- a/RainbowMod/metadata.yaml
+++ b/RainbowMod/metadata.yaml
@@ -1,4 +1,4 @@
-﻿Name: RainbowMod
+﻿Name: Fabeline
 Version: 1.0.0
 DLL: RainbowMod.dll
 Dependencies:


### PR DESCRIPTION
I don't entirely see what mod name localization support has to do with this.