### PR TITLE
Dialog Trigger now follows naming conventions

### DIFF
--- a/Celeste.Mod.mm/Patches/Level.cs
+++ b/Celeste.Mod.mm/Patches/Level.cs
@@ -188,7 +188,7 @@ namespace Celeste {
                 return true;
             }
 
-            if (entityData.Name == "everest/dialogtrigger")
+            if (entityData.Name == "everest/dialogTrigger")
             {
                 int id = entityData.ID;
                 EntityID entityID = new EntityID(levelData.Name, id);


### PR DESCRIPTION
Might cause issues if Exudias mod is updated to use the `everest/dialogtrigger` name.
Fixes inconsistencies for `everest/flagTrigger` and ever other trigger in the base game.