### PR TITLE
Automatic dependency downloader?

### DIFF
--- a/Celeste.Mod.mm/Celeste.Mod.mm.csproj
+++ b/Celeste.Mod.mm/Celeste.Mod.mm.csproj
@@ -129,6 +129,8 @@
     <Compile Include="Mod\Everest\LuaTypeBuilder.cs" />
     <Compile Include="Mod\Everest\Everest.LuaLoader.HookHelper.cs" />
     <Compile Include="Mod\Everest\Everest.LuaLoader.cs" />
+    <Compile Include="Mod\Helpers\ModUpdateInfo.cs" />
+    <Compile Include="Mod\Helpers\ModUpdaterHelper.cs" />
     <Compile Include="Mod\Helpers\QueuedTaskHelper.cs" />
     <Compile Include="Mod\Helpers\MainThreadHelper.cs" />
     <Compile Include="Mod\Helpers\DirectoryProxy.cs" />
@@ -145,6 +147,7 @@
     <Compile Include="Mod\Entities\TriggerSpikesOriginal.cs" />
     <Compile Include="Mod\Helpers\EndUserException.cs" />
     <Compile Include="Mod\Helpers\SafeRoutine.cs" />
+    <Compile Include="Mod\UI\OuiDependencyDownloader.cs" />
     <Compile Include="Mod\UI\OuiHelper_ChapterSelect_Reload.cs" />
     <Compile Include="Mod\UI\OuiModUpdateList.cs" />
     <Compile Include="Patches\MapEditor.cs" />

--- a/Celeste.Mod.mm/Content/Dialog/English.txt
+++ b/Celeste.Mod.mm/Content/Dialog/English.txt
@@ -34,7 +34,7 @@
 
 # Core Module Options
 	MODOPTIONS_COREMODULE_UPDATE= 							Update Everest to ((version))
-	MODOPTIONS_COREMODULE_DOWNLOADDEPS= 					Download dependencies
+	MODOPTIONS_COREMODULE_DOWNLOADDEPS= 					Install missing dependencies
 	MODOPTIONS_COREMODULE_VERSIONLIST= 						Version list
 	MODOPTIONS_COREMODULE_TITLE= 							Everest Core
 	MODOPTIONS_COREMODULE_DEBUGMODE= 						Debug mode
@@ -99,6 +99,27 @@
 	MODUPDATECHECKER_INSTALLING=	installing...
 	MODUPDATECHECKER_FAILED=		update failed!
 	MODUPDATECHECKER_WILLRESTART=	press Back to restart Celeste
+
+# Dependency downloader
+	DEPENDENCYDOWNLOADER_TITLE=						INSTALL DEPENDENCIES
+	DEPENDENCYDOWNLOADER_DOWNLOADING_DATABASE=		Downloading mod database...
+	DEPENDENCYDOWNLOADER_DOWNLOAD_DATABASE_FAILED=	ERROR: Downloading the database failed. Please check your log.txt for more info.
+	DEPENDENCYDOWNLOADER_MUST_UPDATE_EVEREST=		ERROR: You must update Everest to play some of your mods.
+	DEPENDENCYDOWNLOADER_MOD_NOT_FOUND=				ERROR: {0} could not be found in the database. Please install this mod manually.
+	DEPENDENCYDOWNLOADER_MOD_NOT_AUTO_INSTALLABLE=	ERROR: {0} is available in multiple versions and cannot be installed automatically. Please install this mod manually.
+	DEPENDENCYDOWNLOADER_MOD_BLACKLISTED=			ERROR: {0}.zip is present in your blacklist. Please unblacklist it to be able to use it as a dependency.
+	DEPENDENCYDOWNLOADER_MOD_WRONG_VERSION=			ERROR: Version(s) {1} of {0} are required, but only version {2} is in the database. Please install this mod manually.
+	DEPENDENCYDOWNLOADER_RESTARTING=				Restarting
+	DEPENDENCYDOWNLOADER_RESTARTING_IN=				Restarting in {0}
+	DEPENDENCYDOWNLOADER_PRESS_BACK_TO_RESTART=		Press Back to restart Celeste.
+	DEPENDENCYDOWNLOADER_PRESS_BACK_TO_GO_BACK=		Press Back to return to Mod Options.
+	DEPENDENCYDOWNLOADER_DOWNLOADING=				Downloading {0} from {1}...
+	DEPENDENCYDOWNLOADER_DOWNLOAD_FINISHED=			Download finished.
+	DEPENDENCYDOWNLOADER_VERIFYING_CHECKSUM=		Verifying checksum...
+	DEPENDENCYDOWNLOADER_UPDATING=					Installing update for {0} ({1} -> {2}) to {3}...
+	DEPENDENCYDOWNLOADER_INSTALLING=				Installing mod {0} v.{1} to {2}...
+	DEPENDENCYDOWNLOADER_INSTALL_FAILED=			ERROR: Installing {0} failed. Please check your log.txt for more info.
+
 
 # Misc
 	UI_GIVEUP_HINT=			Your progress is saved, but you'll need to restart at the last :checkpoint:

