### PR TITLE
Chapter 9 update fixes

### DIFF
--- a/Celeste.Mod.mm/Celeste.Mod.mm.csproj
+++ b/Celeste.Mod.mm/Celeste.Mod.mm.csproj
@@ -248,6 +248,7 @@
     <Compile Include="Patches\Overworld.cs" />
     <Compile Include="Patches\FireBall.cs" />
     <Compile Include="Patches\HeartGem.cs" />
+    <Compile Include="Patches\TrailManager.cs" />
     <Compile Include="Patches\TheoCrystal.cs" />
     <Compile Include="Patches\UnlockEverythingThingy.cs" />
     <Compile Include="Patches\TheoCrystalCollider.cs" />

--- a/Celeste.Mod.mm/Patches/Level.cs
+++ b/Celeste.Mod.mm/Patches/Level.cs
@@ -252,6 +252,8 @@ namespace Celeste {
                     color = CrystalColor.Red;
                 else if (level.Session.Area.ID == 6)
                     color = CrystalColor.Purple;
+                else if (level.Session.Area.ID == 10)
+                    color = CrystalColor.Rainbow;
                 else if ("core".Equals(entityData.Attr("color"), StringComparison.InvariantCultureIgnoreCase))
                     color = (CrystalColor) (-1);
                 else if (!Enum.TryParse(entityData.Attr("color"), true, out color))
@@ -262,7 +264,10 @@ namespace Celeste {
             }
 
             if (entityData.Name == "trackSpinner") {
-                if (level.Session.Area.ID == 3 ||
+                if (level.Session.Area.ID == 10) {
+                    level.Add(new StarTrackSpinner(entityData, offset));
+                    return true;
+                } else if (level.Session.Area.ID == 3 ||
                     (level.Session.Area.ID == 7 && level.Session.Level.StartsWith("d-")) ||
                     entityData.Bool("dust")) {
                     level.Add(new DustTrackSpinner(entityData, offset));
@@ -274,7 +279,10 @@ namespace Celeste {
             }
 
             if (entityData.Name == "rotateSpinner") {
-                if (level.Session.Area.ID == 3 ||
+                if(level.Session.Area.ID == 10) {
+                    level.Add(new StarRotateSpinner(entityData, offset));
+                    return true;
+                } else if (level.Session.Area.ID == 3 ||
                     (level.Session.Area.ID == 7 && level.Session.Level.StartsWith("d-")) ||
                     entityData.Bool("dust")) {
                     level.Add(new DustRotateSpinner(entityData, offset));

--- a/Celeste.Mod.mm/Patches/LevelEnter.cs
+++ b/Celeste.Mod.mm/Patches/LevelEnter.cs
@@ -65,11 +65,13 @@ namespace Celeste {
             public extern void orig_ctor(Session session);
             [MonoModConstructor]
             public void ctor(Session session) {
+                // Initialize the artist. If we are in a vanilla level, it will be replaced afterwards.
+                AreaData area = AreaData.Get(session);
+                artist = Dialog.Get(area.Name + "_remix_artist");
+
                 orig_ctor(session);
 
-                AreaData area = AreaData.Get(session);
-                if (string.IsNullOrEmpty(artist) || Dialog.Has(area.Name + "_remix_artist"))
-                    artist = Dialog.Get(area.Name + "_remix_artist");
+                // Replace the album if defined in the language file.
                 if (string.IsNullOrEmpty(album) || Dialog.Has(area.Name + "_remix_album"))
                     album = Dialog.Get(area.Name + "_remix_album");
             }

--- a/Celeste.Mod.mm/Patches/LevelLoader.cs
+++ b/Celeste.Mod.mm/Patches/LevelLoader.cs
@@ -48,8 +48,10 @@ namespace Celeste {
                 { 'i', 4 },
                 { 'j', 8 },
                 { 'k', 3 },
-                { 'l', 33 },
-                { 'm', 3 }
+                { 'l', 25 },
+                { 'm', 44 },
+                { 'n', 40 },
+                { 'o', 43 }
             };
 
             AreaData area = AreaData.Get(session);

--- a/Celeste.Mod.mm/Patches/TrailManager.cs
+++ b/Celeste.Mod.mm/Patches/TrailManager.cs
@@ -1,0 +1,24 @@
+﻿#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
+
+using Celeste.Mod;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Input;
+using Monocle;
+using MonoMod;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+
+namespace Celeste {
+    class patch_TrailManager : TrailManager {
+
+        // Make this signature accessible to older mods.
+        public static void Add(Entity entity, Color color, float duration = 1f) {
+            TrailManager.Add(entity, color, duration);
+        }
+
+    }
+}

--- a/Celeste.Mod.mm/Patches/TrailManager.cs
+++ b/Celeste.Mod.mm/Patches/TrailManager.cs
@@ -1,18 +1,8 @@
-﻿#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
-
-using Celeste.Mod;
-using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Input;
+﻿using Microsoft.Xna.Framework;
 using Monocle;
-using MonoMod;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Xml;
 
-namespace Celeste {
+namespace Celeste
+{
     class patch_TrailManager : TrailManager {
 
         // Make this signature accessible to older mods.

--- a/Celeste.Mod.mm/Patches/TrailManager.cs
+++ b/Celeste.Mod.mm/Patches/TrailManager.cs
@@ -1,14 +1,12 @@
 ﻿using Microsoft.Xna.Framework;
 using Monocle;
 
-namespace Celeste
-{
+namespace Celeste {
     class patch_TrailManager : TrailManager {
 
         // Make this signature accessible to older mods.
         public static void Add(Entity entity, Color color, float duration = 1f) {
-            TrailManager.Add(entity, color, duration);
+            TrailManager.Add(entity, color, duration, false, false);
         }
-
     }
 }


### PR DESCRIPTION
The vanilla code for the BSideTitle constructor does something like:
```
1/ initialize artist name depending on level
2/ if artist name starts with "image:", load image from GUI atlas
```

So it crashes with a NullReferenceException on step 2 if we are in a custom map.
What this PR does is defining artist before the call to the original constructor.

(Will update this PR with new fixes if I find any before you can review it)