### PR TITLE
ActivateDreamBlocksTrigger

### DIFF
--- a/Celeste.Mod.mm/Mod/Entities/ActivateDreamBlocksTrigger.cs
+++ b/Celeste.Mod.mm/Mod/Entities/ActivateDreamBlocksTrigger.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.Xna.Framework;
+
+namespace Celeste.Mod.Entities
+{
+    [CustomEntity("everest/activateDreamBlocksTrigger")]
+    class ActivateDreamBlocksTrigger : Trigger
+    {
+        private readonly Level level;
+
+        public ActivateDreamBlocksTrigger(EntityData data, Vector2 offset)
+            : base(data, offset)
+        {
+            level = Scene as Level;
+        }
+
+        public override void OnEnter(Player player)
+        {
+            if (!level.Session.Inventory.DreamDash)
+            {
+                level.Session.Inventory.DreamDash = true;
+                foreach (DreamBlock dreamBlock in level.Tracker.GetEntities<DreamBlock>())
+                {
+                    dreamBlock.Activate();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Activates Dream Blocks for any inventory with animation. Does only have one mode since there is only animation for activating dream blocks. Given a reverse animation it can be extended with support for deactivating them.