--- a/Celeste.Mod.mm/Content/Dialog/English.txt
+++ b/Celeste.Mod.mm/Content/Dialog/English.txt
@@ -34,6 +34,7 @@
 
 # Core Module Options
 	MODOPTIONS_COREMODULE_UPDATE= 							Update Everest to ((version))
+	MODOPTIONS_COREMODULE_DOWNLOADDEPS= 					Download dependencies
 	MODOPTIONS_COREMODULE_VERSIONLIST= 						Version list
 	MODOPTIONS_COREMODULE_TITLE= 							Everest Core
 	MODOPTIONS_COREMODULE_DEBUGMODE= 						Debug mode

--- a/Celeste.Mod.mm/Content/Dialog/English.txt
+++ b/Celeste.Mod.mm/Content/Dialog/English.txt
@@ -108,7 +108,7 @@
 	DEPENDENCYDOWNLOADER_MOD_NOT_FOUND=				ERROR: {0} could not be found in the database. Please install this mod manually.
 	DEPENDENCYDOWNLOADER_MOD_NOT_AUTO_INSTALLABLE=	ERROR: {0} is available in multiple versions and cannot be installed automatically. Please install this mod manually.
 	DEPENDENCYDOWNLOADER_MOD_BLACKLISTED=			ERROR: {0}.zip is present in your blacklist. Please unblacklist it to be able to use it as a dependency.
-	DEPENDENCYDOWNLOADER_MOD_WRONG_VERSION=			ERROR: Version(s) {1} of {0} are required, but only version {2} is in the database. Please install this mod manually.
+	DEPENDENCYDOWNLOADER_MOD_WRONG_VERSION=			ERROR: Version(s) {1} of {0} are required, but only version {2} is available. Please install this mod manually.
 	DEPENDENCYDOWNLOADER_RESTARTING=				Restarting
 	DEPENDENCYDOWNLOADER_RESTARTING_IN=				Restarting in {0}
 	DEPENDENCYDOWNLOADER_PRESS_BACK_TO_RESTART=		Press Back to restart Celeste.

--- a/Celeste.Mod.mm/Content/Dialog/French.txt
+++ b/Celeste.Mod.mm/Content/Dialog/French.txt
@@ -16,6 +16,7 @@
 
 # Core Module Options
 	MODOPTIONS_COREMODULE_UPDATE= 							Mettre à jour vers ((version))
+	MODOPTIONS_COREMODULE_DOWNLOADDEPS= 					Télécharger les dépendances
 	MODOPTIONS_COREMODULE_VERSIONLIST= 						Liste des versions
 	MODOPTIONS_COREMODULE_TITLE= 							Everest Core
 	MODOPTIONS_COREMODULE_DEBUGMODE= 						Mode debug

--- a/Celeste.Mod.mm/Content/Dialog/French.txt
+++ b/Celeste.Mod.mm/Content/Dialog/French.txt
@@ -16,7 +16,7 @@
 
 # Core Module Options
 	MODOPTIONS_COREMODULE_UPDATE= 							Mettre à jour vers ((version))
-	MODOPTIONS_COREMODULE_DOWNLOADDEPS= 					Télécharger les dépendances
+	MODOPTIONS_COREMODULE_DOWNLOADDEPS= 					Installer les dépendances manquantes
 	MODOPTIONS_COREMODULE_VERSIONLIST= 						Liste des versions
 	MODOPTIONS_COREMODULE_TITLE= 							Everest Core
 	MODOPTIONS_COREMODULE_DEBUGMODE= 						Mode debug
@@ -82,6 +82,26 @@
 	MODUPDATECHECKER_INSTALLING=	installation...
 	MODUPDATECHECKER_FAILED=		échec de mise à jour
 	MODUPDATECHECKER_WILLRESTART=	appuyez sur Retour pour redémarrer Celeste
