### PR TITLE
Feed back stamp textures (fixes Bingo UI journal page crashes)

### DIFF
--- a/Celeste.Mod.mm/Mod/Core/CoreModule.cs
+++ b/Celeste.Mod.mm/Mod/Core/CoreModule.cs
@@ -145,6 +145,9 @@ namespace Celeste.Mod.Core {
                 GFX.Game[$"objects/checkpoint/flag{i:D2}"] = GFX.Game["util/pixel"];
             for (int i = 0; i <= 27; i++)
                 GFX.Game[$"objects/checkpoint/obelisk{i:D2}"] = GFX.Game["util/pixel"];
+
+            GFX.Gui["fileselect/assist"] = GFX.Game["util/pixel"];
+            GFX.Gui["fileselect/cheatmode"] = GFX.Game["util/pixel"];
         }
 
         public override void Unload() {


### PR DESCRIPTION
This change in 1.3.0.0 broke Bingo UI (and Dash Count in Journal but this one got updated):
> Assist Mode, Variant Mode, and Cheat Mode File Slot icons changed from Stamps to Tabs

Bingo UI still tries to render the stamps for Assist Mode and Cheat Mode, and that gives a crash upon viewing the "binoculars" journal page.

I'm opening a PR for this because I'm unsure we want to do this. This fixes the crash, so it is ready to be merged. :)