### PR TITLE
[WIP] Fix nix package expression.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ fetchNuGet, buildDotnetPackage, dotnetPackages }:
+{ fetchNuGet, buildDotnetPackage }:
 
 let
   HookedMethod = fetchNuGet {
@@ -46,9 +46,8 @@ in buildDotnetPackage rec {
     ln -sn ${ValueTuple}/lib/dotnet/System.ValueTuple packages/System.ValueTuple.${ValueTuple.version}
   '';
 
-#  Is this still necessary?
-#  postInstall = ''
-#    mkdir -pv "$out/lib/dotnet/${baseName}"
-#    sed -i '2i cd $1' $out/bin/miniinstaller
-#  '';
+  postInstall = ''
+    mkdir -pv "$out/lib/dotnet/${baseName}"
+    sed -i '2i cd $1' $out/bin/miniinstaller
+  '';
 }

--- a/default.nix
+++ b/default.nix
@@ -48,6 +48,7 @@ in buildDotnetPackage rec {
 
   postInstall = ''
     mkdir -pv "$out/lib/dotnet/${baseName}"
+    sed -i "2i cp -r $out/lib/dotnet/Everest/* "'$1' $out/bin/miniinstaller
     sed -i '2i cd $1' $out/bin/miniinstaller
   '';
 }

--- a/default.nix
+++ b/default.nix
@@ -1,22 +1,52 @@
-let nixpkgs = import <nixpkgs> {};
-    stdenv = nixpkgs.stdenv;
-    nuget = nixpkgs.dotnetPackages.Nuget;
+{ fetchNuGet, buildDotnetPackage, dotnetPackages }:
 
-in rec {
-  everest = nixpkgs.buildDotnetPackage rec {
-    baseName = "Everest";
-    version = "0.0.0";
-    name = "${baseName}-dev-${version}";
-    
-    src = ./.;
-
-    xBuildFiles = [ "Celeste.Mod.mm/Celeste.Mod.mm.csproj" "MiniInstaller/MiniInstaller.csproj" ];
-
-    outputFiles = [ "Celeste.Mod.mm/bin/Debug/*" /* vim syntax bug workaround */ "MiniInstaller/bin/Debug/*" /* vim syntax bug workaround */ ];
-    
-    postInstall = ''
-        mkdir -pv "$out/lib/dotnet/${baseName}"
-        sed -i '2i cd $1' $out/bin/miniinstaller
-    '';
+let
+  HookedMethod = fetchNuGet {
+    baseName = "HookedMethod";
+    version = "0.3.3-beta";
+    sha256 = "5abc349e55d57777fed6fc5d65cda4cc97aa8cb1dc87927dea7d4182f3fa57df";
+    outputFiles = [ "lib/*" ];
   };
+
+  Cecil = fetchNuGet {
+    baseName = "Mono.Cecil";
+    version = "0.10.0";
+    sha256 = "f4c64a1dd69df48fe50952a9ece8c1430e54650703be432c41c93b52802cb864";
+    outputFiles = [ "lib/*" ];
+  };
+
+  ValueTuple = fetchNuGet {
+    baseName = "System.ValueTuple";
+    version = "4.4.0";
+    sha256 = "68c3ad8ff7deb843c13710fd115c8e8d64492f639fa434059e1440a311a04424";
+    outputFiles = ["lib/*"];
+  };
+
+in buildDotnetPackage rec {
+  baseName = "Everest";
+  version = "0.0.0";
+  name = "${baseName}-dev-${version}";
+
+  src = ./.;
+  buildInputs = [ HookedMethod Cecil ValueTuple ];
+
+  # Re-add Miniinstaler once everything else works
+  xBuildFiles = [ "Celeste.Mod.mm/Celeste.Mod.mm.csproj" ]; # "MiniInstaller/MiniInstaller.csproj" ];
+  outputFiles = [ "Celeste.Mod.mm/bin/Debug/*" /* vim syntax bug workaround */ ]; # "MiniInstaller/bin/Debug/*" /* vim syntax bug workaround */ ];
+
+  # could probably loop over buildInputs
+  preBuild = ''
+    # Fake nuget restore
+    mkdir -p  Celeste.Mod.mm/packages/HookedMethod.${HookedMethod.version}
+    ln -sn ${HookedMethod}/lib/ Celeste.Mod.mm/packages/HookedMethod.${HookedMethod.version}/lib
+    mkdir -p  Celeste.Mod.mm/packages/Mono.Cecil.${Cecil.version}
+    ln -sn ${Cecil}/lib/ Celeste.Mod.mm/packages/Mono.Cecil.${Cecil.version}/lib
+    mkdir -p  Celeste.Mod.mm/packages/ValueTuple.${ValueTuple.version}
+    ln -sn ${ValueTuple}/lib/ Celeste.Mod.mm/packages/ValueTuple.${ValueTuple.version}/lib
+  '';
+
+  postInstall = ''
+    mkdir -pv "$out/lib/dotnet/${baseName}"
+    sed -i '2i cd $1' $out/bin/miniinstaller
+  '';
 }

--- a/run-nuget.sh
+++ b/run-nuget.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-source $stdenv/setup
-$nuget restore

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,9 @@
+with import <nixpkgs> {};
+
+let
+  Everest = callPackage ./default.nix {};
+
+in stdenv.mkDerivation {
+  name = "everestEnv";
+  buildInputs = [ Everest ];
+}


### PR DESCRIPTION
I've fixed most issues with the nix package, there is; however, still an error when calling the miniinstaller that I don't really know how to fix.

Changes and Motivations:
- Use fetchNuGet instead of calling nuget restore. Nuget can lead to non deterministic builds.
- Provide a shell.nix file for users (so there is no longer the need to actually install the Everest installer)

Build Instructions:
The project can be built by either invoking nix-shell or by running:
`nix-build -E "with import <nixpkgs> {}; callPackage ./default.nix {}"`

It builds on both nixos-18.09 and nixos-unstable.

ToDo:
- remove old remains of old attempts to get nix working.
- fix error during installation.

Error:
[miniinstaller-log.txt](https://github.com/EverestAPI/Everest/files/2390252/miniinstaller-log.txt)
For reference, here is the file/directory tree of the build/result folder:
[result.txt](https://github.com/EverestAPI/Everest/files/2390270/result.txt)