+	
+# Dependency downloader
+	DEPENDENCYDOWNLOADER_TITLE=						INSTALLATION DES DÉPENDANCES
+	DEPENDENCYDOWNLOADER_DOWNLOADING_DATABASE=		Téléchargement de la base de données de mods...
+	DEPENDENCYDOWNLOADER_DOWNLOAD_DATABASE_FAILED=	ERREUR: Le téléchargement de la base de données a échoué. Vérifiez votre log.txt pour plus d'informations.
+	DEPENDENCYDOWNLOADER_MUST_UPDATE_EVEREST=		ERREUR: Vous devez mettre Everest à jour pour jouer à certains de vos mods.
+	DEPENDENCYDOWNLOADER_MOD_NOT_FOUND=				ERREUR: {0} n'a pas été trouvé dans la base de données. Merci de l'installer manuellement.
+	DEPENDENCYDOWNLOADER_MOD_NOT_AUTO_INSTALLABLE=	ERREUR: {0} possède plusieurs versions et ne peut pas être installé automatiquement. Merci de l'installer manuellement.
+	DEPENDENCYDOWNLOADER_MOD_BLACKLISTED=			ERREUR: {0}.zip est dans votre blacklist. Retirez-le de la blacklist pour pouvoir l'utiliser comme une dépendance.
+	DEPENDENCYDOWNLOADER_MOD_WRONG_VERSION=			ERREUR: La version {1} de {0} est nécessaire, mais uniquement la version {2} est dans la base de données. Merci d'installer ce mod manuellement.
+	DEPENDENCYDOWNLOADER_RESTARTING=				Redémarrage en cours
+	DEPENDENCYDOWNLOADER_RESTARTING_IN=				Redémarrage dans {0}
+	DEPENDENCYDOWNLOADER_PRESS_BACK_TO_RESTART=		Appuyez sur Retour pour redémarrer Celeste.
+	DEPENDENCYDOWNLOADER_PRESS_BACK_TO_GO_BACK=		Appuyez sur Retour pour revenir aux options des mods.
+	DEPENDENCYDOWNLOADER_DOWNLOADING=				Téléchargement de {0} depuis {1}...
+	DEPENDENCYDOWNLOADER_DOWNLOAD_FINISHED=			Téléchargement terminé.
+	DEPENDENCYDOWNLOADER_VERIFYING_CHECKSUM=		Vérification de la somme de contrôle...
+	DEPENDENCYDOWNLOADER_UPDATING=					Installation de la mise à jour de {0} ({1} -> {2}) vers {3}...
+	DEPENDENCYDOWNLOADER_INSTALLING=				Installation du mod {0} v.{1} vers {2}...
+	DEPENDENCYDOWNLOADER_INSTALL_FAILED=			ERREUR: L'installation de {0} a échoué. Vérifiez votre log.txt pour plus d'informations.
 
 # Misc
 	UI_GIVEUP_HINT=			Votre progression est sauvegardée, mais vous devrez recommencer depuis le dernier :checkpoint:

--- a/Celeste.Mod.mm/Content/Dialog/French.txt
+++ b/Celeste.Mod.mm/Content/Dialog/French.txt
@@ -91,7 +91,7 @@
 	DEPENDENCYDOWNLOADER_MOD_NOT_FOUND=				ERREUR: {0} n'a pas été trouvé dans la base de données. Merci de l'installer manuellement.
 	DEPENDENCYDOWNLOADER_MOD_NOT_AUTO_INSTALLABLE=	ERREUR: {0} possède plusieurs versions et ne peut pas être installé automatiquement. Merci de l'installer manuellement.
 	DEPENDENCYDOWNLOADER_MOD_BLACKLISTED=			ERREUR: {0}.zip est dans votre blacklist. Retirez-le de la blacklist pour pouvoir l'utiliser comme une dépendance.
