### PR TITLE
Fix crash when calling ILCursor.GotoLabel(ILLabel) with a newer MonoMod version

### DIFF
--- a/Celeste.Mod.mm/Mod/Helpers/MonoModUpdateShim.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/MonoModUpdateShim.cs
@@ -23,6 +23,7 @@ namespace Celeste.Mod.Helpers {
 
         public static class _ILCursor {
             public static void Remove(ILCursor c) => c.Remove();
+            [ShimFromAttribute("System.Void MonoMod.Cil.ILCursor::GotoLabel(MonoMod.Cil.ILLabel)")]
             public static void GotoLabel(ILCursor c, ILLabel label) => c.GotoLabel(label);
             public static void MoveAfterLabel(ILCursor c) => c.MoveAfterLabels();
             public static void MoveBeforeLabel(ILCursor c) => c.MoveBeforeLabels();


### PR DESCRIPTION
This is a sort of follow-up to issue #45: while developing my code mod I tried calling `ILCursor.GotoLabel(ILLabel)` and got a crash. 😕 (The error was "The JIT compiler encountered an internal limitation")

So I did pretty much the same thing as PR #46 and tested it with both my code mod and the modified CelesteTAS-EverestInterop that calls pretty much everything in MonoModUpdateShim.