### PR TITLE
Fix F6 on an A-side wiping out B- and C-side properties

### DIFF
--- a/Celeste.Mod.mm/Mod/Meta/MapMeta.cs
+++ b/Celeste.Mod.mm/Mod/Meta/MapMeta.cs
@@ -211,7 +211,7 @@ namespace Celeste.Mod.Meta {
                 if (!string.IsNullOrEmpty(Portraits))
                     meta.Portraits = Portraits;
 
-                if ((Modes?.Length ?? 0) != 0)
+                if ((Modes?.Length ?? 0) != 0 && Modes.Any(mode => mode != null))
                     meta.Modes = Modes;
 
                 if (Mountain != null)


### PR DESCRIPTION
I'm back at opening PRs for changes I'm unsure about... I feel like it's a more proper way to do this.

The issue here can be reproduced on [this map](https://cdn.discordapp.com/attachments/449297822827937795/629258383161032704/smaerdnogylop.zip): go into the A-side, F6 teleport to the end, then go into the B-side. You spawn near the end, as the "Start Level" property has been wiped.

This is caused by the Modes field in the map metadata being replaced with an array of 3 nulls. Here, I tried to add a check to ensure the array is not only filled with nulls before applying it. This fixes the issue... but I'm PRing this in case this has consequences I don't know about.

(While testing that, I noticed a small issue with the music: on this map, when I F6 teleport from the beginning to the end, the music only gets updated if I hold Ctrl. I might get to it later.)