### PR TITLE
Fix language files being loaded multiple times

### DIFF
--- a/Celeste.Mod.mm/Patches/Dialog.cs
+++ b/Celeste.Mod.mm/Patches/Dialog.cs
@@ -46,11 +46,16 @@ namespace Celeste {
             LoadOriginalLanguageFiles = false;
             LoadModLanguageFiles = true;
 
+            // Check all installed mods to find out which languages exist.
+            HashSet<string> languagesToLoad = new HashSet<string>();
             foreach (ModAsset asset in Everest.Content.Map.Values) {
-                if (!asset.PathVirtual.StartsWith("Dialog/"))
-                    continue;
-                LoadLanguage(Path.Combine(Engine.ContentDirectory, "Dialog", asset.PathVirtual.Substring(7) + ".txt"));
+                if (asset.PathVirtual.StartsWith("Dialog/"))
+                    languagesToLoad.Add(asset.PathVirtual.Substring(7));
             }
+
+            // Load all languages that were found.
+            foreach (string language in languagesToLoad)
+                LoadLanguage(Path.Combine(Engine.ContentDirectory, "Dialog", language + ".txt"));
 
             // Remove all empty dummy languages.
             HashSet<string> dummies = new HashSet<string>();


### PR DESCRIPTION
A while ago, I had a look at how mod content is loaded by Everest to see how it works, out of curiosity. I made Everest write a log line each time a file is read, and I noticed that the language files were loaded **many** times. As it turns out, each time an `English.txt` is encountered in the mods, all `English.txt` files get loaded again.

This PR aims to call `LoadLanguage` only once per language encountered in the mods directory.