-	DEPENDENCYDOWNLOADER_MOD_WRONG_VERSION=			ERREUR: La version {1} de {0} est nécessaire, mais uniquement la version {2} est dans la base de données. Merci d'installer ce mod manuellement.
+	DEPENDENCYDOWNLOADER_MOD_WRONG_VERSION=			ERREUR: La version {1} de {0} est nécessaire, mais seule la version {2} est disponible. Merci d'installer ce mod manuellement.
 	DEPENDENCYDOWNLOADER_RESTARTING=				Redémarrage en cours
 	DEPENDENCYDOWNLOADER_RESTARTING_IN=				Redémarrage dans {0}
 	DEPENDENCYDOWNLOADER_PRESS_BACK_TO_RESTART=		Appuyez sur Retour pour redémarrer Celeste.

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
@@ -490,29 +490,39 @@ namespace Celeste.Mod {
                     EverestModuleMetadata meta = other.Metadata;
                     if (meta.Name != depName)
                         continue;
+
                     Version version = meta.Version;
-
-                    // Special case: Always true if version == 0.0.*
-                    if (version.Major == 0 && version.Minor == 0)
-                        return true;
-                    
-                    // Major version, breaking changes, must match.
-                    if (version.Major != depVersion.Major)
-                        return false;
-                    // Minor version, non-breaking changes, installed can't be lower than what we depend on.
-                    if (version.Minor < depVersion.Minor)
-                        return false;
-
-                    // "Build" is "PATCH" in semver, but we'll also check for it and "Revision".
-                    if (version.Minor == depVersion.Minor && version.Build < depVersion.Build)
-                        return false;
-                    if (version.Minor == depVersion.Minor && version.Build == depVersion.Build && version.Revision < depVersion.Revision)
-                        return false;
-
-                    return true;
+                    return VersionSatisfiesDependency(depVersion, version);
                 }
 
                 return false;
