### PR TITLE
Make Badeline bosses usable in rooms with wind

### DIFF
--- a/Celeste.Mod.mm/Patches/Player.cs
+++ b/Celeste.Mod.mm/Patches/Player.cs
@@ -113,6 +113,14 @@ namespace Celeste {
             }
         }
 
+        private extern void orig_WindMove(Vector2 move);
+        private void WindMove(Vector2 move) {
+            // Don't apply wind on player in the Attract state: this would constantly push the player away from its target.
+            // This causes an infinite loop when hitting Badeline bosses.
+            if (StateMachine.State != StAttract)
+                orig_WindMove(move);
+        }
+
         [MethodImpl(MethodImplOptions.NoInlining)]
         public Color GetCurrentTrailColor() => GetTrailColor(wasDashB);
         [MethodImpl(MethodImplOptions.NoInlining)]


### PR DESCRIPTION
Badeline Boss + wind = infinite loop, since Badeline wants to attract the player to her, and wind pushes them away from her. This patch makes wind have no effect on the player if they are in the Attract state.

From what I saw, the Attract state is only used by Badeline bosses, and bosses + wind is not happening anywhere in vanilla (~~it wouldn't work anyway~~), so this shouldn't have any side effect.

(This is currently patched in extended variants because it can make bosses and wind show up in the same room, but getting it into Everest would allow mappers to do that as well.)