### PR TITLE
Optimization in text menu rendering

### DIFF
--- a/Celeste.Mod.mm/Patches/TextMenu.cs
+++ b/Celeste.Mod.mm/Patches/TextMenu.cs
@@ -3,6 +3,7 @@
 #pragma warning disable CS0169 // The field is never used
 
 using Celeste.Mod;
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
 using Monocle;
 using MonoMod;
@@ -53,7 +54,23 @@ namespace Celeste {
             return this;
         }
 
+        [MonoModReplace]
+        public override void Render() {
+            RecalculateSize();
+            Vector2 currentPosition = Position - Justify * new Vector2(Width, Height);
+            foreach (Item item in items) {
+                if (item.Visible) {
+                    float itemHeight = item.Height();
+                    Vector2 drawPosition = currentPosition + new Vector2(0f, itemHeight * 0.5f + item.SelectWiggler.Value * 8f);
+                    if (drawPosition.Y + itemHeight * 0.5f > 0 && drawPosition.Y - itemHeight * 0.5f < Engine.Height) {
+                        item.Render(drawPosition, Focused && Current == item);
+                    }
+                    currentPosition.Y += itemHeight + ItemSpacing;
+                }
+            }
+        }
     }
+
     public static partial class TextMenuExt {
 
         // Mods can't access patch_ classes directly.

--- a/Celeste.Mod.mm/Patches/TextMenu.cs
+++ b/Celeste.Mod.mm/Patches/TextMenu.cs
@@ -56,12 +56,14 @@ namespace Celeste {
 
         [MonoModReplace]
         public override void Render() {
+            // this is heavily based on the vanilla method, adding a check to skip rendering off-screen options.
             RecalculateSize();
             Vector2 currentPosition = Position - Justify * new Vector2(Width, Height);
             foreach (Item item in items) {
                 if (item.Visible) {
                     float itemHeight = item.Height();
                     Vector2 drawPosition = currentPosition + new Vector2(0f, itemHeight * 0.5f + item.SelectWiggler.Value * 8f);
+                    // skip rendering the option if it is off-screen.
                     if (drawPosition.Y + itemHeight * 0.5f > 0 && drawPosition.Y - itemHeight * 0.5f < Engine.Height) {
                         item.Render(drawPosition, Focused && Current == item);
                     }


### PR DESCRIPTION
My mod install is quite a stress test for Everest, and quite a few of them have mod options (... like, 15 of them). So, I got pretty bad frame drops in the Mod Options menu (~30 FPS).

This is pretty much a copy-paste of the vanilla method for option rendering, adding a check to skip rendering of off-screen options. This really helps and I now get 60 FPS in the Mod Options menu.

... except on some instances where I get 50 FPS instead? I'm investigating on that. I'll tell you when I'm done with this 🙂 