### PR TITLE
Integrate Update Checker into Everest

### DIFF
--- a/Celeste.Mod.mm/Celeste.Mod.mm.csproj
+++ b/Celeste.Mod.mm/Celeste.Mod.mm.csproj
@@ -143,6 +143,7 @@
     <Compile Include="Mod\Helpers\EndUserException.cs" />
     <Compile Include="Mod\Helpers\SafeRoutine.cs" />
     <Compile Include="Mod\UI\OuiHelper_ChapterSelect_Reload.cs" />
+    <Compile Include="Mod\UI\OuiModUpdateList.cs" />
     <Compile Include="Patches\MapEditor.cs" />
     <Compile Include="Patches\CassetteBlock.cs" />
     <Compile Include="Patches\Checkpoint.cs" />

--- a/Celeste.Mod.mm/Content/Dialog/English.txt
+++ b/Celeste.Mod.mm/Content/Dialog/English.txt
@@ -50,6 +50,7 @@
 	MODOPTIONS_COREMODULE_INPUTGUI_TOUCH= 					TOUCH
 	MODOPTIONS_COREMODULE_LQATLAS=							Prefer LQ atlases
 	MODOPTIONS_COREMODULE_NONTHREADEDGL=					Non-threaded GL
+	MODOPTIONS_COREMODULE_MODUPDATES= 						Check for Mod Updates
 	
 	MODOPTIONS_COREMODULE_RECRAWL= 							~Reload assets~
 
@@ -85,6 +86,18 @@
 	UPDATER_VERSIONS_ERR_FORMAT= 	Unknown format.
 	
 	UPDATER_SRC_BUILDBOT= 			Automatic builds
+
+# Mod Updater
+	MODUPDATECHECKER_MENU_TITLE=	MOD UPDATES
+	MODUPDATECHECKER_NOUPDATE=		No update available
+	MODUPDATECHECKER_MENU_HEADER=	Available Updates
+	MODUPDATECHECKER_FETCHING=		Checking for updates...
+	MODUPDATECHECKER_ERROR=			Update checking failed.
+	MODUPDATECHECKER_UPDATED=		updated
+	MODUPDATECHECKER_DOWNLOADING=	downloading...
+	MODUPDATECHECKER_INSTALLING=	installing...
+	MODUPDATECHECKER_FAILED=		update failed!
+	MODUPDATECHECKER_WILLRESTART=	press Back to restart Celeste
 
 # Misc
 	UI_GIVEUP_HINT=			Your progress is saved, but you'll need to restart at the last :checkpoint:

--- a/Celeste.Mod.mm/Content/Dialog/French.txt
+++ b/Celeste.Mod.mm/Content/Dialog/French.txt
@@ -33,6 +33,7 @@
 	MODOPTIONS_COREMODULE_INPUTGUI_TOUCH= 					TOUCH
 	MODOPTIONS_COREMODULE_LQATLAS=							Préférer LQ atlases
 	MODOPTIONS_COREMODULE_NONTHREADEDGL=					GL non-traité
+	MODOPTIONS_COREMODULE_MODUPDATES= 						Mises à jour des mods
 	
 	MODOPTIONS_COREMODULE_RECRAWL= 							~Recharger aspects~
 
@@ -68,6 +69,18 @@
 	UPDATER_VERSIONS_ERR_FORMAT= 	Format inconnu.
 	
 	UPDATER_SRC_BUILDBOT= 			Constructions automatiques
+	
+# Mod Updater
+	MODUPDATECHECKER_MENU_TITLE=	MISE À JOUR DES MODS
+	MODUPDATECHECKER_NOUPDATE=		Aucune mise à jour disponible
+	MODUPDATECHECKER_MENU_HEADER=	Mises à jour disponibles
+	MODUPDATECHECKER_FETCHING=		Vérification en cours...
+	MODUPDATECHECKER_ERROR=			Erreur de vérification des mises à jour.
+	MODUPDATECHECKER_UPDATED=		mis à jour
+	MODUPDATECHECKER_DOWNLOADING=	téléchargement en cours...
+	MODUPDATECHECKER_INSTALLING=	installation...
+	MODUPDATECHECKER_FAILED=		échec de mise à jour
+	MODUPDATECHECKER_WILLRESTART=	appuyez sur Retour pour redémarrer Celeste
 
 # Misc
 	UI_GIVEUP_HINT=			Votre progression est sauvegardée, mais vous devrez recommencer depuis le dernier :checkpoint:

