### PR TITLE
Text menus: Fix GetYOffsetOf taking invisible options into account

### DIFF
--- a/Celeste.Mod.mm/Patches/TextMenu.cs
+++ b/Celeste.Mod.mm/Patches/TextMenu.cs
@@ -55,6 +55,24 @@ namespace Celeste {
         }
 
         [MonoModReplace]
+        public new float GetYOffsetOf(Item targetItem) {
+            // this is a small fix of the vanilla method to better support invisible menu items.
+            if (targetItem == null)
+                return 0f;
+
+            float num = 0f;
+            foreach (Item listItem in items) {
+                if (listItem.Visible) // this is targetItem.Visible in vanilla.
+                    num += listItem.Height() + ItemSpacing;
+
+                if (listItem == targetItem)
+                    break;
+            }
+
+            return num - targetItem.Height() * 0.5f - ItemSpacing;
+        }
+
+        [MonoModReplace]
         public override void Render() {
             // this is heavily based on the vanilla method, adding a check to skip rendering off-screen options.
             RecalculateSize();


### PR DESCRIPTION
While working on Extended Variants, I found what looks like a _very slight_ vanilla bug implying text menus: even when options are invisible, they are taken into account when the game computes the Y offset of options below them. So, scrolling past hidden options moves the menu up to the same offset as if they were visible. This has _very minor_ impact on vanilla (I can only think of the options menu: when on fullscreen, the "window scale" option is hidden).

Extended Variants currently fixes this with a hook to avoid completely destroying the Mod Options menu, but I don't know if this kind of fix better fits into Everest directly.