### PR TITLE
Fix level set ordering

### DIFF
--- a/Celeste.Mod.mm/Patches/SaveData.cs
+++ b/Celeste.Mod.mm/Patches/SaveData.cs
@@ -283,7 +283,7 @@ namespace Celeste {
             }
 
             // Order the levelsets to appear just as their areas appear in AreaData.Areas
-            LevelSets.OrderBy(set => set.AreaOffset);
+            LevelSets.Sort((set1, set2) => set1.AreaOffset.CompareTo(set2.AreaOffset));
 
             // Carry over any progress from vanilla saves.
             if (LastArea_Unsafe.ID != 0)


### PR DESCRIPTION
A while ago I noticed an issue with Everest when adding new mods. I can reproduce it with these steps:
- get a clean save file with no maps installed
- install Early Core, get a strawberry then return to map
- install Crystalized :arrow_right: in the menu you see 1 strawberry on Crystalized and none on Early Core. If you play Early Core again the strawberry you got before is no longer collected
- if you open the save file and swap the LevelSetStats the issue is fixed

Actually this happens whenever you install a new map that comes before an already installed map in alphabetical order. Ordering the LevelSetStats properly in the save file fixes the issue.

Everest actually tries to do that ordering, but it does not actually do it: this is what this PR is about.
Hope this will help, I really wanted to contribute somehow :sweat_smile: (I am max480#4596 on the Discord server by the way)