### PR TITLE
[Suggestion] Display missing dependencies in-game

### DIFF
--- a/Celeste.Mod.mm/Content/Dialog/English.txt
+++ b/Celeste.Mod.mm/Content/Dialog/English.txt
@@ -58,6 +58,7 @@
 
 	MODOPTIONS_COREMODULE_NOTLOADED_A= 						Some mods failed loading.
 	MODOPTIONS_COREMODULE_NOTLOADED_B= 						Please check your log.txt for more info.
+	MODOPTIONS_COREMODULE_NOTLOADED_NOTFOUND= 					not found
 
 # Sound Test
 	SOUNDTEST_TITLE=	SOUND TEST

--- a/Celeste.Mod.mm/Content/Dialog/French.txt
+++ b/Celeste.Mod.mm/Content/Dialog/French.txt
@@ -38,6 +38,10 @@
 
 	MODOPTIONS_COREMODULE_SOUNDTEST= 						Test sons
 
+	MODOPTIONS_COREMODULE_NOTLOADED_A= 						Certains mods n'ont pas pu être chargés.
+	MODOPTIONS_COREMODULE_NOTLOADED_B= 						Vérifiez votre log.txt pour plus d'informations.
+	MODOPTIONS_COREMODULE_NOTLOADED_NOTFOUND=					non trouvé(s)
+
 # Sound Test
 	SOUNDTEST_TITLE=	TEST SONS
 

--- a/Celeste.Mod.mm/Mod/Core/CoreModule.cs
+++ b/Celeste.Mod.mm/Mod/Core/CoreModule.cs
@@ -246,7 +246,9 @@ namespace Celeste.Mod.Core {
                                 }
                             }
 
-                            menu.Add(new TextMenuExt.SubHeaderExt(mod.Item1.Name + " | v." + mod.Item1.VersionString + missingDepsString) { HeightExtra = 0f, TextColor = Color.PaleVioletRed });
+                            menu.Add(new TextMenuExt.SubHeaderExt(mod.Item1.Name + " | v." + mod.Item1.VersionString + missingDepsString) {
+                                HeightExtra = 0f, TextColor = Color.PaleVioletRed
+                            });
                         }
                     }
                 }

--- a/Celeste.Mod.mm/Mod/Core/CoreModule.cs
+++ b/Celeste.Mod.mm/Mod/Core/CoreModule.cs
@@ -224,8 +224,30 @@ namespace Celeste.Mod.Core {
                     if (Everest.Loader.Delayed.Count > 0) {
                         menu.Add(new TextMenuExt.SubHeaderExt(Dialog.Clean("modoptions_coremodule_notloaded_a")) { HeightExtra = 0f, TextColor = Color.OrangeRed });
                         menu.Add(new TextMenuExt.SubHeaderExt(Dialog.Clean("modoptions_coremodule_notloaded_b")) { HeightExtra = 0f, TextColor = Color.OrangeRed });
-                        foreach (Tuple<EverestModuleMetadata, Action> mod in Everest.Loader.Delayed)
-                            menu.Add(new TextMenuExt.SubHeaderExt(mod.Item1.Name + " | v." + mod.Item1.VersionString) { HeightExtra = 0f, TextColor = Color.PaleVioletRed });
+
+                        foreach (Tuple<EverestModuleMetadata, Action> mod in Everest.Loader.Delayed) {
+                            string missingDepsString = "";
+                            if(mod.Item1.Dependencies != null) {
+                                // check for missing dependencies
+                                List<EverestModuleMetadata> missingDependencies = mod.Item1.Dependencies
+                                    .FindAll(dep => !Everest.Loader.DependencyLoaded(dep));
+
+                                if(missingDependencies.Count != 0) {
+                                    // format their names and versions, and join all of them in a single string
+                                    missingDepsString = string.Join(", ", missingDependencies.Select(dependency => dependency.Name + " | v." + dependency.VersionString));
+
+                                    // ensure that string is not too long, or else it would break the display
+                                    if (missingDepsString.Length > 40) {
+                                        missingDepsString = missingDepsString.Substring(0, 40) + "...";
+                                    }
+
+                                    // wrap that in a " ({list} not found)" message
+                                    missingDepsString = $" ({missingDepsString} {Dialog.Clean("modoptions_coremodule_notloaded_notfound")})";
+                                }
+                            }
+
+                            menu.Add(new TextMenuExt.SubHeaderExt(mod.Item1.Name + " | v." + mod.Item1.VersionString + missingDepsString) { HeightExtra = 0f, TextColor = Color.PaleVioletRed });
+                        }
                     }
                 }
 


### PR DESCRIPTION
Just a small addition I think would be useful for beginners. When a mod doesn't load because of a missing dependency, they are displayed in-game like this:
![image](https://user-images.githubusercontent.com/52103563/62365219-d4c9f980-b523-11e9-85c4-b70e48cf2533.png)

I went for "[xxx] not found" to keep the message short (if the line is too long it seems to break the display, so I also truncate the list if it is too long).

Don't hesitate with feedback about code style or whatever, I did not do a lot of C# development 😅 and don't hesitate to close the PR if you feel it's wrong, I did not spend that much time on it.

(For the "French translation" part, I'm French so I just translated the English strings. 😃)