### PR TITLE
Fix default.nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -246,3 +246,6 @@ ModelManifest.xml
 
 # vscode files
 .vscode/
+
+# Nix build result
+result

--- a/default.nix
+++ b/default.nix
@@ -119,9 +119,12 @@ in buildDotnetPackage rec {
   '';
 
   postInstall = ''
-    mkdir -pv "$out/lib/dotnet/${baseName}"
-    cp $out/lib/dotnet/Everest/libMonoPosixHelper.dylib.dSYM/Contents/Resources/DWARF/libMonoPosixHelper.dylib \
-      $out/lib/dotnet/Everest/libMonoPosixHelper.dylib
+    mv \
+      $out/lib/dotnet/Everest/libMonoPosixHelper.dylib.dSYM/Contents/Resources/DWARF/libMonoPosixHelper.dylib \
+      $out/lib/dotnet/Everest/libMonoPosixHelper.dylib.dSYM/Contents/Info.plist \
+      $out/lib/dotnet/Everest/lib64/* \
+      $out/lib/dotnet/Everest/
+    rm -r $out/lib/dotnet/Everest/lib64 $out/lib/dotnet/Everest/libMonoPosixHelper.dylib.dSYM
     sed -i "2i chmod -R u+w ." $out/bin/miniinstaller
     sed -i "2i cp -r $out/lib/dotnet/Everest/* "'$1' $out/bin/miniinstaller
     sed -i '2i cd $1' $out/bin/miniinstaller

--- a/default.nix
+++ b/default.nix
@@ -120,6 +120,7 @@ in buildDotnetPackage rec {
 
   postInstall = ''
     mkdir -pv "$out/lib/dotnet/${baseName}"
+    sed -i "2i chmod -R u+w ." $out/bin/miniinstaller
     sed -i "2i cp -r $out/lib/dotnet/Everest/* "'$1' $out/bin/miniinstaller
     sed -i '2i cd $1' $out/bin/miniinstaller
   '';

--- a/default.nix
+++ b/default.nix
@@ -3,7 +3,7 @@
 let
   DotNetZip = fetchNuGet {
     baseName = "DotNetZip";
-    version  = "1.13.4";
+    version = "1.13.4";
     sha256 = "0j7b8b12dz7wxmhr1i9xs9mr9hq65xnsxdg4vlaz53k7ddi36v39";
     outputFiles = ["*"];
   };
@@ -17,63 +17,63 @@ let
 
   KeraLua = fetchNuGet {
     baseName = "KeraLua";
-    version  = "1.0.22";
+    version = "1.0.22";
     sha256 = "09b4kp6rnzkxdz69bk2w964l3vkypga6p1lnp5g7vzcnq24zhn6y";
     outputFiles = ["*"];
   };
 
   Cecil = fetchNuGet {
     baseName = "Mono.Cecil";
-    version  = "0.10.4";
+    version = "0.10.4";
     sha256 = "16iabjrizkh3g4g9dj40bm2z1kba7752pp5qfszy06x82ahs8l9l";
     outputFiles = ["*"];
   };
 
   MonoMod = fetchNuGet {
     baseName = "MonoMod";
-    version  = "19.9.1.6";
+    version = "19.9.1.6";
     sha256 = "1z5rz44m62i5f6n87z71fsgdy00xc445s29fca80cjvb8qwmwwz4";
     outputFiles = ["*"];
   };
 
   MonoMod-RD = fetchNuGet {
     baseName = "MonoMod.RuntimeDetour";
-    version  = "19.9.1.6";
+    version = "19.9.1.6";
     sha256 = "07ggcssl9xyf5g6b80xsd0y4nlzap2cnm9fhv7bywiynvlkh2rd8";
     outputFiles = ["*"];
   };
 
   MonoMod-RD-HG = fetchNuGet {
     baseName = "MonoMod.RuntimeDetour.HookGen";
-    version  = "19.9.1.6";
+    version = "19.9.1.6";
     sha256 = "04vf06ascqph6yl0c6i0iqzw3sqhn1m1hwhgn0jm02ps0wjgvvqa";
     outputFiles = ["*"];
   };
 
   MonoMod-Utils = fetchNuGet {
     baseName = "MonoMod.Utils";
-    version  = "19.9.1.6";
+    version = "19.9.1.6";
     sha256 = "174pfw9d8kwk64rdy75aw6acag619fvd5vin5iwzbrhxniv3pb69";
     outputFiles = ["*"];
   };
 
   Json = fetchNuGet {
     baseName = "Newtonsoft.Json";
-    version  = "12.0.2";
+    version = "12.0.2";
     sha256 = "0w2fbji1smd2y7x25qqibf1qrznmv4s6s0jvrbvr6alb7mfyqvh5";
     outputFiles = ["*"];
   };
 
   NLua = fetchNuGet {
     baseName = "NLua";
-    version  = "1.4.24";
+    version = "1.4.24";
     sha256 = "0gcn2gfbrf8ib4dw1j0dy0pn256x3171gvws225gg9lkm96n3dqn";
     outputFiles = ["*"];
   };
 
   YamlDotNet = fetchNuGet {
     baseName = "YamlDotNet";
-    version  = "7.0.0";
+    version = "7.0.0";
     sha256 = "1vckldz58qn2pmnc9kfvvfqayyxiy8yzyini8s7fl2c7fm3nrjyg";
     outputFiles = ["*"];
   };

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,13 @@
 { pkgs ? import <nixpkgs> {}, fetchNuGet ? pkgs.fetchNuGet, buildDotnetPackage ? pkgs.buildDotnetPackage }:
 
 let
+  DotNetZip = fetchNuGet {
+    baseName = "DotNetZip";
+    version  = "1.13.4";
+    sha256 = "0j7b8b12dz7wxmhr1i9xs9mr9hq65xnsxdg4vlaz53k7ddi36v39";
+    outputFiles = ["*"];
+  };
+
   Jdenticon = fetchNuGet {
     baseName = "Jdenticon-net";
     version = "2.2.1";
@@ -8,24 +15,73 @@ let
     outputFiles = ["*"];
   };
 
-  Cecil = fetchNuGet {
-    baseName = "Mono.Cecil";
-    version = "0.10.0";
-    sha256 = "0yg9c0papkdlvmhas5jh8d849hwmigam4whyljn6ig1npx6lmsik";
-    outputFiles = [ "*" ];
-  };
-
-  Json = fetchNuGet {
-    baseName = "Newtonsoft.Json";
-    version  = "12.0.1";
-    sha256 = "11f30cfxwn0z1hr5y69hxac0yyjz150ar69nvqhn18n9k92zfxz1";
-    outputFiles = ["*"];
-  };
-
   KeraLua = fetchNuGet {
     baseName = "KeraLua";
     version  = "1.0.22";
     sha256 = "09b4kp6rnzkxdz69bk2w964l3vkypga6p1lnp5g7vzcnq24zhn6y";
+    outputFiles = ["*"];
+  };
+
+  Cecil = fetchNuGet {
+    baseName = "Mono.Cecil";
+    version  = "0.10.4";
+    sha256 = "16iabjrizkh3g4g9dj40bm2z1kba7752pp5qfszy06x82ahs8l9l";
+    outputFiles = ["*"];
+  };
+
+  Cecil-Rocks = fetchNuGet {
+    baseName = "Mono.Cecil.Rocks";
+    version  = "0.10.4";
+    sha256 = "09b4kp6rnzkxdz69bk2w964l3vkypga6p1lnp5g7vzcnq24zhn6y";
+    outputFiles = ["*"];
+  };
+
+  MonoMod = fetchNuGet {
+    baseName = "MonoMod";
+    version  = "19.9.1.6";
+    sha256 = "1z5rz44m62i5f6n87z71fsgdy00xc445s29fca80cjvb8qwmwwz4";
+    outputFiles = ["*"];
+  };
+
+  MonoMod-RD = fetchNuGet {
+    baseName = "MonoMod.RuntimeDetour";
+    version  = "19.9.1.6";
+    sha256 = "07ggcssl9xyf5g6b80xsd0y4nlzap2cnm9fhv7bywiynvlkh2rd8";
+    outputFiles = ["*"];
+  };
+
+  MonoMod-RD-HG = fetchNuGet {
+    baseName = "MonoMod.RuntimeDetour.HookGen";
+    version  = "19.9.1.6";
+    sha256 = "04vf06ascqph6yl0c6i0iqzw3sqhn1m1hwhgn0jm02ps0wjgvvqa";
+    outputFiles = ["*"];
+  };
+
+  MonoMod-Utils = fetchNuGet {
+    baseName = "MonoMod.Utils";
+    version  = "19.9.1.6";
+    sha256 = "174pfw9d8kwk64rdy75aw6acag619fvd5vin5iwzbrhxniv3pb69";
+    outputFiles = ["*"];
+  };
+
+  Json = fetchNuGet {
+    baseName = "Newtonsoft.Json";
+    version  = "12.0.2";
+    sha256 = "0w2fbji1smd2y7x25qqibf1qrznmv4s6s0jvrbvr6alb7mfyqvh5";
+    outputFiles = ["*"];
+  };
+
+  NLua = fetchNuGet {
+    baseName = "NLua";
+    version  = "1.4.24";
+    sha256 = "0gcn2gfbrf8ib4dw1j0dy0pn256x3171gvws225gg9lkm96n3dqn";
+    outputFiles = ["*"];
+  };
+
+  YamlDotNet = fetchNuGet {
+    baseName = "YamlDotNet";
+    version  = "7.0.0";
+    sha256 = "1vckldz58qn2pmnc9kfvvfqayyxiy8yzyini8s7fl2c7fm3nrjyg";
     outputFiles = ["*"];
   };
 
@@ -48,10 +104,17 @@ in buildDotnetPackage rec {
   preBuild = ''
     # Fake nuget restore, not very elegant but it works.
     mkdir -p packages
-    ln -sn ${Jdenticon}/lib/dotnet/Jdenticon-net packages/Jdenticon-net.${Jdenticon.version}
-    ln -sn ${Cecil}/lib/dotnet/Mono.Cecil packages/Mono.Cecil.${Cecil.version}
-    ln -sn ${Json}/lib/dotnet/Newtonsoft.Json packages/Newtonsoft.Json.${Json.version}
-    ln -sn ${KeraLua}/lib/dotnet/KeraLua packages/KeraLua.${KeraLua.version}
+    ln -sn ${Jdenticon}/lib/dotnet/Jdenticon-net                     packages/Jdenticon-net.${Jdenticon.version}
+    ln -sn ${KeraLua}/lib/dotnet/KeraLua                             packages/KeraLua.${KeraLua.version}
+    ln -sn ${DotNetZip}/lib/dotnet/DotNetZip                         packages/DotNetZip.${DotNetZip.version}
+    ln -sn ${Cecil}/lib/dotnet/Mono.Cecil                            packages/Mono.Cecil.${Cecil.version}
+    ln -sn ${MonoMod}/lib/dotnet/MonoMod                             packages/MonoMod.${MonoMod.version}
+    ln -sn ${MonoMod-RD}/lib/dotnet/MonoMod.RuntimeDetour            packages/MonoMod.RuntimeDetour.${MonoMod-RD.version}
+    ln -sn ${MonoMod-RD-HG}/lib/dotnet/MonoMod.RuntimeDetour.HookGen packages/MonoMod.RuntimeDetour.HookGen.${MonoMod-RD-HG.version}
+    ln -sn ${MonoMod-Utils}/lib/dotnet/MonoMod.Utils                 packages/MonoMod.Utils.${MonoMod-Utils.version}
+    ln -sn ${Json}/lib/dotnet/Newtonsoft.Json                        packages/Newtonsoft.Json.${Json.version}
+    ln -sn ${NLua}/lib/dotnet/NLua                                   packages/NLua.${NLua.version}
+    ln -sn ${YamlDotNet}/lib/dotnet/YamlDotNet                       packages/YamlDotNet.${YamlDotNet.version}
   '';
 
   postInstall = ''

--- a/default.nix
+++ b/default.nix
@@ -131,7 +131,7 @@ in buildDotnetPackage rec {
     sed -i "2i cp -r $out/lib/dotnet/Everest/* ."                                                                    $out/bin/miniinstaller
     sed -i '2i fi'                                                                                                   $out/bin/miniinstaller
     sed -i '2i \ \ exit 1'                                                                                           $out/bin/miniinstaller
-    sed -i '2i \ \ echo "No Celeste executeable found, refusing to install" 1>&2'                                    $out/bin/miniinstaller
+    sed -i '2i \ \ echo "No Celeste executable found, refusing to install" 1>&2'                                     $out/bin/miniinstaller
     sed -i '2i if ! [[ -f Celeste.exe || -f Celeste.bin.osx || -f Celeste.bin.x86_64 || -f Celeste.bin.x86 ]]; then' $out/bin/miniinstaller
     sed -i '2i cd "$1"'                                                                                              $out/bin/miniinstaller
   '';

--- a/default.nix
+++ b/default.nix
@@ -79,9 +79,11 @@ let
     outputFiles = ["*"];
   };
 
+  commit = pkgs.lib.commitIdFromGitRepo ./.git;
+
 in buildDotnetPackage rec {
   baseName = "Everest";
-  version = pkgs.lib.commitIdFromGitRepo ./.git;
+  version = "0.0.0";
   name = "${baseName}-dev-${version}";
 
   src = ./.;
@@ -96,7 +98,7 @@ in buildDotnetPackage rec {
 
     # See c4263f8 Celeste.Mod.mm/Mod/Everest/Everest.cs line 31
     # This is normally set by Azure
-    substituteInPlace Celeste.Mod.mm/Mod/Everest/Everest.cs --replace '0.0.0-dev' "0.0.0-nix-${builtins.substring 0 7 version}"
+    substituteInPlace Celeste.Mod.mm/Mod/Everest/Everest.cs --replace '0.0.0-dev' "0.0.0-nix-${builtins.substring 0 7 commit}"
   '';
 
   preBuild = ''

--- a/default.nix
+++ b/default.nix
@@ -88,10 +88,6 @@ in buildDotnetPackage rec {
   xBuildFiles = [ "Celeste.Mod.mm/Celeste.Mod.mm.csproj" "MiniInstaller/MiniInstaller.csproj" ];
   outputFiles = [ "Celeste.Mod.mm/bin/Release/*" "MiniInstaller/bin/Release/*" ];
 
-  # The build number appears to be Azure-specific, so there is no "correct"
-  # number to use here.
-  buildNumber = 0;
-
   patchPhase = ''
     # $(SolutionDir) does not work for some reason
     substituteInPlace Celeste.Mod.mm/Celeste.Mod.mm.csproj --replace '$(SolutionDir)' ".."
@@ -99,7 +95,7 @@ in buildDotnetPackage rec {
 
     # See c4263f8 Celeste.Mod.mm/Mod/Everest/Everest.cs line 31
     # This is normally set by Azure
-    substituteInPlace Celeste.Mod.mm/Mod/Everest/Everest.cs --replace '0.0.0-dev' "1.${toString buildNumber}.0-nix-${builtins.substring 0 7 version}"
+    substituteInPlace Celeste.Mod.mm/Mod/Everest/Everest.cs --replace '0.0.0-dev' "0.0.0-nix-${builtins.substring 0 7 version}"
   '';
 
   preBuild = ''

--- a/default.nix
+++ b/default.nix
@@ -127,7 +127,7 @@ in buildDotnetPackage rec {
       cp ${mono}/lib/libMonoPosixHelper.so $out/lib/dotnet/Everest
     fi
     rm -r $out/lib/dotnet/Everest/lib64 $out/lib/dotnet/Everest/libMonoPosixHelper.dylib.dSYM
-    sed -i "2i chmod -R u+w ."                                                                                       $out/bin/miniinstaller
+    sed -i '2i chmod -R u+w .'                                                                                       $out/bin/miniinstaller
     sed -i "2i cp -r $out/lib/dotnet/Everest/* ."                                                                    $out/bin/miniinstaller
     sed -i '2i fi'                                                                                                   $out/bin/miniinstaller
     sed -i '2i \ \ exit 1'                                                                                           $out/bin/miniinstaller

--- a/default.nix
+++ b/default.nix
@@ -88,7 +88,9 @@ in buildDotnetPackage rec {
   xBuildFiles = [ "Celeste.Mod.mm/Celeste.Mod.mm.csproj" "MiniInstaller/MiniInstaller.csproj" ];
   outputFiles = [ "Celeste.Mod.mm/bin/Release/*" "MiniInstaller/bin/Release/*" ];
 
-  buildNumber = "0";
+  # The build number appears to be Azure-specific, so there is no "correct"
+  # number to use here.
+  buildNumber = 0;
 
   patchPhase = ''
     # $(SolutionDir) does not work for some reason
@@ -96,7 +98,8 @@ in buildDotnetPackage rec {
     substituteInPlace MiniInstaller/MiniInstaller.csproj --replace '$(SolutionDir)' ".."
 
     # See c4263f8 Celeste.Mod.mm/Mod/Everest/Everest.cs line 31
-    substituteInPlace Celeste.Mod.mm/Mod/Everest/Everest.cs --replace '0.0.0-dev' "1.${buildNumber}.0-nix-${builtins.substring 0 7 version}"
+    # This is normally set by Azure
+    substituteInPlace Celeste.Mod.mm/Mod/Everest/Everest.cs --replace '0.0.0-dev' "1.${toString buildNumber}.0-nix-${builtins.substring 0 7 version}"
   '';
 
   preBuild = ''

--- a/default.nix
+++ b/default.nix
@@ -22,6 +22,13 @@ let
     outputFiles = ["*"];
   };
 
+  KeraLua = fetchNuGet {
+    baseName = "KeraLua";
+    version  = "1.0.22";
+    sha256 = "09b4kp6rnzkxdz69bk2w964l3vkypga6p1lnp5g7vzcnq24zhn6y";
+    outputFiles = ["*"];
+  };
+
 in buildDotnetPackage rec {
   baseName = "Everest";
   version = pkgs.lib.commitIdFromGitRepo ./.git;
@@ -44,6 +51,7 @@ in buildDotnetPackage rec {
     ln -sn ${Jdenticon}/lib/dotnet/Jdenticon-net packages/Jdenticon-net.${Jdenticon.version}
     ln -sn ${Cecil}/lib/dotnet/Mono.Cecil packages/Mono.Cecil.${Cecil.version}
     ln -sn ${Json}/lib/dotnet/Newtonsoft.Json packages/Newtonsoft.Json.${Json.version}
+    ln -sn ${KeraLua}/lib/dotnet/KeraLua packages/KeraLua.${KeraLua.version}
   '';
 
   postInstall = ''

--- a/default.nix
+++ b/default.nix
@@ -120,6 +120,8 @@ in buildDotnetPackage rec {
 
   postInstall = ''
     mkdir -pv "$out/lib/dotnet/${baseName}"
+    cp $out/lib/dotnet/Everest/libMonoPosixHelper.dylib.dSYM/Contents/Resources/DWARF/libMonoPosixHelper.dylib \
+      $out/lib/dotnet/Everest/libMonoPosixHelper.dylib
     sed -i "2i chmod -R u+w ." $out/bin/miniinstaller
     sed -i "2i cp -r $out/lib/dotnet/Everest/* "'$1' $out/bin/miniinstaller
     sed -i '2i cd $1' $out/bin/miniinstaller

--- a/default.nix
+++ b/default.nix
@@ -29,13 +29,6 @@ let
     outputFiles = ["*"];
   };
 
-  Cecil-Rocks = fetchNuGet {
-    baseName = "Mono.Cecil.Rocks";
-    version  = "0.10.4";
-    sha256 = "09b4kp6rnzkxdz69bk2w964l3vkypga6p1lnp5g7vzcnq24zhn6y";
-    outputFiles = ["*"];
-  };
-
   MonoMod = fetchNuGet {
     baseName = "MonoMod";
     version  = "19.9.1.6";

--- a/default.nix
+++ b/default.nix
@@ -121,7 +121,9 @@ in buildDotnetPackage rec {
       $out/lib/dotnet/Everest/libMonoPosixHelper.dylib.dSYM/Contents/Info.plist \
       $out/lib/dotnet/Everest/lib64/* \
       $out/lib/dotnet/Everest/
-    cp ${mono}/lib/libMonoPosixHelper.so $out/lib/dotnet/Everest
+    if [ -f "${mono}/lib/libMonoPosixHelper.so"]; then
+      cp ${mono}/lib/libMonoPosixHelper.so $out/lib/dotnet/Everest
+    fi
     rm -r $out/lib/dotnet/Everest/lib64 $out/lib/dotnet/Everest/libMonoPosixHelper.dylib.dSYM
     sed -i "2i chmod -R u+w ." $out/bin/miniinstaller
     sed -i "2i cp -r $out/lib/dotnet/Everest/* "'$1' $out/bin/miniinstaller

--- a/default.nix
+++ b/default.nix
@@ -121,7 +121,7 @@ in buildDotnetPackage rec {
       $out/lib/dotnet/Everest/libMonoPosixHelper.dylib.dSYM/Contents/Info.plist \
       $out/lib/dotnet/Everest/lib64/* \
       $out/lib/dotnet/Everest/
-    if [ -f "${mono}/lib/libMonoPosixHelper.so"]; then
+    if [ -f "${mono}/lib/libMonoPosixHelper.so" ]; then
       cp ${mono}/lib/libMonoPosixHelper.so $out/lib/dotnet/Everest
     fi
     rm -r $out/lib/dotnet/Everest/lib64 $out/lib/dotnet/Everest/libMonoPosixHelper.dylib.dSYM

--- a/default.nix
+++ b/default.nix
@@ -125,12 +125,12 @@ in buildDotnetPackage rec {
       cp ${mono}/lib/libMonoPosixHelper.so $out/lib/dotnet/Everest
     fi
     rm -r $out/lib/dotnet/Everest/lib64 $out/lib/dotnet/Everest/libMonoPosixHelper.dylib.dSYM
-    sed -i "2i chmod -R u+w ."                                  $out/bin/miniinstaller
-    sed -i "2i cp -r $out/lib/dotnet/Everest/* ."               $out/bin/miniinstaller
-    sed -i '2i fi'                                              $out/bin/miniinstaller
-    sed -i '2i \ \ exit 1'                                      $out/bin/miniinstaller
-    sed -i '2i \ \ echo "File Celeste.exe does not exist" 1>&2' $out/bin/miniinstaller
-    sed -i '2i if [ ! -f Celeste.exe ]; then'                   $out/bin/miniinstaller
-    sed -i '2i cd "$1"'                                         $out/bin/miniinstaller
+    sed -i "2i chmod -R u+w ."                                                                   $out/bin/miniinstaller
+    sed -i "2i cp -r $out/lib/dotnet/Everest/* ."                                                $out/bin/miniinstaller
+    sed -i '2i fi'                                                                               $out/bin/miniinstaller
+    sed -i '2i \ \ exit 1'                                                                       $out/bin/miniinstaller
+    sed -i '2i \ \ echo "No file named Celeste or Celeste.exe exists, refusing to install" 1>&2' $out/bin/miniinstaller
+    sed -i '2i if ! [[ -f Celeste.exe || -f Celeste ]]; then'                                    $out/bin/miniinstaller
+    sed -i '2i cd "$1"'                                                                          $out/bin/miniinstaller
   '';
 } // { shell = import ./shell.nix; }

--- a/default.nix
+++ b/default.nix
@@ -125,8 +125,12 @@ in buildDotnetPackage rec {
       cp ${mono}/lib/libMonoPosixHelper.so $out/lib/dotnet/Everest
     fi
     rm -r $out/lib/dotnet/Everest/lib64 $out/lib/dotnet/Everest/libMonoPosixHelper.dylib.dSYM
-    sed -i "2i chmod -R u+w ." $out/bin/miniinstaller
-    sed -i "2i cp -r $out/lib/dotnet/Everest/* "'$1' $out/bin/miniinstaller
-    sed -i '2i cd $1' $out/bin/miniinstaller
+    sed -i "2i chmod -R u+w ."                                  $out/bin/miniinstaller
+    sed -i "2i cp -r $out/lib/dotnet/Everest/* ."               $out/bin/miniinstaller
+    sed -i '2i fi'                                              $out/bin/miniinstaller
+    sed -i '2i \ \ exit 1'                                      $out/bin/miniinstaller
+    sed -i '2i \ \ echo "File Celeste.exe does not exist" 1>&2' $out/bin/miniinstaller
+    sed -i '2i if [ ! -f Celeste.exe ]; then'                   $out/bin/miniinstaller
+    sed -i '2i cd "$1"'                                         $out/bin/miniinstaller
   '';
 } // { shell = import ./shell.nix; }

--- a/default.nix
+++ b/default.nix
@@ -88,10 +88,15 @@ in buildDotnetPackage rec {
   xBuildFiles = [ "Celeste.Mod.mm/Celeste.Mod.mm.csproj" "MiniInstaller/MiniInstaller.csproj" ];
   outputFiles = [ "Celeste.Mod.mm/bin/Release/*" "MiniInstaller/bin/Release/*" ];
 
+  buildNumber = "0";
+
   patchPhase = ''
     # $(SolutionDir) does not work for some reason
     substituteInPlace Celeste.Mod.mm/Celeste.Mod.mm.csproj --replace '$(SolutionDir)' ".."
     substituteInPlace MiniInstaller/MiniInstaller.csproj --replace '$(SolutionDir)' ".."
+
+    # See c4263f8 Celeste.Mod.mm/Mod/Everest/Everest.cs line 31
+    substituteInPlace Celeste.Mod.mm/Mod/Everest/Everest.cs --replace '0.0.0-dev' "1.${buildNumber}.0-nix-${builtins.substring 0 7 version}"
   '';
 
   preBuild = ''

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,5 @@
-{ pkgs ? import <nixpkgs> {}, fetchNuGet ? pkgs.fetchNuGet, buildDotnetPackage ? pkgs.buildDotnetPackage }:
+{ pkgs ? import <nixpkgs> {}, fetchNuGet ? pkgs.fetchNuGet, buildDotnetPackage ? pkgs.buildDotnetPackage,
+  mono ? pkgs.mono }:
 
 let
   DotNetZip = fetchNuGet {
@@ -120,6 +121,7 @@ in buildDotnetPackage rec {
       $out/lib/dotnet/Everest/libMonoPosixHelper.dylib.dSYM/Contents/Info.plist \
       $out/lib/dotnet/Everest/lib64/* \
       $out/lib/dotnet/Everest/
+    cp ${mono}/lib/libMonoPosixHelper.so $out/lib/dotnet/Everest
     rm -r $out/lib/dotnet/Everest/lib64 $out/lib/dotnet/Everest/libMonoPosixHelper.dylib.dSYM
     sed -i "2i chmod -R u+w ." $out/bin/miniinstaller
     sed -i "2i cp -r $out/lib/dotnet/Everest/* "'$1' $out/bin/miniinstaller

--- a/default.nix
+++ b/default.nix
@@ -127,12 +127,12 @@ in buildDotnetPackage rec {
       cp ${mono}/lib/libMonoPosixHelper.so $out/lib/dotnet/Everest
     fi
     rm -r $out/lib/dotnet/Everest/lib64 $out/lib/dotnet/Everest/libMonoPosixHelper.dylib.dSYM
-    sed -i "2i chmod -R u+w ."                                                                   $out/bin/miniinstaller
-    sed -i "2i cp -r $out/lib/dotnet/Everest/* ."                                                $out/bin/miniinstaller
-    sed -i '2i fi'                                                                               $out/bin/miniinstaller
-    sed -i '2i \ \ exit 1'                                                                       $out/bin/miniinstaller
-    sed -i '2i \ \ echo "No file named Celeste or Celeste.exe exists, refusing to install" 1>&2' $out/bin/miniinstaller
-    sed -i '2i if ! [[ -f Celeste.exe || -f Celeste ]]; then'                                    $out/bin/miniinstaller
-    sed -i '2i cd "$1"'                                                                          $out/bin/miniinstaller
+    sed -i "2i chmod -R u+w ."                                                                                       $out/bin/miniinstaller
+    sed -i "2i cp -r $out/lib/dotnet/Everest/* ."                                                                    $out/bin/miniinstaller
+    sed -i '2i fi'                                                                                                   $out/bin/miniinstaller
+    sed -i '2i \ \ exit 1'                                                                                           $out/bin/miniinstaller
+    sed -i '2i \ \ echo "No Celeste executeable found, refusing to install" 1>&2'                                    $out/bin/miniinstaller
+    sed -i '2i if ! [[ -f Celeste.exe || -f Celeste.bin.osx || -f Celeste.bin.x86_64 || -f Celeste.bin.x86 ]]; then' $out/bin/miniinstaller
+    sed -i '2i cd "$1"'                                                                                              $out/bin/miniinstaller
   '';
 } // { shell = import ./shell.nix; }


### PR DESCRIPTION
**Edit:** Ready to be merged

Should fix regression caused by commit 1247f3a. There are still 843 errors when running `nix-shell`, but those were there before 1247f3a as well.

Note that the build instructions on <https://everestapi.github.io> appear to be wrong (as of commit 7312341):
```bash
nix-env -f default.nix -iA everest
```
should be one of
```bash
nix-env -f default.nix -i  # Remove --attr everest
nix-env -f . -i            # Equivalent
nix-build                  # Doesn't permanently install anything
nix-shell                  # Same as nix-build, but also launches a shell with
                           # miniinstaller available
```