### PR TITLE
(Partially) fix save loading in Everest 849

### DIFF
--- a/Celeste.Mod.mm/Patches/SaveData.cs
+++ b/Celeste.Mod.mm/Patches/SaveData.cs
@@ -72,7 +72,6 @@ namespace Celeste {
 
         // Legacy code should benefit from the new LevelSetStats.
 
-        [XmlAttribute]
         [MonoModLinkFrom("System.Int32 Celeste.SaveData::UnlockedAreas_Unsafe")]
         public new int UnlockedAreas;
 
@@ -97,7 +96,6 @@ namespace Celeste {
         }
 
 
-        [XmlAttribute]
         [MonoModLinkFrom("System.Int32 Celeste.SaveData::TotalStrawberries_Unsafe")]
         public new int TotalStrawberries;
 

--- a/Celeste.Mod.mm/Patches/SaveData.cs
+++ b/Celeste.Mod.mm/Patches/SaveData.cs
@@ -122,7 +122,6 @@ namespace Celeste {
         }
 
 
-        [XmlAttribute]
         [MonoModLinkFrom("System.Collections.Generic.List`1<Celeste.AreaStats> Celeste.SaveData::Areas_Unsafe")]
         public new List<AreaStats> Areas;
 


### PR DESCRIPTION
This [XmlAttribute] somehow became a problem after the dependency upgrade: the save file loading fails with the exception `Cannot serialize member 'Areas' of type Celeste.AreaStats. XmlAttribute/XmlText cannot be used to encode complex types.`

Now the saves are loading (no more showing "Load failed") but there are still some mistakes (at least in strawberry count and unlocked level count).