+            }
+
+            /// <summary>
+            /// Checks if the given version number is "compatible" with the one required as a dependency.
+            /// </summary>
+            /// <param name="requiredVersion">The version required by a mod in their dependencies</param>
+            /// <param name="installedVersion">The version to check for</param>
+            /// <returns>true if the versions number are compatible, false otherwise.</returns>
+            public static bool VersionSatisfiesDependency(Version requiredVersion, Version installedVersion) {
+                // Special case: Always true if version == 0.0.*
+                if (installedVersion.Major == 0 && installedVersion.Minor == 0)
+                    return true;
+
+                // Major version, breaking changes, must match.
+                if (installedVersion.Major != requiredVersion.Major)
+                    return false;
+                // Minor version, non-breaking changes, installed can't be lower than what we depend on.
+                if (installedVersion.Minor < requiredVersion.Minor)
+                    return false;
+
+                // "Build" is "PATCH" in semver, but we'll also check for it and "Revision".
+                if (installedVersion.Minor == requiredVersion.Minor && installedVersion.Build < requiredVersion.Build)
+                    return false;
+                if (installedVersion.Minor == requiredVersion.Minor && installedVersion.Build == requiredVersion.Build && installedVersion.Revision < requiredVersion.Revision)
+                    return false;
+
+                return true;
             }
 
             private static ResolveEventHandler GenerateModAssemblyResolver(EverestModuleMetadata meta) {

--- a/Celeste.Mod.mm/Mod/Helpers/ModUpdateInfo.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/ModUpdateInfo.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+namespace Celeste.Mod.Helpers {
+    public class ModUpdateInfo {
+        public virtual string Name { get; set; }
+        public virtual string Version { get; set; }
+        public virtual int LastUpdate { get; set; }
+        public virtual string URL { get; set; }
+        public virtual List<string> xxHash { get; set; }
+    }
+}

--- a/Celeste.Mod.mm/Mod/Helpers/ModUpdaterHelper.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/ModUpdaterHelper.cs
@@ -16,7 +16,7 @@ namespace Celeste.Mod.Helpers {
             try {
                 string modUpdaterDatabaseUrl = getModUpdaterDatabaseUrl();
 
-                Logger.Log("OuiModUpdateList", $"Downloading last versions list from {modUpdaterDatabaseUrl}");
+                Logger.Log("ModUpdaterHelper", $"Downloading last versions list from {modUpdaterDatabaseUrl}");
 
                 using (WebClient wc = new WebClient()) {
                     string yamlData = wc.DownloadString(modUpdaterDatabaseUrl);
@@ -24,10 +24,10 @@ namespace Celeste.Mod.Helpers {
                     foreach (string name in updateCatalog.Keys) {
                         updateCatalog[name].Name = name;
                     }
-                    Logger.Log("OuiModUpdateList", $"Downloaded {updateCatalog.Count} item(s)");
+                    Logger.Log("ModUpdaterHelper", $"Downloaded {updateCatalog.Count} item(s)");
                 }
             } catch (Exception e) {
-                Logger.Log("OuiModUpdateList", $"Downloading database failed!");
+                Logger.Log("ModUpdaterHelper", $"Downloading database failed!");
                 Logger.LogDetailed(e);
             }
 
@@ -42,7 +42,7 @@ namespace Celeste.Mod.Helpers {
         public static void VerifyChecksum(ModUpdateInfo update, string filePath) {
             string actualHash = BitConverter.ToString(Everest.GetChecksum(filePath)).Replace("-", "").ToLowerInvariant();
             string expectedHash = update.xxHash[0];
-            Logger.Log("OuiModUpdateList", $"Verifying checksum: actual hash is {actualHash}, expected hash is {expectedHash}");
+            Logger.Log("ModUpdaterHelper", $"Verifying checksum: actual hash is {actualHash}, expected hash is {expectedHash}");
             if (expectedHash != actualHash) {
                 throw new IOException($"Checksum error: expected {expectedHash}, got {actualHash}");
             }
@@ -61,16 +61,16 @@ namespace Celeste.Mod.Helpers {
                 if (content.GetType() == typeof(ZipModContent) && (content as ZipModContent).Mod.Name == mod.Name) {
                     ZipModContent modZip = content as ZipModContent;
 
-                    Logger.Log("OuiModUpdateList", $"Closing mod .zip: {modZip.Path}");
+                    Logger.Log("ModUpdaterHelper", $"Closing mod .zip: {modZip.Path}");
                     modZip.Dispose();
                 }
             }
 
             // delete the old zip, and move the new one.
-            Logger.Log("OuiModUpdateList", $"Deleting mod .zip: {mod.PathArchive}");
+            Logger.Log("ModUpdaterHelper", $"Deleting mod .zip: {mod.PathArchive}");
             File.Delete(mod.PathArchive);
 
-            Logger.Log("OuiModUpdateList", $"Moving {zipPath} to {mod.PathArchive}");
+            Logger.Log("ModUpdaterHelper", $"Moving {zipPath} to {mod.PathArchive}");
             File.Move(zipPath, mod.PathArchive);
         }
 
@@ -80,7 +80,7 @@ namespace Celeste.Mod.Helpers {
         /// </summary>
         private static string getModUpdaterDatabaseUrl() {
             using (WebClient wc = new WebClient()) {
-                Logger.Log("OuiModUpdateList", "Fetching mod updater database URL");
+                Logger.Log("ModUpdaterHelper", "Fetching mod updater database URL");
                 return wc.DownloadString("https://everestapi.github.io/modupdater.txt").Trim();
             }
         }

--- a/Celeste.Mod.mm/Mod/Helpers/ModUpdaterHelper.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/ModUpdaterHelper.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using YamlDotNet.Serialization;
+
+namespace Celeste.Mod.Helpers {
+    public class ModUpdaterHelper {
+        /// <summary>
+        /// Downloads the full update list from the update checker server.
+        /// Returns null if the download fails for any reason.
+        /// </summary>
+        public static Dictionary<string, ModUpdateInfo> DownloadModUpdateList() {
+            Dictionary<string, ModUpdateInfo> updateCatalog = null;
+
+            try {
+                string modUpdaterDatabaseUrl = getModUpdaterDatabaseUrl();
+
+                Logger.Log("OuiModUpdateList", $"Downloading last versions list from {modUpdaterDatabaseUrl}");
+
+                using (WebClient wc = new WebClient()) {
+                    string yamlData = wc.DownloadString(modUpdaterDatabaseUrl);
+                    updateCatalog = new Deserializer().Deserialize<Dictionary<string, ModUpdateInfo>>(yamlData);
+                    foreach (string name in updateCatalog.Keys) {
+                        updateCatalog[name].Name = name;
+                    }
+                    Logger.Log("OuiModUpdateList", $"Downloaded {updateCatalog.Count} item(s)");
+                }
+            } catch (Exception e) {
+                Logger.Log("OuiModUpdateList", $"Downloading database failed!");
+                Logger.LogDetailed(e);
+            }
+
+            return updateCatalog;
+        }
+
+        /// <summary>
+        /// Verifies the downloaded mod's checksum, and throws an IOException if it doesn't match the database one.
+        /// </summary>
+        /// <param name="update">The mod info from the database</param>
+        /// <param name="filePath">The path to the file to check</param>
+        public static void VerifyChecksum(ModUpdateInfo update, string filePath) {
+            string actualHash = BitConverter.ToString(Everest.GetChecksum(filePath)).Replace("-", "").ToLowerInvariant();
+            string expectedHash = update.xxHash[0];
+            Logger.Log("OuiModUpdateList", $"Verifying checksum: actual hash is {actualHash}, expected hash is {expectedHash}");
+            if (expectedHash != actualHash) {
+                throw new IOException($"Checksum error: expected {expectedHash}, got {actualHash}");
+            }
+        }
+
+        /// <summary>
+        /// Installs a mod update in the Mods directory once it has been downloaded.
+        /// This method will replace the installed mod zip with the one that was just downloaded.
+        /// </summary>
+        /// <param name="update">The update info coming from the update server</param>
+        /// <param name="mod">The mod metadata from Everest for the installed mod</param>
+        /// <param name="zipPath">The path to the zip the update has been downloaded to</param>
+        public static void InstallModUpdate(ModUpdateInfo update, EverestModuleMetadata mod, string zipPath) {
+            // let's close the zip, as we will replace it now.
+            foreach (ModContent content in Everest.Content.Mods) {
+                if (content.GetType() == typeof(ZipModContent) && (content as ZipModContent).Mod.Name == mod.Name) {
+                    ZipModContent modZip = content as ZipModContent;
+
+                    Logger.Log("OuiModUpdateList", $"Closing mod .zip: {modZip.Path}");
+                    modZip.Dispose();
+                }
+            }
+
+            // delete the old zip, and move the new one.
+            Logger.Log("OuiModUpdateList", $"Deleting mod .zip: {mod.PathArchive}");
+            File.Delete(mod.PathArchive);
+
+            Logger.Log("OuiModUpdateList", $"Moving {zipPath} to {mod.PathArchive}");
+            File.Move(zipPath, mod.PathArchive);
+        }
+
+        /// <summary>
+        /// Retrieves the mod updater database location from everestapi.github.io.
+        /// This should point to a running instance of https://github.com/max4805/EverestUpdateCheckerServer.
+        /// </summary>
+        private static string getModUpdaterDatabaseUrl() {
+            using (WebClient wc = new WebClient()) {
+                Logger.Log("OuiModUpdateList", "Fetching mod updater database URL");
+                return wc.DownloadString("https://everestapi.github.io/modupdater.txt").Trim();
+            }
+        }
+    }
+}

--- a/Celeste.Mod.mm/Mod/UI/OuiDependencyDownloader.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiDependencyDownloader.cs
@@ -1,0 +1,210 @@
+﻿using Celeste.Mod.Helpers;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Celeste.Mod.UI {
+    class OuiDependencyDownloader : OuiLoggedProgress {
+        public static List<EverestModuleMetadata> MissingDependencies;
+
+        private bool shouldAutoRestart;
+        private bool shouldRestart;
+
+        private Task task = null;
+
+        public override IEnumerator Enter(Oui from) {
+            Title = Dialog.Clean("MODOPTIONS_COREMODULE_DOWNLOADDEPS").ToUpperInvariant();
+            task = new Task(downloadAllDependencies);
+            Lines = new List<string>();
+            Progress = 0;
+            ProgressMax = 0;
+            shouldAutoRestart = true;
+            shouldRestart = false;
+
+            task.Start();
+
+            IEnumerator enterBase = base.Enter(from);
+            while (enterBase.MoveNext()) yield return enterBase.Current;
+            yield break;
+        }
+
+        private void downloadAllDependencies() {
+            // 1. Compute the list of dependencies we must download.
+            LogLine("Downloading mod database...");
+            Dictionary<string, ModUpdateInfo> availableDownloads = ModUpdaterHelper.DownloadModUpdateList();
+            if (availableDownloads == null) {
+                shouldAutoRestart = false;
+                shouldRestart = false;
+
+                LogLine($"[ERROR] Downloading the database failed. Please check your log.txt for more info.");
+            } else {
+                LogLine("Computing dependencies to download...");
+                Dictionary<string, ModUpdateInfo> modsToInstall = new Dictionary<string, ModUpdateInfo>();
+                Dictionary<string, ModUpdateInfo> modsToUpdate = new Dictionary<string, ModUpdateInfo>();
+                Dictionary<string, EverestModuleMetadata> modsToUpdateCurrentVersions = new Dictionary<string, EverestModuleMetadata>();
+                HashSet<string> modsNotFound = new HashSet<string>();
+                HashSet<string> modsNotInstallableAutomatically = new HashSet<string>();
+                HashSet<string> modsBlacklisted = new HashSet<string>();
+                bool shouldUpdateEverest = false;
+
+                foreach (EverestModuleMetadata dependency in MissingDependencies) {
+                    if (dependency.Name == "Everest") {
+                        Logger.Log("OuiDependencyDownloader", $"Everest should be updated");
+                        shouldUpdateEverest = true;
+                        shouldAutoRestart = false;
+
+                    // TODO: maybe check more precisely for blacklisted mods? We're only basing ourselves on the name here.
+                    } else if (Everest.Loader.Blacklist.Contains($"{dependency.Name}.zip")) {
+                        Logger.Log("OuiDependencyDownloader", $"{dependency.Name} is blacklisted, and should be unblacklisted instead");
+                        modsBlacklisted.Add(dependency.Name);
+                        shouldAutoRestart = false;
+
+                    } else if (!availableDownloads.ContainsKey(dependency.Name)) {
+                        Logger.Log("OuiDependencyDownloader", $"{dependency.Name} was not found in the database");
+                        modsNotFound.Add(dependency.Name);
+                        shouldAutoRestart = false;
+
+                    } else if (availableDownloads[dependency.Name].xxHash.Count > 1) {
+                        Logger.Log("OuiDependencyDownloader", $"{dependency.Name} has multiple versions and cannot be installed automatically");
+                        modsNotInstallableAutomatically.Add(dependency.Name);
+                        shouldAutoRestart = false;
+
+                    } else {
+                        EverestModuleMetadata installedVersion = null;
+                        foreach (EverestModule module in Everest.Modules) {
+                            // note: if the mod is installed, but not as a zip, this will be treated as a fresh install.
+                            // this is fine since zips take the priority over directories.
+                            if (module.Metadata.PathArchive != null && module.Metadata.Name == dependency.Name) {
+                                installedVersion = module.Metadata;
+                                break;
+                            }
+                        }
+
+                        if (installedVersion != null) {
+                            Logger.Log("OuiDependencyDownloader", $"{dependency.Name} is already installed and will be updated");
+                            modsToUpdate[dependency.Name] = availableDownloads[dependency.Name];
+                            modsToUpdateCurrentVersions[dependency.Name] = installedVersion;
+
+                        } else {
+                            Logger.Log("OuiDependencyDownloader", $"{dependency.Name} will be installed");
+                            modsToInstall[dependency.Name] = availableDownloads[dependency.Name];
+                        }
+                    }
+                    // TODO: also check if version is actually compatible?
+                }
+
+                // actually install the mods now
+                foreach (ModUpdateInfo modToInstall in modsToInstall.Values)
+                    downloadDependency(modToInstall, null);
+
+                foreach (ModUpdateInfo modToUpdate in modsToUpdate.Values)
+                    downloadDependency(modToUpdate, modsToUpdateCurrentVersions[modToUpdate.Name]);
+
+                // display all mods that couldn't be accounted for
+                if (shouldUpdateEverest)
+                    LogLine($"[ERROR] You must update Everest to play some of your mods.");
+
+                foreach (string mod in modsNotFound)
+                    LogLine($"[ERROR] {mod} could not be found in the database. Please install this mod manually.");
+
+                foreach (string mod in modsNotInstallableAutomatically)
+                    LogLine($"[ERROR] {mod} is available in multiple versions and cannot be installed automatically. Please install this mod manually.");
+
+                foreach (string mod in modsBlacklisted)
+                    LogLine($"[ERROR] {mod}.zip is present in your blacklist. Please unblacklist it to satisfy the dependency on {mod}.");
+            }
+
+            Progress = 1;
+            ProgressMax = 1;
+
+            if (shouldAutoRestart) {
+                // there are no errors to display: restart automatically
+                LogLine("Restarting");
+                for (int i = 3; i > 0; --i) {
+                    Lines[Lines.Count - 1] = $"Restarting in {i}";
+                    Thread.Sleep(1000);
+                }
+                Lines[Lines.Count - 1] = $"Restarting";
+
+                Everest.QuickFullRestart();
+            } else if (shouldRestart) {
+                LogLine("\nPress Back to restart Celeste.");
+            } else {
+                LogLine("\nPress Back to return to Mod Options.");
+            }
+        }
+
+        private void downloadDependency(ModUpdateInfo mod, EverestModuleMetadata installedVersion) {
+            string downloadDestination = Path.Combine(Everest.PathGame, $"dependency-download.zip");
+            try {
+                // 1. Download
+                LogLine($"Downloading {mod.Name} from {mod.URL}...");
+                LogLine($"", false);
+
+                Everest.Updater.DownloadFileWithProgress(mod.URL, downloadDestination, (position, length, speed) => {
+                    if (length > 0) {
+                        Lines[Lines.Count - 1] = $"{((int)Math.Floor(100D * (position / (double)length)))}% @ {speed} KiB/s";
+                        Progress = position;
+                        ProgressMax = (int)length;
+                    } else {
+                        Lines[Lines.Count - 1] = $"{((int)Math.Floor(position / 1000D))}KiB @ {speed} KiB/s";
+                        ProgressMax = 0;
+                    }
+                });
+
+                ProgressMax = 0;
+                Lines[Lines.Count - 1] = $"Download finished.";
+
+                // 2. Verify checksum
+                LogLine($"Verifying checksum...");
+                ModUpdaterHelper.VerifyChecksum(mod, downloadDestination);
+
+                // 3. Install mod
+                shouldRestart = true;
+                if (installedVersion != null) {
+                    LogLine($"Installing update for {mod.Name} ({installedVersion.Version} -> {mod.Version}) to {installedVersion.PathArchive}...");
+                    ModUpdaterHelper.InstallModUpdate(mod, installedVersion, downloadDestination);
+                } else {
+                    string installDestination = Path.Combine(Everest.Loader.PathMods, $"{mod.Name}.zip");
+                    LogLine($"Installing mod {mod.Name} v.{mod.Version} to {installDestination}...");
+                    File.Move(downloadDestination, installDestination);
+                }
+            } catch (Exception e) {
+                // install failed
+                LogLine($"[ERROR] Installing {mod.Name} failed. Please check your log.txt for more info.");
+                Logger.LogDetailed(e);
+                shouldAutoRestart = false;
+
+                // try to delete the file if it still exists.
+                if (File.Exists(downloadDestination)) {
+                    try {
+                        Logger.Log("OuiDependencyDownloader", $"Deleting temp file {downloadDestination}");
+                        File.Delete(downloadDestination);
+                    } catch (Exception) {
+                        Logger.Log("OuiDependencyDownloader", $"Removing {downloadDestination} failed");
+                    }
+                }
+            }
+        }
+
+        public override void Update() {
+            // handle pressing the Back key
+            if (task != null && !shouldAutoRestart && (task.IsCompleted || task.IsCanceled || task.IsFaulted) && Input.MenuCancel.Pressed) {
+                if (shouldRestart) {
+                    Everest.QuickFullRestart();
+                } else {
+                    // go back to mod options instead
+                    task = null;
+                    Lines.Clear();
+                    Audio.Play(SFX.ui_main_button_back);
+                    Overworld.Goto<OuiModOptions>();
+                }
+            }
+
+            base.Update();
+        }
+    }
+}

--- a/Celeste.Mod.mm/Mod/UI/OuiLoggedProgress.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiLoggedProgress.cs
@@ -66,7 +66,7 @@ namespace Celeste.Mod.UI {
             StringBuilder escaped = new StringBuilder();
             for (int i = 0; i < line.Length; i++) {
                 char c = line[i];
-                if (!Draw.DefaultFont.Characters.Contains(c))
+                if (!ActiveFont.Font.Get(ActiveFont.BaseSize * 0.5f).Characters.ContainsKey(c))
                     c = ' ';
                 escaped.Append(c);
             }


### PR DESCRIPTION
Here is something that's not quite finished yet (there are TODOs for edge cases left in the code this time), but I chose to open a PR anyway to be able to discuss about this (for example, is that a good idea or is that too much of a mess? are the different cases here handled correctly?)

So, what's here is a thing that adds a button in the Mod Options to automatically download missing dependencies if there are any. This uses the same database as the update checker, as it provides what we need here: we can get a download link for a mod based on its name.

~~Note: the only mod that cannot be retrieved automatically by this (and by the update checker as well) is DJ Map Helper, because it has both a Windows and a Linux version.~~ Update (Oct 27): This is not the case anymore. Thanks DJ!