--- a/Celeste.Mod.mm/Mod/Core/CoreModule.cs
+++ b/Celeste.Mod.mm/Mod/Core/CoreModule.cs
@@ -277,6 +277,10 @@ namespace Celeste.Mod.Core {
                 menu.Add(new TextMenu.Button(Dialog.Clean("modoptions_coremodule_versionlist")).Pressed(() => {
                     OuiModOptions.Instance.Overworld.Goto<OuiVersionList>();
                 }));
+
+                menu.Add(new TextMenu.Button(Dialog.Clean("modoptions_coremodule_modupdates")).Pressed(() => {
+                    OuiModOptions.Instance.Overworld.Goto<OuiModUpdateList>();
+                }));
             }
         }
 

--- a/Celeste.Mod.mm/Mod/Core/CoreModuleSettings.cs
+++ b/Celeste.Mod.mm/Mod/Core/CoreModuleSettings.cs
@@ -135,6 +135,10 @@ namespace Celeste.Mod.Core {
         [SettingIgnore]
         public string DiscordSubtextInGame { get; set; } = "((deaths)) x 💀 | ((strawberries)) x 🍓";
 
+        // this address should lead to a running instance of https://github.com/max4805/EverestUpdateCheckerServer
+        [SettingIgnore]
+        public string ModUpdateServerAddress { get; set; } = "https://max480-random-stuff.appspot.com/celeste/everest_update.yaml";
+
         [SettingIgnore]
         public int? QuickRestart { get; set; }
 

--- a/Celeste.Mod.mm/Mod/Core/CoreModuleSettings.cs
+++ b/Celeste.Mod.mm/Mod/Core/CoreModuleSettings.cs
@@ -135,10 +135,6 @@ namespace Celeste.Mod.Core {
         [SettingIgnore]
         public string DiscordSubtextInGame { get; set; } = "((deaths)) x 💀 | ((strawberries)) x 🍓";
 
-        // this address should lead to a running instance of https://github.com/max4805/EverestUpdateCheckerServer
-        [SettingIgnore]
-        public string ModUpdateServerAddress { get; set; } = "https://max480-random-stuff.appspot.com/celeste/everest_update.yaml";
-
         [SettingIgnore]
         public int? QuickRestart { get; set; }
 

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Updater.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Updater.cs
@@ -400,7 +400,7 @@ namespace Celeste.Mod {
                     int count = 0;
                     TimeSpan td;
                     while (read > 0) {
-                        count = length > 0 ? (int)Math.Min(buffer.Length, length - pos) : buffer.Length;
+                        count = length > 0 ? (int) Math.Min(buffer.Length, length - pos) : buffer.Length;
                         read = input.Read(buffer, 0, count);
                         output.Write(buffer, 0, read);
                         pos += read;
@@ -408,7 +408,7 @@ namespace Celeste.Mod {
 
                         td = DateTime.Now - timeLastSpeed;
                         if (td.TotalMilliseconds > 100) {
-                            speed = (int)((readForSpeed / 1024D) / td.TotalSeconds);
+                            speed = (int) ((readForSpeed / 1024D) / td.TotalSeconds);
                             readForSpeed = 0;
                             timeLastSpeed = DateTime.Now;
                         }

--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -236,6 +236,9 @@ namespace Celeste.Mod {
                 };
             }
 
+            // enable TLS 1.2 to fix connecting to everestapi.github.io
+            ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
+
             PathGame = Path.GetDirectoryName(typeof(Celeste).Assembly.Location);
 
             // .NET hates it when strong-named dependencies get updated.

--- a/Celeste.Mod.mm/Mod/UI/OuiModUpdateList.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiModUpdateList.cs
@@ -254,7 +254,7 @@ namespace Celeste.Mod.UI {
                     if (menu.Selection + 1 > menu.LastPossibleSelection)
                         menu.Selection = menu.LastPossibleSelection;
                     else
-                        menu.Selection++;
+                        menu.MoveSelection(1);
                 } catch (Exception e) {
                     // update failed
                     button.Label = $"{update.Name} ({Dialog.Clean("MODUPDATECHECKER_FAILED")})";

--- a/Celeste.Mod.mm/Mod/UI/OuiModUpdateList.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiModUpdateList.cs
@@ -1,0 +1,334 @@
+﻿using Celeste.Mod.Core;
+using Microsoft.Xna.Framework;
+using Monocle;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Threading.Tasks;
+using YamlDotNet.Serialization;
+
+namespace Celeste.Mod.UI {
+    class OuiModUpdateList : Oui {
+
+        private class ModUpdateInfo {
+            public virtual string Name { get; set; }
+            public virtual string Version { get; set; }
+            public virtual int LastUpdate { get; set; }
+            public virtual string URL { get; set; }
+            public virtual List<string> xxHash { get; set; }
+        }
+
+        private class MostRecentUpdatedFirst : IComparer<ModUpdateInfo> {
+            public int Compare(ModUpdateInfo x, ModUpdateInfo y) {
+                if(x.LastUpdate != y.LastUpdate) {
+                    return y.LastUpdate - x.LastUpdate;
+                }
+                // fall back to alphabetical order
+                return x.Name.CompareTo(y.Name);
+            }
+        }
+
+        private TextMenu menu;
+        private TextMenuExt.SubHeaderExt subHeader;
+        private TextMenu.Button fetchingButton;
+
+        private const float onScreenX = 960f;
+        private const float offScreenX = 2880f;
+
+        private float alpha = 0f;
+
+        private Task task;
+
+        private bool shouldRestart = false;
+
+        private Dictionary<string, ModUpdateInfo> updateCatalog = null;
+        private SortedDictionary<ModUpdateInfo, EverestModuleMetadata> availableUpdatesCatalog = new SortedDictionary<ModUpdateInfo, EverestModuleMetadata>(new MostRecentUpdatedFirst());
+
+        public override IEnumerator Enter(Oui from) {
+            menu = new TextMenu();
+
+            // display the title and a dummy "Fetching" button
+            menu.Add(new TextMenu.Header(Dialog.Clean("MODUPDATECHECKER_MENU_TITLE")));
+
+            menu.Add(subHeader = new TextMenuExt.SubHeaderExt(Dialog.Clean("MODUPDATECHECKER_MENU_HEADER")));
+
+            fetchingButton = new TextMenu.Button(Dialog.Clean("MODUPDATECHECKER_FETCHING"));
+            fetchingButton.Disabled = true;
+            menu.Add(fetchingButton);
+
+            Scene.Add(menu);
+
+            menu.Visible = Visible = true;
+            menu.Focused = false;
+
+            for (float p = 0f; p < 1f; p += Engine.DeltaTime * 4f) {
+                menu.X = offScreenX + -1920f * Ease.CubeOut(p);
+                alpha = Ease.CubeOut(p);
+                yield return null;
+            }
+
+            menu.Focused = true;
+
+            task = new Task(() => {
+                // 1. Download the updates list
+                Logger.Log("OuiModUpdateList", "Downloading last versions list");
+                try {
+                    using (WebClient wc = new WebClient()) {
+                        string yamlData = wc.DownloadString(CoreModule.Settings.ModUpdateServerAddress);
+                        updateCatalog = new Deserializer().Deserialize<Dictionary<string, ModUpdateInfo>>(yamlData);
+                        foreach (string name in updateCatalog.Keys) {
+                            updateCatalog[name].Name = name;
+                        }
+                        Logger.Log("OuiModUpdateList", $"Downloaded {updateCatalog.Count} item(s)");
+                    }
+                }
+                catch (Exception e) {
+                    Logger.Log("OuiModUpdateList", $"Download failed! {e.ToString()}");
+                }
+
+                // 2. Find out what actually has been updated
+                availableUpdatesCatalog.Clear();
+
+                if (updateCatalog != null) {
+                    Logger.Log("OuiModUpdateList", "Checking for updates");
+
+                    foreach(EverestModule module in Everest.Modules) {
+                        EverestModuleMetadata metadata = module.Metadata;
+                        if (metadata.PathArchive != null && updateCatalog.ContainsKey(metadata.Name)) {
+                            string xxHashStringInstalled = BitConverter.ToString(metadata.Hash).Replace("-", "").ToLowerInvariant();
+                            Logger.Log("OuiModUpdateList", $"Mod {metadata.Name}: installed hash {xxHashStringInstalled}, latest hash(es) {string.Join(", ", updateCatalog[metadata.Name].xxHash)}");
+                            if(!updateCatalog[metadata.Name].xxHash.Contains(xxHashStringInstalled)) {
+                                availableUpdatesCatalog.Add(updateCatalog[metadata.Name], metadata);
+                            }
+                        }
+                    }
+
+                    Logger.Log("OuiModUpdateList", $"{availableUpdatesCatalog.Count} update(s) available");
+                }
+            });
+
+            task.Start();
+        }
+
+        public override IEnumerator Leave(Oui next) {
+            Audio.Play(SFX.ui_main_whoosh_large_out);
+            menu.Focused = false;
+
+            for (float p = 0f; p < 1f; p += Engine.DeltaTime * 4f) {
+                menu.X = onScreenX + 1920f * Ease.CubeIn(p);
+                alpha = 1f - Ease.CubeIn(p);
+                yield return null;
+            }
+
+            menu.Visible = Visible = false;
+            menu.RemoveSelf();
+            menu = null;
+
+            updateCatalog = null;
+            availableUpdatesCatalog = new SortedDictionary<ModUpdateInfo, EverestModuleMetadata>(new MostRecentUpdatedFirst());
+            task = null;
+        }
+
+        public override void Update() {
+            if(menu != null && task != null && task.IsCompleted && fetchingButton != null) {
+                Logger.Log("OuiModUpdateList", "Rendering updates");
+
+                menu.Remove(fetchingButton);
+                fetchingButton = null;
+
+                if(updateCatalog == null) {
+                    // display an error message
+                    TextMenu.Button button = new TextMenu.Button(Dialog.Clean("MODUPDATECHECKER_ERROR"));
+                    button.Disabled = true;
+                    menu.Add(button);
+                } else if (availableUpdatesCatalog.Count == 0) {
+                    // display a dummy "no update available" button
+                    TextMenu.Button button = new TextMenu.Button(Dialog.Clean("MODUPDATECHECKER_NOUPDATE"));
+                    button.Disabled = true;
+                    menu.Add(button);
+                } else {
+                    // display one button per update
+                    foreach(ModUpdateInfo update in availableUpdatesCatalog.Keys) {
+                        EverestModuleMetadata metadata = availableUpdatesCatalog[update];
+                        TextMenu.Button button = new TextMenu.Button($"{metadata.Name} | v. {metadata.VersionString} > {update.Version} ({new DateTime(1970, 1, 1, 0, 0, 0, 0).AddSeconds(update.LastUpdate):yyyy-MM-dd})");
+                        button.Pressed(() => {
+                            // make the menu non-interactive
+                            menu.Focused = false;
+                            button.Disabled = true;
+
+                            // trigger the update download
+                            downloadModUpdate(update, metadata, button);
+                        });
+
+                        // if there is more than one hash, it means there is multiple downloads for this mod. Thus, we can't update it manually.
+                        if (update.xxHash.Count > 1) button.Disabled = true;
+
+                        menu.Add(button);
+                    }
+                }
+            }
+
+            if (menu != null && task != null && menu.Focused && Selected && Input.MenuCancel.Pressed && task.IsCompleted) {
+                if(shouldRestart) {
+                    Everest.QuickFullRestart();
+                } else {
+                    // go back to mod options instead
+                    Audio.Play(SFX.ui_main_button_back);
+                    Overworld.Goto<OuiModOptions>();
+                }
+            }
+
+            base.Update();
+        }
+
+        private void downloadModUpdate(ModUpdateInfo update, EverestModuleMetadata mod, TextMenu.Button button) {
+            task = new Task(() => {
+                // we will download the mod to Celeste_Directory/mod-update.zip at first.
+                string zipPath = Path.Combine(Everest.PathGame, "mod-update.zip");
+
+                try {
+                    // download it...
+                    button.Label = $"{update.Name} ({Dialog.Clean("MODUPDATECHECKER_DOWNLOADING")})";
+                    downloadMod(update, button, zipPath);
+
+                    // verify its checksum
+                    string actualHash = BitConverter.ToString(Everest.GetChecksum("mod-update.zip")).Replace("-", "").ToLowerInvariant();
+                    string expectedHash = update.xxHash[0];
+                    Logger.Log("OuiModUpdateList", $"Verifying checksum: actual hash is {actualHash}, expected hash is {expectedHash}");
+                    if(expectedHash != actualHash) {
+                        throw new IOException($"Checksum error: expected {expectedHash}, got {actualHash}");
+                    }
+
+                    // mark restarting as required, as we will do weird stuff like closing zips afterwards.
+                    if (!shouldRestart) {
+                        shouldRestart = true;
+                        subHeader.TextColor = Color.OrangeRed;
+                        subHeader.Title = $"{Dialog.Clean("MODUPDATECHECKER_MENU_HEADER")} ({Dialog.Clean("MODUPDATECHECKER_WILLRESTART")})";
+                    }
+
+                    // install it
+                    button.Label = $"{update.Name} ({Dialog.Clean("MODUPDATECHECKER_INSTALLING")})";
+                    installMod(update, mod, zipPath);
+
+                    // done!
+                    button.Label = $"{update.Name} ({Dialog.Clean("MODUPDATECHECKER_UPDATED")})";
+
+                    // select another enabled option: the next one, or the last one if there is no next one.
+                    if (menu.Selection + 1 > menu.LastPossibleSelection)
+                        menu.Selection = menu.LastPossibleSelection;
+                    else
+                        menu.Selection++;
+                } catch (Exception e) {
+                    // update failed
+                    button.Label = $"{update.Name} ({Dialog.Clean("MODUPDATECHECKER_FAILED")})";
+                    Logger.Log("OuiModUpdateList", $"Updating {update.Name} failed");
+                    Logger.LogDetailed(e);
+                    button.Disabled = false;
+
+                    // try to delete mod-update.zip if it still exists.
+                    if(File.Exists(zipPath)) {
+                        try {
+                            Logger.Log("OuiModUpdateList", $"Deleting temp file {zipPath}");
+                            File.Delete(zipPath);
+                        } catch(Exception) {
+                            Logger.Log("OuiModUpdateList", $"Removing {zipPath} failed");
+                        }
+                    }
+                }
+
+                // give the menu control back to the player
+                menu.Focused = true;
+            });
+            task.Start();
+        }
+
+        private static void downloadMod(ModUpdateInfo update, TextMenu.Button button, string zipPath) {
+            Logger.Log("OuiModUpdateList", $"Downloading {update.URL} to {zipPath}");
+            DateTime timeStart = DateTime.Now;
+
+            if (File.Exists(zipPath))
+                File.Delete(zipPath);
+
+            // Manual buffered copy from web input to file output.
+            // Allows us to measure speed and progress.
+            using (WebClient wc = new WebClient())
+            using (Stream input = wc.OpenRead(update.URL))
+            using (FileStream output = File.OpenWrite(zipPath)) {
+                long length;
+                if (input.CanSeek) {
+                    length = input.Length;
+                } else {
+                    length = _ContentLength(update.URL);
+                }
+
+                byte[] buffer = new byte[4096];
+                DateTime timeLastSpeed = timeStart;
+                int read = 1;
+                int readForSpeed = 0;
+                int pos = 0;
+                int speed = 0;
+                int count = 0;
+                TimeSpan td;
+                while (read > 0) {
+                    count = length > 0 ? (int)Math.Min(buffer.Length, length - pos) : buffer.Length;
+                    read = input.Read(buffer, 0, count);
+                    output.Write(buffer, 0, read);
+                    pos += read;
+                    readForSpeed += read;
+
+                    td = DateTime.Now - timeLastSpeed;
+                    if (td.TotalMilliseconds > 100) {
+                        speed = (int)((readForSpeed / 1024D) / td.TotalSeconds);
+                        readForSpeed = 0;
+                        timeLastSpeed = DateTime.Now;
+                    }
+
+                    if (length > 0) {
+                        button.Label = $"{update.Name} ({((int)Math.Floor(100D * (pos / (double)length)))}% @ {speed} KiB/s)";
+                    } else {
+                        button.Label = $"{update.Name} ({((int)Math.Floor(pos / 1000D))}KiB @ {speed} KiB/s)";
+                    }
+                }
+            }
+        }
+
+        private static void installMod(ModUpdateInfo update, EverestModuleMetadata mod, string zipPath) {
+            // let's close the zip, as we will replace it now.
+            foreach(ModContent content in Everest.Content.Mods) {
+                if(content.GetType() == typeof(ZipModContent) && (content as ZipModContent).Mod.Name == mod.Name) {
+                    ZipModContent modZip = content as ZipModContent;
+
+                    Logger.Log("OuiModUpdateList", $"Closing mod .zip: {modZip.Path}");
+                    modZip.Dispose();
+                }
+            }
+
+            // delete the old zip, and move the new one.
+            Logger.Log("OuiModUpdateList", $"Deleting mod .zip: {mod.PathArchive}");
+            File.Delete(mod.PathArchive);
+
+            Logger.Log("OuiModUpdateList", $"Moving {zipPath} to {mod.PathArchive}");
+            File.Move(zipPath, mod.PathArchive);
+        }
+
+        private static long _ContentLength(string url) {
+            try {
+                HttpWebRequest request = (HttpWebRequest)WebRequest.Create(url);
+                request.Method = "HEAD";
+                using (HttpWebResponse response = (HttpWebResponse)request.GetResponse())
+                    return response.ContentLength;
+            } catch (Exception) {
+                return 0;
+            }
+        }
+
+        public override void Render() {
+            if (alpha > 0f) {
+                Draw.Rect(-10f, -10f, 1940f, 1100f, Color.Black * alpha * 0.4f);
+            }
+            base.Render();
+        }
+    }
+}

--- a/Celeste.Mod.mm/Mod/UI/OuiModUpdateList.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiModUpdateList.cs
@@ -22,7 +22,7 @@ namespace Celeste.Mod.UI {
 
         private class MostRecentUpdatedFirst : IComparer<ModUpdateInfo> {
             public int Compare(ModUpdateInfo x, ModUpdateInfo y) {
-                if(x.LastUpdate != y.LastUpdate) {
+                if (x.LastUpdate != y.LastUpdate) {
                     return y.LastUpdate - x.LastUpdate;
                 }
                 // fall back to alphabetical order
@@ -86,8 +86,7 @@ namespace Celeste.Mod.UI {
                         }
                         Logger.Log("OuiModUpdateList", $"Downloaded {updateCatalog.Count} item(s)");
                     }
-                }
-                catch (Exception e) {
+                } catch (Exception e) {
                     Logger.Log("OuiModUpdateList", $"Downloading database failed!");
                     Logger.LogDetailed(e);
                 }
@@ -98,12 +97,12 @@ namespace Celeste.Mod.UI {
                 if (updateCatalog != null) {
                     Logger.Log("OuiModUpdateList", "Checking for updates");
 
-                    foreach(EverestModule module in Everest.Modules) {
+                    foreach (EverestModule module in Everest.Modules) {
                         EverestModuleMetadata metadata = module.Metadata;
                         if (metadata.PathArchive != null && updateCatalog.ContainsKey(metadata.Name)) {
                             string xxHashStringInstalled = BitConverter.ToString(metadata.Hash).Replace("-", "").ToLowerInvariant();
                             Logger.Log("OuiModUpdateList", $"Mod {metadata.Name}: installed hash {xxHashStringInstalled}, latest hash(es) {string.Join(", ", updateCatalog[metadata.Name].xxHash)}");
-                            if(!updateCatalog[metadata.Name].xxHash.Contains(xxHashStringInstalled)) {
+                            if (!updateCatalog[metadata.Name].xxHash.Contains(xxHashStringInstalled)) {
                                 availableUpdatesCatalog.Add(updateCatalog[metadata.Name], metadata);
                             }
                         }
@@ -136,10 +135,10 @@ namespace Celeste.Mod.UI {
         }
 
         public override void Update() {
-            if(menu != null && task != null && task.IsCompleted) {
+            if (menu != null && task != null && task.IsCompleted) {
                 // there is no download or install task in progress
 
-                if(fetchingButton != null) {
+                if (fetchingButton != null) {
                     // This means fetching the updates just finished. We have to remove the "Checking for updates" button
                     // and put the actual update list instead.
 
@@ -148,7 +147,7 @@ namespace Celeste.Mod.UI {
                     menu.Remove(fetchingButton);
                     fetchingButton = null;
 
-                    if(updateCatalog == null) {
+                    if (updateCatalog == null) {
                         // display an error message
                         TextMenu.Button button = new TextMenu.Button(Dialog.Clean("MODUPDATECHECKER_ERROR"));
                         button.Disabled = true;
@@ -160,7 +159,7 @@ namespace Celeste.Mod.UI {
                         menu.Add(button);
                     } else {
                         // display one button per update
-                        foreach(ModUpdateInfo update in availableUpdatesCatalog.Keys) {
+                        foreach (ModUpdateInfo update in availableUpdatesCatalog.Keys) {
                             EverestModuleMetadata metadata = availableUpdatesCatalog[update];
                             TextMenu.Button button = new TextMenu.Button($"{metadata.Name} | v. {metadata.VersionString} > {update.Version} ({new DateTime(1970, 1, 1, 0, 0, 0, 0).AddSeconds(update.LastUpdate):yyyy-MM-dd})");
                             button.Pressed(() => {
@@ -180,8 +179,8 @@ namespace Celeste.Mod.UI {
                     }
                 }
 
-                if(menu.Focused && Selected && Input.MenuCancel.Pressed) {
-                    if(shouldRestart) {
+                if (menu.Focused && Selected && Input.MenuCancel.Pressed) {
+                    if (shouldRestart) {
                         Everest.QuickFullRestart();
                     } else {
                         // go back to mod options instead
@@ -232,7 +231,7 @@ namespace Celeste.Mod.UI {
                     string actualHash = BitConverter.ToString(Everest.GetChecksum("mod-update.zip")).Replace("-", "").ToLowerInvariant();
                     string expectedHash = update.xxHash[0];
                     Logger.Log("OuiModUpdateList", $"Verifying checksum: actual hash is {actualHash}, expected hash is {expectedHash}");
-                    if(expectedHash != actualHash) {
+                    if (expectedHash != actualHash) {
                         throw new IOException($"Checksum error: expected {expectedHash}, got {actualHash}");
                     }
 
@@ -263,11 +262,11 @@ namespace Celeste.Mod.UI {
                     button.Disabled = false;
 
                     // try to delete mod-update.zip if it still exists.
-                    if(File.Exists(zipPath)) {
+                    if (File.Exists(zipPath)) {
                         try {
                             Logger.Log("OuiModUpdateList", $"Deleting temp file {zipPath}");
                             File.Delete(zipPath);
-                        } catch(Exception) {
+                        } catch (Exception) {
                             Logger.Log("OuiModUpdateList", $"Removing {zipPath} failed");
                         }
                     }
@@ -306,8 +305,8 @@ namespace Celeste.Mod.UI {
         /// <param name="zipPath">The path to the zip the update has been downloaded to</param>
         private static void installMod(ModUpdateInfo update, EverestModuleMetadata mod, string zipPath) {
             // let's close the zip, as we will replace it now.
-            foreach(ModContent content in Everest.Content.Mods) {
-                if(content.GetType() == typeof(ZipModContent) && (content as ZipModContent).Mod.Name == mod.Name) {
+            foreach (ModContent content in Everest.Content.Mods) {
+                if (content.GetType() == typeof(ZipModContent) && (content as ZipModContent).Mod.Name == mod.Name) {
                     ZipModContent modZip = content as ZipModContent;
 
                     Logger.Log("OuiModUpdateList", $"Closing mod .zip: {modZip.Path}");


### PR DESCRIPTION
This aims to integrate https://gamebanana.com/gamefiles/9920 into Everest directly.

The part I'm the most unsure of here is the method extraction in `Everest.Updater`. The code used by the code mod is pretty much the same as Everest's own updater to download the package while keeping track of progress, so I tried extracting it into a method.

**Not ready to be merged yet**, as if you open a save file, close it, then install updates, Celeste will reboot into the save file directly, which isn't really what should happen.