### PR TITLE
Some way to make sure dialog files are separated properly

### DIFF
--- a/Celeste.Mod.mm/Patches/Dialog.cs
+++ b/Celeste.Mod.mm/Patches/Dialog.cs
@@ -33,6 +33,7 @@ namespace Celeste {
         [PatchLoadLanguage] // Manually manipulate the method via MonoModRules
         public static Language LoadLanguage(string filename) {
             Language language = orig_LoadLanguage(filename);
+            language.Dialog.Remove("EVEREST_SPLIT_BETWEEN_FILES");
 
             if (language?.Id.Equals("english", StringComparison.InvariantCultureIgnoreCase) ?? false)
                 FallbackLanguage = language;
@@ -90,8 +91,10 @@ namespace Celeste {
                 using (StreamReader reader = new StreamReader(asset.Stream, encoding))
                     while (reader.Peek() != -1)
                         yield return reader.ReadLine().Trim('\r', '\n').Trim();
-                yield return "";
-                yield return "";
+                
+                // Feed a new key to be sure that the last key in the file is cut off.
+                // That will prevent mod B from corrupting the last key of mod A if its language txt is bad.
+                yield return "EVEREST_SPLIT_BETWEEN_FILES= New file";
             }
         }
 


### PR DESCRIPTION
I had a look at the "dialog joining issue" (that is, text from mod B appearing in mod A). I am able to reproduce it consistently on my side (install The Secret of Celeste Mountain only, then you should see a `# NOTES:` show up on the Give Up screen).

What I do to address that here is to add a fake variable at the end of each file before reading the next one. This way, we should be sure that the last variable defined in mod A is terminated, and it cannot get content from the first line(s) of mod B (the fake variable will get it instead, and it's removed later anyway).
It's a kinda dubious solution, but I couldn't come with anything better without modding `LoadLanguage` itself. Adding empty lines does not work, since the game seems to just ignore them.

(By the way, it seems that the reason why people see `# NOTES:` is because some mod, in my case Secret of Celeste Mountain, has an `English.txt` encoded in UTF-8 **with BOM**. So, the first line actually starts with the byte order mark instead of #, and it gets included.)