### PR TITLE
Custom mountain

### DIFF
--- a/Celeste.Mod.mm/Celeste.Mod.mm.csproj
+++ b/Celeste.Mod.mm/Celeste.Mod.mm.csproj
@@ -153,6 +153,9 @@
     <Compile Include="Mod\UI\OuiDependencyDownloader.cs" />
     <Compile Include="Mod\UI\OuiHelper_ChapterSelect_Reload.cs" />
     <Compile Include="Mod\UI\OuiModUpdateList.cs" />
+    <Compile Include="Patches\MountainModel.cs" />
+    <Compile Include="Patches\MTN.cs" />
+    <Compile Include="Patches\ObjModel.cs" />
     <Compile Include="Patches\MapEditor.cs" />
     <Compile Include="Patches\CassetteBlock.cs" />
     <Compile Include="Patches\Checkpoint.cs" />

--- a/Celeste.Mod.mm/Mod/Meta/MapMeta.cs
+++ b/Celeste.Mod.mm/Mod/Meta/MapMeta.cs
@@ -430,6 +430,8 @@ namespace Celeste.Mod.Meta {
         }
     }
     public class MapMetaMountain {
+        public string MountainModelDirectory { get; set; } = null;
+        public string MountainTextureDirectory { get; set; } = null;
         public MapMetaMountainCamera Idle { get; set; } = null;
         public MapMetaMountainCamera Select { get; set; } = null;
         public MapMetaMountainCamera Zoom { get; set; } = null;
@@ -437,6 +439,7 @@ namespace Celeste.Mod.Meta {
         public int State { get; set; } = 0;
         public bool Rotate { get; set; } = false;
         public bool ShowCore { get; set; } = false;
+
     }
     public class MapMetaMountainCamera {
         public float[] Position { get; set; }

--- a/Celeste.Mod.mm/Patches/AreaData.cs
+++ b/Celeste.Mod.mm/Patches/AreaData.cs
@@ -381,6 +381,11 @@ namespace Celeste {
                         area.Mode[mode].MapData = new MapData(area.ToKey((AreaMode) mode));
                 }
             }
+
+            // Load custom mountains
+            // This needs to be done after areas are loaded because it depends on the MapMeta
+            MTNExt.LoadMod();
+            MTNExt.LoadModData();
         }
 
         private static int AreaComparison(AreaData a, AreaData b) {

--- a/Celeste.Mod.mm/Patches/MTN.cs
+++ b/Celeste.Mod.mm/Patches/MTN.cs
@@ -11,15 +11,12 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Celeste
-{
-    class patch_MTN
-    {
+namespace Celeste {
+    class patch_MTN {
         // We don't need an Unload() because the vanilla MTN disposes with the Atlas we use
 
         public static extern void orig_UnloadData();
-        public static void UnloadData()
-        {
+        public static void UnloadData() {
             if (MTN.DataLoaded) {
                 foreach (KeyValuePair<string, MountainResources> kvp in MTNExt.MountainMappings) {
                     kvp.Value.MountainTerrain?.Dispose();
@@ -35,8 +32,7 @@ namespace Celeste
 
     }
 
-    public class MountainResources
-    {
+    public class MountainResources {
         public ObjModel MountainTerrain;
 
         public ObjModel MountainBuildings;
@@ -54,8 +50,7 @@ namespace Celeste
         public MountainState[] MountainStates = new MountainState[4];
     }
 
-    public static class MTNExt
-    {
+    public static class MTNExt {
         /// <summary>
         /// Maps the key to the ModAsset of the map in Everest.Content to the MountainResources for it
         /// </summary>
@@ -67,8 +62,7 @@ namespace Celeste
         /// <summary>
         /// Load the custom mountain models for mods.
         /// </summary>
-        public static void LoadModData()
-        {
+        public static void LoadModData() {
             if (!ModsDataLoaded) {
                 Stopwatch stopwatch = Stopwatch.StartNew();
                 foreach (KeyValuePair<string, ModAsset> kvp in Everest.Content.Map) {
@@ -103,8 +97,7 @@ namespace Celeste
         /// <summary>
         /// Load the custom mountain textures for mods.
         /// </summary>
-        public static void LoadMod()
-        {
+        public static void LoadMod() {
             if (!ModsLoaded) {
                 Stopwatch stopwatch = Stopwatch.StartNew();
                 foreach (KeyValuePair<string, ModAsset> kvp in Everest.Content.Map) {

--- a/Celeste.Mod.mm/Patches/MTN.cs
+++ b/Celeste.Mod.mm/Patches/MTN.cs
@@ -1,0 +1,163 @@
+﻿#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
+
+using Celeste.Mod;
+using Celeste.Mod.Meta;
+using Monocle;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Celeste
+{
+    class patch_MTN
+    {
+        // We don't need an Unload() because the vanilla MTN disposes with the Atlas we use
+
+        public static extern void orig_UnloadData();
+        public static void UnloadData()
+        {
+            if (MTN.DataLoaded)
+            {
+                foreach (KeyValuePair<string, MountainResources> kvp in MTNExt.MountainMappings)
+                {
+                    kvp.Value.MountainTerrain?.Dispose();
+                    kvp.Value.MountainTerrain = null;
+                    kvp.Value.MountainBuildings?.Dispose();
+                    kvp.Value.MountainBuildings = null;
+                    kvp.Value.MountainCoreWall?.Dispose();
+                    kvp.Value.MountainCoreWall = null;
+                }
+            }
+            orig_UnloadData();
+        }
+
+    }
+
+    public class MountainResources
+    {
+        public ObjModel MountainTerrain;
+
+        public ObjModel MountainBuildings;
+
+        public ObjModel MountainCoreWall;
+
+        public VirtualTexture[] MountainTerrainTextures;
+
+        public VirtualTexture[] MountainBuildingTextures;
+
+        public VirtualTexture[] MountainSkyboxTextures;
+
+        public VirtualTexture MountainFogTexture;
+
+        public MountainState[] MountainStates = new MountainState[4];
+    }
+
+    public static class MTNExt
+    {
+        /// <summary>
+        /// Maps the key to the ModAsset of the map in Everest.Content to the MountainResources for it
+        /// </summary>
+        public static Dictionary<string, MountainResources> MountainMappings = new Dictionary<string, MountainResources>();
+
+        public static bool ModsLoaded { get; private set; }
+        public static bool ModsDataLoaded { get; private set; }
+
+        /// <summary>
+        /// Load the custom mountain models for mods.
+        /// </summary>
+        public static void LoadModData()
+        {
+            if (!ModsDataLoaded)
+            {
+                Stopwatch stopwatch = Stopwatch.StartNew();
+                foreach (KeyValuePair<string, ModAsset> kvp in Everest.Content.Map)
+                {
+                    MapMeta meta;
+                    if (kvp.Value != null && (meta = kvp.Value.GetMeta<MapMeta>()) != null && meta.Mountain != null && !string.IsNullOrEmpty(meta.Mountain.MountainModelDirectory))
+                    {
+                        if (!MountainMappings.TryGetValue(kvp.Key, out MountainResources resources))
+                        {
+                            resources = new MountainResources();
+                            MountainMappings.Add(kvp.Key, resources);
+                        }
+
+                        if (Everest.Content.TryGet(Path.Combine(meta.Mountain.MountainModelDirectory, "mountain"), out ModAsset mountain))
+                        {
+                            resources.MountainTerrain = ObjModelExt.CreateFromStream(mountain.Stream, Path.Combine(meta.Mountain.MountainModelDirectory, "mountain.obj"));
+                        }
+
+                        if (Everest.Content.TryGet(Path.Combine(meta.Mountain.MountainModelDirectory, "buildings"), out ModAsset buildings))
+                        {
+                            resources.MountainBuildings = ObjModelExt.CreateFromStream(buildings.Stream, Path.Combine(meta.Mountain.MountainModelDirectory, "buildings.obj"));
+                        }
+
+                        if (Everest.Content.TryGet(Path.Combine(meta.Mountain.MountainModelDirectory, "mountain_wall"), out ModAsset coreWall))
+                        {
+                            resources.MountainCoreWall = ObjModelExt.CreateFromStream(coreWall.Stream, Path.Combine(meta.Mountain.MountainModelDirectory, "mountain_wall.obj"));
+                        }
+
+                    }
+                }
+                Console.WriteLine(" - MODDED MTN DATA LOAD: " + stopwatch.ElapsedMilliseconds + "ms");
+            }
+
+            ModsDataLoaded = true;
+        }
+        /// <summary>
+        /// Load the custom mountain textures for mods.
+        /// </summary>
+        public static void LoadMod()
+        {
+            if (!ModsLoaded)
+            {
+                Stopwatch stopwatch = Stopwatch.StartNew();
+                foreach (KeyValuePair<string, ModAsset> kvp in Everest.Content.Map)
+                {
+                    MapMeta meta;
+                    if (kvp.Value != null && (meta = kvp.Value.GetMeta<MapMeta>()) != null && meta.Mountain != null && !string.IsNullOrEmpty(meta.Mountain.MountainTextureDirectory))
+                    {
+                        if (!MountainMappings.TryGetValue(kvp.Key, out MountainResources resources))
+                        {
+                            resources = new MountainResources();
+                            MountainMappings.Add(kvp.Key, resources);
+                        }
+
+                        resources.MountainTerrainTextures = new VirtualTexture[3];
+                        resources.MountainBuildingTextures = new VirtualTexture[3];
+                        resources.MountainSkyboxTextures = new VirtualTexture[3];
+                        for (int i = 0; i < 3; i++)
+                        {
+                            if (MTN.Mountain.Has(Path.Combine(meta.Mountain.MountainTextureDirectory, "skybox_" + i).Replace('\\', '/')))
+                            {
+                                resources.MountainSkyboxTextures[i] = MTN.Mountain[Path.Combine(meta.Mountain.MountainTextureDirectory, "skybox_" + i).Replace('\\', '/')].Texture;
+                            }
+                            if (MTN.Mountain.Has(Path.Combine(meta.Mountain.MountainTextureDirectory, "mountain_" + i).Replace('\\', '/')))
+                            {
+                                resources.MountainTerrainTextures[i] = MTN.Mountain[Path.Combine(meta.Mountain.MountainTextureDirectory, "mountain_" + i).Replace('\\', '/')].Texture;
+                            }
+                            if (MTN.Mountain.Has(Path.Combine(meta.Mountain.MountainTextureDirectory, "buildings_" + i).Replace('\\', '/')))
+                            {
+                                resources.MountainBuildingTextures[i] = MTN.Mountain[Path.Combine(meta.Mountain.MountainTextureDirectory, "buildings_" + i).Replace('\\', '/')].Texture;
+                            }
+                        }
+                        if (MTN.Mountain.Has(Path.Combine(meta.Mountain.MountainTextureDirectory, "fog").Replace('\\', '/')))
+                        {
+                            resources.MountainFogTexture = MTN.Mountain[Path.Combine(meta.Mountain.MountainTextureDirectory, "fog").Replace('\\', '/')].Texture;
+                        }
+
+                        resources.MountainStates[0] = new MountainState(resources.MountainTerrainTextures[0] ?? MTN.MountainTerrainTextures[0], resources.MountainBuildingTextures[0] ?? MTN.MountainBuildingTextures[0], resources.MountainSkyboxTextures[0] ?? MTN.MountainSkyboxTextures[0], Calc.HexToColor("010817"));
+                        resources.MountainStates[1] = new MountainState(resources.MountainTerrainTextures[1] ?? MTN.MountainTerrainTextures[1], resources.MountainBuildingTextures[1] ?? MTN.MountainBuildingTextures[1], resources.MountainSkyboxTextures[1] ?? MTN.MountainSkyboxTextures[1], Calc.HexToColor("13203E"));
+                        resources.MountainStates[2] = new MountainState(resources.MountainTerrainTextures[2] ?? MTN.MountainTerrainTextures[2], resources.MountainBuildingTextures[2] ?? MTN.MountainBuildingTextures[2], resources.MountainSkyboxTextures[2] ?? MTN.MountainSkyboxTextures[2], Calc.HexToColor("281A35"));
+                        resources.MountainStates[3] = new MountainState(resources.MountainTerrainTextures[0] ?? MTN.MountainTerrainTextures[0], resources.MountainBuildingTextures[0] ?? MTN.MountainBuildingTextures[0], resources.MountainSkyboxTextures[0] ?? MTN.MountainSkyboxTextures[0], Calc.HexToColor("010817"));
+                    }
+                }
+                Console.WriteLine(" - MODDED MTN LOAD: " + stopwatch.ElapsedMilliseconds + "ms");
+            }
+            ModsLoaded = true;
+        }
+    }
+}

--- a/Celeste.Mod.mm/Patches/MTN.cs
+++ b/Celeste.Mod.mm/Patches/MTN.cs
@@ -77,8 +77,10 @@ namespace Celeste
                 foreach (KeyValuePair<string, ModAsset> kvp in Everest.Content.Map)
                 {
                     MapMeta meta;
+                    // Check if the meta for this asset exists and if it has a MountainModelDirectory specified
                     if (kvp.Value != null && (meta = kvp.Value.GetMeta<MapMeta>()) != null && meta.Mountain != null && !string.IsNullOrEmpty(meta.Mountain.MountainModelDirectory))
                     {
+                        // Create the mountain resources for this map if they don't exist already
                         if (!MountainMappings.TryGetValue(kvp.Key, out MountainResources resources))
                         {
                             resources = new MountainResources();
@@ -118,8 +120,10 @@ namespace Celeste
                 foreach (KeyValuePair<string, ModAsset> kvp in Everest.Content.Map)
                 {
                     MapMeta meta;
+                    // Check if the meta for this asset exists and if it has a MountainTextureDirectory specified
                     if (kvp.Value != null && (meta = kvp.Value.GetMeta<MapMeta>()) != null && meta.Mountain != null && !string.IsNullOrEmpty(meta.Mountain.MountainTextureDirectory))
                     {
+                        // Create the mountain resources for this map if they don't exist already
                         if (!MountainMappings.TryGetValue(kvp.Key, out MountainResources resources))
                         {
                             resources = new MountainResources();
@@ -149,6 +153,7 @@ namespace Celeste
                             resources.MountainFogTexture = MTN.Mountain[Path.Combine(meta.Mountain.MountainTextureDirectory, "fog").Replace('\\', '/')].Texture;
                         }
 
+                        // Use the default textures if no custom ones were loaded
                         resources.MountainStates[0] = new MountainState(resources.MountainTerrainTextures[0] ?? MTN.MountainTerrainTextures[0], resources.MountainBuildingTextures[0] ?? MTN.MountainBuildingTextures[0], resources.MountainSkyboxTextures[0] ?? MTN.MountainSkyboxTextures[0], Calc.HexToColor("010817"));
                         resources.MountainStates[1] = new MountainState(resources.MountainTerrainTextures[1] ?? MTN.MountainTerrainTextures[1], resources.MountainBuildingTextures[1] ?? MTN.MountainBuildingTextures[1], resources.MountainSkyboxTextures[1] ?? MTN.MountainSkyboxTextures[1], Calc.HexToColor("13203E"));
                         resources.MountainStates[2] = new MountainState(resources.MountainTerrainTextures[2] ?? MTN.MountainTerrainTextures[2], resources.MountainBuildingTextures[2] ?? MTN.MountainBuildingTextures[2], resources.MountainSkyboxTextures[2] ?? MTN.MountainSkyboxTextures[2], Calc.HexToColor("281A35"));

--- a/Celeste.Mod.mm/Patches/MTN.cs
+++ b/Celeste.Mod.mm/Patches/MTN.cs
@@ -20,10 +20,8 @@ namespace Celeste
         public static extern void orig_UnloadData();
         public static void UnloadData()
         {
-            if (MTN.DataLoaded)
-            {
-                foreach (KeyValuePair<string, MountainResources> kvp in MTNExt.MountainMappings)
-                {
+            if (MTN.DataLoaded) {
+                foreach (KeyValuePair<string, MountainResources> kvp in MTNExt.MountainMappings) {
                     kvp.Value.MountainTerrain?.Dispose();
                     kvp.Value.MountainTerrain = null;
                     kvp.Value.MountainBuildings?.Dispose();
@@ -71,34 +69,27 @@ namespace Celeste
         /// </summary>
         public static void LoadModData()
         {
-            if (!ModsDataLoaded)
-            {
+            if (!ModsDataLoaded) {
                 Stopwatch stopwatch = Stopwatch.StartNew();
-                foreach (KeyValuePair<string, ModAsset> kvp in Everest.Content.Map)
-                {
+                foreach (KeyValuePair<string, ModAsset> kvp in Everest.Content.Map) {
                     MapMeta meta;
                     // Check if the meta for this asset exists and if it has a MountainModelDirectory specified
-                    if (kvp.Value != null && (meta = kvp.Value.GetMeta<MapMeta>()) != null && meta.Mountain != null && !string.IsNullOrEmpty(meta.Mountain.MountainModelDirectory))
-                    {
+                    if (kvp.Value != null && (meta = kvp.Value.GetMeta<MapMeta>()) != null && meta.Mountain != null && !string.IsNullOrEmpty(meta.Mountain.MountainModelDirectory)) {
                         // Create the mountain resources for this map if they don't exist already
-                        if (!MountainMappings.TryGetValue(kvp.Key, out MountainResources resources))
-                        {
+                        if (!MountainMappings.TryGetValue(kvp.Key, out MountainResources resources)) {
                             resources = new MountainResources();
                             MountainMappings.Add(kvp.Key, resources);
                         }
 
-                        if (Everest.Content.TryGet(Path.Combine(meta.Mountain.MountainModelDirectory, "mountain"), out ModAsset mountain))
-                        {
+                        if (Everest.Content.TryGet(Path.Combine(meta.Mountain.MountainModelDirectory, "mountain"), out ModAsset mountain)) {
                             resources.MountainTerrain = ObjModelExt.CreateFromStream(mountain.Stream, Path.Combine(meta.Mountain.MountainModelDirectory, "mountain.obj"));
                         }
 
-                        if (Everest.Content.TryGet(Path.Combine(meta.Mountain.MountainModelDirectory, "buildings"), out ModAsset buildings))
-                        {
+                        if (Everest.Content.TryGet(Path.Combine(meta.Mountain.MountainModelDirectory, "buildings"), out ModAsset buildings)) {
                             resources.MountainBuildings = ObjModelExt.CreateFromStream(buildings.Stream, Path.Combine(meta.Mountain.MountainModelDirectory, "buildings.obj"));
                         }
 
-                        if (Everest.Content.TryGet(Path.Combine(meta.Mountain.MountainModelDirectory, "mountain_wall"), out ModAsset coreWall))
-                        {
+                        if (Everest.Content.TryGet(Path.Combine(meta.Mountain.MountainModelDirectory, "mountain_wall"), out ModAsset coreWall)) {
                             resources.MountainCoreWall = ObjModelExt.CreateFromStream(coreWall.Stream, Path.Combine(meta.Mountain.MountainModelDirectory, "mountain_wall.obj"));
                         }
 
@@ -114,18 +105,14 @@ namespace Celeste
         /// </summary>
         public static void LoadMod()
         {
-            if (!ModsLoaded)
-            {
+            if (!ModsLoaded) {
                 Stopwatch stopwatch = Stopwatch.StartNew();
-                foreach (KeyValuePair<string, ModAsset> kvp in Everest.Content.Map)
-                {
+                foreach (KeyValuePair<string, ModAsset> kvp in Everest.Content.Map) {
                     MapMeta meta;
                     // Check if the meta for this asset exists and if it has a MountainTextureDirectory specified
-                    if (kvp.Value != null && (meta = kvp.Value.GetMeta<MapMeta>()) != null && meta.Mountain != null && !string.IsNullOrEmpty(meta.Mountain.MountainTextureDirectory))
-                    {
+                    if (kvp.Value != null && (meta = kvp.Value.GetMeta<MapMeta>()) != null && meta.Mountain != null && !string.IsNullOrEmpty(meta.Mountain.MountainTextureDirectory)) {
                         // Create the mountain resources for this map if they don't exist already
-                        if (!MountainMappings.TryGetValue(kvp.Key, out MountainResources resources))
-                        {
+                        if (!MountainMappings.TryGetValue(kvp.Key, out MountainResources resources)) {
                             resources = new MountainResources();
                             MountainMappings.Add(kvp.Key, resources);
                         }
@@ -133,23 +120,18 @@ namespace Celeste
                         resources.MountainTerrainTextures = new VirtualTexture[3];
                         resources.MountainBuildingTextures = new VirtualTexture[3];
                         resources.MountainSkyboxTextures = new VirtualTexture[3];
-                        for (int i = 0; i < 3; i++)
-                        {
-                            if (MTN.Mountain.Has(Path.Combine(meta.Mountain.MountainTextureDirectory, "skybox_" + i).Replace('\\', '/')))
-                            {
+                        for (int i = 0; i < 3; i++) {
+                            if (MTN.Mountain.Has(Path.Combine(meta.Mountain.MountainTextureDirectory, "skybox_" + i).Replace('\\', '/'))) {
                                 resources.MountainSkyboxTextures[i] = MTN.Mountain[Path.Combine(meta.Mountain.MountainTextureDirectory, "skybox_" + i).Replace('\\', '/')].Texture;
                             }
-                            if (MTN.Mountain.Has(Path.Combine(meta.Mountain.MountainTextureDirectory, "mountain_" + i).Replace('\\', '/')))
-                            {
+                            if (MTN.Mountain.Has(Path.Combine(meta.Mountain.MountainTextureDirectory, "mountain_" + i).Replace('\\', '/'))) {
                                 resources.MountainTerrainTextures[i] = MTN.Mountain[Path.Combine(meta.Mountain.MountainTextureDirectory, "mountain_" + i).Replace('\\', '/')].Texture;
                             }
-                            if (MTN.Mountain.Has(Path.Combine(meta.Mountain.MountainTextureDirectory, "buildings_" + i).Replace('\\', '/')))
-                            {
+                            if (MTN.Mountain.Has(Path.Combine(meta.Mountain.MountainTextureDirectory, "buildings_" + i).Replace('\\', '/'))) {
                                 resources.MountainBuildingTextures[i] = MTN.Mountain[Path.Combine(meta.Mountain.MountainTextureDirectory, "buildings_" + i).Replace('\\', '/')].Texture;
                             }
                         }
-                        if (MTN.Mountain.Has(Path.Combine(meta.Mountain.MountainTextureDirectory, "fog").Replace('\\', '/')))
-                        {
+                        if (MTN.Mountain.Has(Path.Combine(meta.Mountain.MountainTextureDirectory, "fog").Replace('\\', '/'))) {
                             resources.MountainFogTexture = MTN.Mountain[Path.Combine(meta.Mountain.MountainTextureDirectory, "fog").Replace('\\', '/')].Texture;
                         }
 

--- a/Celeste.Mod.mm/Patches/MountainModel.cs
+++ b/Celeste.Mod.mm/Patches/MountainModel.cs
@@ -1,0 +1,232 @@
+﻿#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
+#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
+
+using Monocle;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using System;
+using System.Collections.Generic;
+using MonoMod;
+using Celeste.Mod;
+using Celeste.Mod.Meta;
+using System.IO;
+
+namespace Celeste
+{
+    class patch_MountainModel : MountainModel
+    {
+        // A whole bunch of private fields need to be used in BeforeRender
+        private bool ignoreCameraRotation;
+        private Quaternion lastCameraRotation;
+        private VirtualRenderTarget buffer;
+        private int currState;
+        private int nextState;
+        private float easeState;
+        private VirtualRenderTarget blurA;
+        private VirtualRenderTarget blurB;
+        private MountainState[] mountainStates;
+        private Ring fog;
+        private Ring fog2;
+
+        protected Ring customFog;
+        protected Ring customFog2;
+        // Used to check when we transition from a different area
+        protected string PreviousSID;
+        // How opaque the bg is when transitioning between models
+        protected float fade = 0f;
+        protected float fadeHoldCountdown = 0;
+
+        public extern void orig_ctor();
+        [MonoModConstructor]
+        public void ctor()
+        {
+            orig_ctor();
+            customFog = fog;
+            customFog2 = fog2;
+        }
+
+        public extern void orig_Update();
+        public new void Update()
+        {
+            orig_Update();
+            string path = Path.Combine("Maps", SaveData.Instance?.LastArea.GetSID() ?? "").Replace('\\', '/');
+            if (SaveData.Instance != null && Everest.Content.TryGet(path, out ModAsset asset))
+            {
+                MapMeta meta;
+                if (asset != null && (meta = asset.GetMeta<MapMeta>()) != null && meta.Mountain != null && !(string.IsNullOrEmpty(meta.Mountain.MountainModelDirectory) && string.IsNullOrEmpty(meta.Mountain.MountainTextureDirectory)))
+                {
+                    MountainResources resources = MTNExt.MountainMappings[path];
+                    customFog.Rotate((0f - Engine.DeltaTime) * 0.01f);
+                    customFog.TopColor = (customFog.BotColor = Color.Lerp((resources.MountainStates?[currState] ?? mountainStates[currState]).FogColor, (resources.MountainStates?[nextState] ?? mountainStates[nextState]).FogColor, easeState));
+                    customFog2.Rotate((0f - Engine.DeltaTime) * 0.01f);
+                    customFog2.TopColor = (customFog2.BotColor = Color.White * 0.3f * NearFogAlpha);
+                }
+            }
+        }
+
+        [MonoModIgnore]
+        private void DrawBillboards(Matrix matrix, List<Component> billboards)
+        {
+        }
+
+        public extern void orig_BeforeRender(Scene scene);
+        public new void BeforeRender(Scene scene)
+        {
+            string path = Path.Combine("Maps", SaveData.Instance?.LastArea.GetSID() ?? "").Replace('\\', '/');
+            string SIDToUse = SaveData.Instance?.LastArea.GetSID() ?? "";
+            bool fadingIn = true;
+            // Check if we're changing mountain models or textures
+            // If so, we want to fade out and then back in
+            if (!(SaveData.Instance?.LastArea.GetSID() ?? "").Equals(PreviousSID))
+            {
+                string oldModelDir = "", oldTextureDir = "", newModelDir = "", newTextureDir = "";
+                if (SaveData.Instance != null && Everest.Content.TryGet(path, out ModAsset asset1))
+                {
+                    MapMeta meta;
+                    if (asset1 != null && (meta = asset1.GetMeta<MapMeta>()) != null && meta.Mountain != null)
+                    {
+                        newModelDir = meta.Mountain.MountainModelDirectory ?? "";
+                        newTextureDir = meta.Mountain.MountainTextureDirectory ?? "";
+                    }
+                }
+                string oldPath = Path.Combine("Maps", PreviousSID ?? "").Replace('\\', '/');
+                if (SaveData.Instance != null && Everest.Content.TryGet(oldPath, out asset1))
+                {
+                    MapMeta meta;
+                    if (asset1 != null && (meta = asset1.GetMeta<MapMeta>()) != null && meta.Mountain != null)
+                    {
+                        oldModelDir = meta.Mountain.MountainModelDirectory ?? "";
+                        oldTextureDir = meta.Mountain.MountainTextureDirectory ?? "";
+                    }
+                }
+                
+                if ((!oldModelDir.Equals(newModelDir) || !oldTextureDir.Equals(newTextureDir)) /*&& !string.IsNullOrEmpty(PreviousSID)*/)
+                {
+                    if (fade != 1f)
+                    {
+                        SIDToUse = PreviousSID;
+                        path = oldPath;
+                        fade = Calc.Approach(fade, 1f, Engine.DeltaTime * 4f);
+                        fadingIn = false;
+                    }
+                    else
+                    {
+                        fadeHoldCountdown = .3f;
+                    }
+                }
+            }
+
+            if (fadingIn && fade != 0f)
+            {
+                if (fadeHoldCountdown <= 0)
+                {
+                    fade = Calc.Approach(fade, 0f, Engine.DeltaTime * 4f);
+                }
+                else
+                {
+                    fadeHoldCountdown -= Engine.DeltaTime;
+                }
+            }
+            
+            if (SaveData.Instance != null && Everest.Content.TryGet(path, out ModAsset asset))
+            {
+                MapMeta meta;
+                if (asset != null && (meta = asset.GetMeta<MapMeta>()) != null && meta.Mountain != null && !(string.IsNullOrEmpty(meta.Mountain.MountainModelDirectory) && string.IsNullOrEmpty(meta.Mountain.MountainTextureDirectory)))
+                {
+                    MountainResources resources = MTNExt.MountainMappings[path];
+                    
+                    ResetRenderTargets();
+                    Quaternion rotation = Camera.Rotation;
+                    if (ignoreCameraRotation)
+                    {
+                        rotation = lastCameraRotation;
+                    }
+                    Matrix matrix = Matrix.CreatePerspectiveFieldOfView((float)Math.PI / 4f, (float)Engine.Width / (float)Engine.Height, 0.25f, 50f);
+                    Matrix matrix2 = Matrix.CreateTranslation(-Camera.Position) * Matrix.CreateFromQuaternion(rotation);
+                    Matrix matrix3 = matrix2 * matrix;
+                    Forward = Vector3.Transform(Vector3.Forward, Camera.Rotation.Conjugated());
+                    Engine.Graphics.GraphicsDevice.SetRenderTarget(buffer);
+
+                    Matrix matrix4 = Matrix.CreateTranslation(0f, 5f - Camera.Position.Y * 1.1f, 0f) * Matrix.CreateFromQuaternion(rotation) * matrix;
+                    
+                    if (currState == nextState)
+                    {
+                        (resources.MountainStates?[currState] ?? mountainStates[currState]).Skybox.Draw(matrix4, Color.White);
+                    }
+                    else
+                    {
+                        (resources.MountainStates?[currState] ?? mountainStates[currState]).Skybox.Draw(matrix4, Color.White);
+                        (resources.MountainStates?[currState] ?? mountainStates[currState]).Skybox.Draw(matrix4, Color.White * easeState);
+                    }
+                    if (currState != nextState)
+                    {
+                        GFX.FxMountain.Parameters["ease"].SetValue(easeState);
+                        GFX.FxMountain.CurrentTechnique = GFX.FxMountain.Techniques["Easing"];
+                    }
+                    else
+                    {
+                        GFX.FxMountain.CurrentTechnique = GFX.FxMountain.Techniques["Single"];
+                    }
+                    Engine.Graphics.GraphicsDevice.DepthStencilState = DepthStencilState.Default;
+                    Engine.Graphics.GraphicsDevice.BlendState = BlendState.AlphaBlend;
+                    Engine.Graphics.GraphicsDevice.RasterizerState = MountainRasterizer;
+                    GFX.FxMountain.Parameters["WorldViewProj"].SetValue(matrix3);
+                    GFX.FxMountain.Parameters["fog"].SetValue(customFog.TopColor.ToVector3());
+                    Engine.Graphics.GraphicsDevice.Textures[0] = (resources.MountainStates?[currState] ?? mountainStates[currState]).TerrainTexture.Texture;
+                    Engine.Graphics.GraphicsDevice.SamplerStates[0] = SamplerState.LinearClamp;
+                    if (currState != nextState)
+                    {
+                        Engine.Graphics.GraphicsDevice.Textures[1] = (resources.MountainStates?[nextState] ?? mountainStates[nextState]).TerrainTexture.Texture;
+                        Engine.Graphics.GraphicsDevice.SamplerStates[1] = SamplerState.LinearClamp;
+                    }
+                    (resources.MountainTerrain ?? MTN.MountainTerrain).Draw(GFX.FxMountain);
+                    GFX.FxMountain.Parameters["WorldViewProj"].SetValue(Matrix.CreateTranslation(CoreWallPosition) * matrix3);
+                    (resources.MountainCoreWall ?? MTN.MountainCoreWall).Draw(GFX.FxMountain);
+                    GFX.FxMountain.Parameters["WorldViewProj"].SetValue(matrix3);
+                    Engine.Graphics.GraphicsDevice.Textures[0] = (resources.MountainStates?[currState] ?? mountainStates[currState]).BuildingsTexture.Texture;
+                    Engine.Graphics.GraphicsDevice.SamplerStates[0] = SamplerState.LinearClamp;
+                    if (currState != nextState)
+                    {
+                        Engine.Graphics.GraphicsDevice.Textures[1] = (resources.MountainStates?[nextState] ?? mountainStates[nextState]).BuildingsTexture.Texture;
+                        Engine.Graphics.GraphicsDevice.SamplerStates[1] = SamplerState.LinearClamp;
+                    }
+                    (resources.MountainBuildings ?? MTN.MountainBuildings).Draw(GFX.FxMountain);
+                    customFog.Draw(matrix3);
+
+                    DrawBillboards(matrix3, scene.Tracker.GetComponents<Billboard>());
+                    customFog2.Draw(matrix3, CullCRasterizer);
+
+                    if (DrawDebugPoints && DebugPoints.Count > 0)
+                    {
+                        GFX.FxDebug.World = Matrix.Identity;
+                        GFX.FxDebug.View = matrix2;
+                        GFX.FxDebug.Projection = matrix;
+                        GFX.FxDebug.TextureEnabled = false;
+                        GFX.FxDebug.VertexColorEnabled = true;
+                        VertexPositionColor[] array = DebugPoints.ToArray();
+                        foreach (EffectPass pass in GFX.FxDebug.CurrentTechnique.Passes)
+                        {
+                            pass.Apply();
+                            Engine.Graphics.GraphicsDevice.DrawUserPrimitives(PrimitiveType.TriangleList, array, 0, array.Length / 3);
+                        }
+                    }
+                    GaussianBlur.Blur((RenderTarget2D)buffer, blurA, blurB, 0.75f, clear: true, samples: GaussianBlur.Samples.Five);
+                    Draw.Rect(-10f, -10f, 1940f, 1100f, Color.Black * fade);
+
+                    if (!(SIDToUse).Equals(PreviousSID) && resources.MountainFogTexture != null)
+                    {
+                        customFog = new Ring(6f, -1f, 20f, 0f, 24, Color.White, resources.MountainFogTexture ?? MTN.MountainFogTexture);
+                        customFog2 = new Ring(6f, -4f, 10f, 0f, 24, Color.White, resources.MountainFogTexture ?? MTN.MountainFogTexture);
+                    }
+                    PreviousSID = SIDToUse;
+                    return;
+                }
+            }
+
+            orig_BeforeRender(scene);
+            Draw.Rect(-10f, -10f, 1940f, 1100f, Color.Black * fade);
+            PreviousSID = SIDToUse;
+        }
+
+    }
+}

--- a/Celeste.Mod.mm/Patches/MountainModel.cs
+++ b/Celeste.Mod.mm/Patches/MountainModel.cs
@@ -50,11 +50,9 @@ namespace Celeste
         {
             orig_Update();
             string path = Path.Combine("Maps", SaveData.Instance?.LastArea.GetSID() ?? "").Replace('\\', '/');
-            if (SaveData.Instance != null && Everest.Content.TryGet(path, out ModAsset asset))
-            {
+            if (SaveData.Instance != null && Everest.Content.TryGet(path, out ModAsset asset)) {
                 MapMeta meta;
-                if (asset != null && (meta = asset.GetMeta<MapMeta>()) != null && meta.Mountain != null && !(string.IsNullOrEmpty(meta.Mountain.MountainModelDirectory) && string.IsNullOrEmpty(meta.Mountain.MountainTextureDirectory)))
-                {
+                if (asset != null && (meta = asset.GetMeta<MapMeta>()) != null && meta.Mountain != null && !(string.IsNullOrEmpty(meta.Mountain.MountainModelDirectory) && string.IsNullOrEmpty(meta.Mountain.MountainTextureDirectory))) {
                     MountainResources resources = MTNExt.MountainMappings[path];
                     customFog.Rotate((0f - Engine.DeltaTime) * 0.01f);
                     customFog.TopColor = (customFog.BotColor = Color.Lerp((resources.MountainStates?[currState] ?? mountainStates[currState]).FogColor, (resources.MountainStates?[nextState] ?? mountainStates[nextState]).FogColor, easeState));
@@ -65,9 +63,7 @@ namespace Celeste
         }
 
         [MonoModIgnore]
-        private void DrawBillboards(Matrix matrix, List<Component> billboards)
-        {
-        }
+        private extern void DrawBillboards(Matrix matrix, List<Component> billboards);
 
         public extern void orig_BeforeRender(Scene scene);
         public new void BeforeRender(Scene scene)
@@ -77,69 +73,53 @@ namespace Celeste
             bool fadingIn = true;
             // Check if we're changing mountain models or textures
             // If so, we want to fade out and then back in
-            if (!(SaveData.Instance?.LastArea.GetSID() ?? "").Equals(PreviousSID))
-            {
+            if (!(SaveData.Instance?.LastArea.GetSID() ?? "").Equals(PreviousSID)) {
                 string oldModelDir = "", oldTextureDir = "", newModelDir = "", newTextureDir = "";
-                if (SaveData.Instance != null && Everest.Content.TryGet(path, out ModAsset asset1))
-                {
+                if (SaveData.Instance != null && Everest.Content.TryGet(path, out ModAsset asset1)) {
                     MapMeta meta;
-                    if (asset1 != null && (meta = asset1.GetMeta<MapMeta>()) != null && meta.Mountain != null)
-                    {
+                    if (asset1 != null && (meta = asset1.GetMeta<MapMeta>()) != null && meta.Mountain != null) {
                         newModelDir = meta.Mountain.MountainModelDirectory ?? "";
                         newTextureDir = meta.Mountain.MountainTextureDirectory ?? "";
                     }
                 }
                 string oldPath = Path.Combine("Maps", PreviousSID ?? "").Replace('\\', '/');
-                if (SaveData.Instance != null && Everest.Content.TryGet(oldPath, out asset1))
-                {
+                if (SaveData.Instance != null && Everest.Content.TryGet(oldPath, out asset1)) {
                     MapMeta meta;
-                    if (asset1 != null && (meta = asset1.GetMeta<MapMeta>()) != null && meta.Mountain != null)
-                    {
+                    if (asset1 != null && (meta = asset1.GetMeta<MapMeta>()) != null && meta.Mountain != null) {
                         oldModelDir = meta.Mountain.MountainModelDirectory ?? "";
                         oldTextureDir = meta.Mountain.MountainTextureDirectory ?? "";
                     }
                 }
-                
-                if (!oldModelDir.Equals(newModelDir) || !oldTextureDir.Equals(newTextureDir))
-                {
-                    if (fade != 1f)
-                    {
+
+                if (!oldModelDir.Equals(newModelDir) || !oldTextureDir.Equals(newTextureDir)) {
+                    if (fade != 1f) {
                         SIDToUse = PreviousSID;
                         path = oldPath;
                         fade = Calc.Approach(fade, 1f, Engine.DeltaTime * 4f);
                         fadingIn = false;
-                    }
-                    else
-                    {
+                    } else {
                         // How long we want it to stay opaque before fading back in
                         fadeHoldCountdown = .3f;
                     }
                 }
             }
 
-            if (fadingIn && fade != 0f)
-            {
-                if (fadeHoldCountdown <= 0)
-                {
+            if (fadingIn && fade != 0f) {
+                if (fadeHoldCountdown <= 0) {
                     fade = Calc.Approach(fade, 0f, Engine.DeltaTime * 4f);
-                }
-                else
-                {
+                } else {
                     fadeHoldCountdown -= Engine.DeltaTime;
                 }
             }
-            
-            if (SaveData.Instance != null && Everest.Content.TryGet(path, out ModAsset asset))
-            {
+
+            if (SaveData.Instance != null && Everest.Content.TryGet(path, out ModAsset asset)) {
                 MapMeta meta;
-                if (asset != null && (meta = asset.GetMeta<MapMeta>()) != null && meta.Mountain != null && !(string.IsNullOrEmpty(meta.Mountain.MountainModelDirectory) && string.IsNullOrEmpty(meta.Mountain.MountainTextureDirectory)))
-                {
+                if (asset != null && (meta = asset.GetMeta<MapMeta>()) != null && meta.Mountain != null && !(string.IsNullOrEmpty(meta.Mountain.MountainModelDirectory) && string.IsNullOrEmpty(meta.Mountain.MountainTextureDirectory))) {
                     MountainResources resources = MTNExt.MountainMappings[path];
-                    
+
                     ResetRenderTargets();
                     Quaternion rotation = Camera.Rotation;
-                    if (ignoreCameraRotation)
-                    {
+                    if (ignoreCameraRotation) {
                         rotation = lastCameraRotation;
                     }
                     Matrix matrix = Matrix.CreatePerspectiveFieldOfView((float)Math.PI / 4f, (float)Engine.Width / (float)Engine.Height, 0.25f, 50f);
@@ -149,23 +129,17 @@ namespace Celeste
                     Engine.Graphics.GraphicsDevice.SetRenderTarget(buffer);
 
                     Matrix matrix4 = Matrix.CreateTranslation(0f, 5f - Camera.Position.Y * 1.1f, 0f) * Matrix.CreateFromQuaternion(rotation) * matrix;
-                    
-                    if (currState == nextState)
-                    {
+
+                    if (currState == nextState) {
                         (resources.MountainStates?[currState] ?? mountainStates[currState]).Skybox.Draw(matrix4, Color.White);
-                    }
-                    else
-                    {
+                    } else {
                         (resources.MountainStates?[currState] ?? mountainStates[currState]).Skybox.Draw(matrix4, Color.White);
                         (resources.MountainStates?[currState] ?? mountainStates[currState]).Skybox.Draw(matrix4, Color.White * easeState);
                     }
-                    if (currState != nextState)
-                    {
+                    if (currState != nextState) {
                         GFX.FxMountain.Parameters["ease"].SetValue(easeState);
                         GFX.FxMountain.CurrentTechnique = GFX.FxMountain.Techniques["Easing"];
-                    }
-                    else
-                    {
+                    } else {
                         GFX.FxMountain.CurrentTechnique = GFX.FxMountain.Techniques["Single"];
                     }
                     Engine.Graphics.GraphicsDevice.DepthStencilState = DepthStencilState.Default;
@@ -175,8 +149,7 @@ namespace Celeste
                     GFX.FxMountain.Parameters["fog"].SetValue(customFog.TopColor.ToVector3());
                     Engine.Graphics.GraphicsDevice.Textures[0] = (resources.MountainStates?[currState] ?? mountainStates[currState]).TerrainTexture.Texture;
                     Engine.Graphics.GraphicsDevice.SamplerStates[0] = SamplerState.LinearClamp;
-                    if (currState != nextState)
-                    {
+                    if (currState != nextState) {
                         Engine.Graphics.GraphicsDevice.Textures[1] = (resources.MountainStates?[nextState] ?? mountainStates[nextState]).TerrainTexture.Texture;
                         Engine.Graphics.GraphicsDevice.SamplerStates[1] = SamplerState.LinearClamp;
                     }
@@ -186,8 +159,7 @@ namespace Celeste
                     GFX.FxMountain.Parameters["WorldViewProj"].SetValue(matrix3);
                     Engine.Graphics.GraphicsDevice.Textures[0] = (resources.MountainStates?[currState] ?? mountainStates[currState]).BuildingsTexture.Texture;
                     Engine.Graphics.GraphicsDevice.SamplerStates[0] = SamplerState.LinearClamp;
-                    if (currState != nextState)
-                    {
+                    if (currState != nextState) {
                         Engine.Graphics.GraphicsDevice.Textures[1] = (resources.MountainStates?[nextState] ?? mountainStates[nextState]).BuildingsTexture.Texture;
                         Engine.Graphics.GraphicsDevice.SamplerStates[1] = SamplerState.LinearClamp;
                     }
@@ -197,16 +169,14 @@ namespace Celeste
                     DrawBillboards(matrix3, scene.Tracker.GetComponents<Billboard>());
                     customFog2.Draw(matrix3, CullCRasterizer);
 
-                    if (DrawDebugPoints && DebugPoints.Count > 0)
-                    {
+                    if (DrawDebugPoints && DebugPoints.Count > 0) {
                         GFX.FxDebug.World = Matrix.Identity;
                         GFX.FxDebug.View = matrix2;
                         GFX.FxDebug.Projection = matrix;
                         GFX.FxDebug.TextureEnabled = false;
                         GFX.FxDebug.VertexColorEnabled = true;
                         VertexPositionColor[] array = DebugPoints.ToArray();
-                        foreach (EffectPass pass in GFX.FxDebug.CurrentTechnique.Passes)
-                        {
+                        foreach (EffectPass pass in GFX.FxDebug.CurrentTechnique.Passes) {
                             pass.Apply();
                             Engine.Graphics.GraphicsDevice.DrawUserPrimitives(PrimitiveType.TriangleList, array, 0, array.Length / 3);
                         }
@@ -215,8 +185,7 @@ namespace Celeste
                     Draw.Rect(-10f, -10f, 1940f, 1100f, Color.Black * fade);
 
                     // Initialize new custom fog when we switch between maps
-                    if (!(SIDToUse).Equals(PreviousSID) && resources.MountainFogTexture != null)
-                    {
+                    if (!(SIDToUse).Equals(PreviousSID) && resources.MountainFogTexture != null) {
                         customFog = new Ring(6f, -1f, 20f, 0f, 24, Color.White, resources.MountainFogTexture ?? MTN.MountainFogTexture);
                         customFog2 = new Ring(6f, -4f, 10f, 0f, 24, Color.White, resources.MountainFogTexture ?? MTN.MountainFogTexture);
                     }

--- a/Celeste.Mod.mm/Patches/MountainModel.cs
+++ b/Celeste.Mod.mm/Patches/MountainModel.cs
@@ -100,7 +100,7 @@ namespace Celeste
                     }
                 }
                 
-                if ((!oldModelDir.Equals(newModelDir) || !oldTextureDir.Equals(newTextureDir)) /*&& !string.IsNullOrEmpty(PreviousSID)*/)
+                if (!oldModelDir.Equals(newModelDir) || !oldTextureDir.Equals(newTextureDir))
                 {
                     if (fade != 1f)
                     {
@@ -111,6 +111,7 @@ namespace Celeste
                     }
                     else
                     {
+                        // How long we want it to stay opaque before fading back in
                         fadeHoldCountdown = .3f;
                     }
                 }
@@ -213,6 +214,7 @@ namespace Celeste
                     GaussianBlur.Blur((RenderTarget2D)buffer, blurA, blurB, 0.75f, clear: true, samples: GaussianBlur.Samples.Five);
                     Draw.Rect(-10f, -10f, 1940f, 1100f, Color.Black * fade);
 
+                    // Initialize new custom fog when we switch between maps
                     if (!(SIDToUse).Equals(PreviousSID) && resources.MountainFogTexture != null)
                     {
                         customFog = new Ring(6f, -1f, 20f, 0f, 24, Color.White, resources.MountainFogTexture ?? MTN.MountainFogTexture);

--- a/Celeste.Mod.mm/Patches/MountainModel.cs
+++ b/Celeste.Mod.mm/Patches/MountainModel.cs
@@ -11,10 +11,8 @@ using Celeste.Mod;
 using Celeste.Mod.Meta;
 using System.IO;
 
-namespace Celeste
-{
-    class patch_MountainModel : MountainModel
-    {
+namespace Celeste {
+    class patch_MountainModel : MountainModel {
         // A whole bunch of private fields need to be used in BeforeRender
         private bool ignoreCameraRotation;
         private Quaternion lastCameraRotation;
@@ -38,16 +36,14 @@ namespace Celeste
 
         public extern void orig_ctor();
         [MonoModConstructor]
-        public void ctor()
-        {
+        public void ctor() {
             orig_ctor();
             customFog = fog;
             customFog2 = fog2;
         }
 
         public extern void orig_Update();
-        public new void Update()
-        {
+        public new void Update() {
             orig_Update();
             string path = Path.Combine("Maps", SaveData.Instance?.LastArea.GetSID() ?? "").Replace('\\', '/');
             if (SaveData.Instance != null && Everest.Content.TryGet(path, out ModAsset asset)) {
@@ -66,8 +62,7 @@ namespace Celeste
         private extern void DrawBillboards(Matrix matrix, List<Component> billboards);
 
         public extern void orig_BeforeRender(Scene scene);
-        public new void BeforeRender(Scene scene)
-        {
+        public new void BeforeRender(Scene scene) {
             string path = Path.Combine("Maps", SaveData.Instance?.LastArea.GetSID() ?? "").Replace('\\', '/');
             string SIDToUse = SaveData.Instance?.LastArea.GetSID() ?? "";
             bool fadingIn = true;

--- a/Celeste.Mod.mm/Patches/ObjModel.cs
+++ b/Celeste.Mod.mm/Patches/ObjModel.cs
@@ -9,12 +9,9 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 
-namespace Celeste
-{
-    class patch_ObjModel : ObjModel
-    {
-        public static ObjModel CreateFromStream(Stream stream, string fname)
-        {
+namespace Celeste {
+    class patch_ObjModel : ObjModel {
+        public static ObjModel CreateFromStream(Stream stream, string fname) {
             ObjModel objModel = new ObjModel();
             List<VertexPositionTexture> list = new List<VertexPositionTexture>();
             List<Vector3> list2 = new List<Vector3>();
@@ -110,8 +107,7 @@ namespace Celeste
         private static extern float Float(string data);
     }
 
-    public static class ObjModelExt
-    {
+    public static class ObjModelExt {
 
         // Mods can't access patch_ classes directly.
         // We thus expose any new members through extensions.
@@ -120,8 +116,7 @@ namespace Celeste
         /// Create a new ObjModel from a stream
         /// The filename is mainly just to check if it's a .export
         /// </summary>
-        public static ObjModel CreateFromStream(Stream stream, string fname)
-        {
+        public static ObjModel CreateFromStream(Stream stream, string fname) {
             return patch_ObjModel.CreateFromStream(stream, fname);
         }
 

--- a/Celeste.Mod.mm/Patches/ObjModel.cs
+++ b/Celeste.Mod.mm/Patches/ObjModel.cs
@@ -1,0 +1,160 @@
+﻿#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
+
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Monocle;
+using MonoMod;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+
+namespace Celeste
+{
+    class patch_ObjModel : ObjModel
+    {
+        public static ObjModel CreateFromStream(Stream stream, string fname)
+        {
+            ObjModel objModel = new ObjModel();
+            List<VertexPositionTexture> list = new List<VertexPositionTexture>();
+            List<Vector3> list2 = new List<Vector3>();
+            List<Vector2> list3 = new List<Vector2>();
+            Mesh mesh = null;
+            if (fname.EndsWith(".export"))
+            {
+                using (BinaryReader binaryReader = new BinaryReader(stream))
+                {
+                    int num = binaryReader.ReadInt32();
+                    for (int i = 0; i < num; i++)
+                    {
+                        if (mesh != null)
+                        {
+                            mesh.VertexCount = list.Count - mesh.VertexStart;
+                        }
+                        mesh = new Mesh();
+                        mesh.Name = binaryReader.ReadString();
+                        mesh.VertexStart = list.Count;
+                        objModel.Meshes.Add(mesh);
+                        int num2 = binaryReader.ReadInt32();
+                        for (int j = 0; j < num2; j++)
+                        {
+                            float x = binaryReader.ReadSingle();
+                            float y = binaryReader.ReadSingle();
+                            float z = binaryReader.ReadSingle();
+                            list2.Add(new Vector3(x, y, z));
+                        }
+                        int num3 = binaryReader.ReadInt32();
+                        for (int k = 0; k < num3; k++)
+                        {
+                            float x2 = binaryReader.ReadSingle();
+                            float y2 = binaryReader.ReadSingle();
+                            list3.Add(new Vector2(x2, y2));
+                        }
+                        int num4 = binaryReader.ReadInt32();
+                        for (int l = 0; l < num4; l++)
+                        {
+                            int index = binaryReader.ReadInt32() - 1;
+                            int index2 = binaryReader.ReadInt32() - 1;
+                            list.Add(new VertexPositionTexture
+                            {
+                                Position = list2[index],
+                                TextureCoordinate = list3[index2]
+                            });
+                        }
+                    }
+                }
+            }
+            else
+            {
+                using (StreamReader streamReader = new StreamReader(stream))
+                {
+                    string text;
+                    while ((text = streamReader.ReadLine()) != null)
+                    {
+                        string[] array = text.Split(' ');
+                        if (array.Length != 0)
+                        {
+                            string a = array[0];
+                            if (a == "o")
+                            {
+                                if (mesh != null)
+                                {
+                                    mesh.VertexCount = list.Count - mesh.VertexStart;
+                                }
+                                mesh = new Mesh();
+                                mesh.Name = array[1];
+                                mesh.VertexStart = list.Count;
+                                objModel.Meshes.Add(mesh);
+                            }
+                            else if (a == "v")
+                            {
+                                Vector3 item = new Vector3(Float(array[1]), Float(array[2]), Float(array[3]));
+                                list2.Add(item);
+                            }
+                            else if (a == "vt")
+                            {
+                                Vector2 item2 = new Vector2(Float(array[1]), Float(array[2]));
+                                list3.Add(item2);
+                            }
+                            else if (a == "f")
+                            {
+                                for (int m = 1; m < Math.Min(4, array.Length); m++)
+                                {
+                                    VertexPositionTexture item3 = default(VertexPositionTexture);
+                                    string[] array2 = array[m].Split('/');
+                                    if (array2[0].Length > 0)
+                                    {
+                                        item3.Position = list2[int.Parse(array2[0]) - 1];
+                                    }
+                                    if (array2[1].Length > 0)
+                                    {
+                                        item3.TextureCoordinate = list3[int.Parse(array2[1]) - 1];
+                                    }
+                                    list.Add(item3);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            if (mesh != null)
+            {
+                mesh.VertexCount = list.Count - mesh.VertexStart;
+            }
+            ((patch_ObjModel)objModel).verts = list.ToArray();
+            ((patch_ObjModel)objModel).ResetVertexBuffer();
+            return objModel;
+        }
+
+        private VertexPositionTexture[] verts;
+
+        [MonoModIgnore]
+        private bool ResetVertexBuffer()
+        {
+            return true;
+        }
+
+        [MonoModIgnore]
+        private static float Float(string data)
+        {
+            return float.Parse(data, CultureInfo.InvariantCulture);
+        }
+    }
+
+    public static class ObjModelExt
+    {
+
+        // Mods can't access patch_ classes directly.
+        // We thus expose any new members through extensions.
+        
+        /// <summary>
+        /// Create a new ObjModel from a stream
+        /// The filename is mainly just to check if it's a .export
+        /// </summary>
+        public static ObjModel CreateFromStream(Stream stream, string fname)
+        {
+            return patch_ObjModel.CreateFromStream(stream, fname);
+        }
+
+    }
+}

--- a/Celeste.Mod.mm/Patches/ObjModel.cs
+++ b/Celeste.Mod.mm/Patches/ObjModel.cs
@@ -20,15 +20,11 @@ namespace Celeste
             List<Vector3> list2 = new List<Vector3>();
             List<Vector2> list3 = new List<Vector2>();
             Mesh mesh = null;
-            if (fname.EndsWith(".export"))
-            {
-                using (BinaryReader binaryReader = new BinaryReader(stream))
-                {
+            if (fname.EndsWith(".export")) {
+                using (BinaryReader binaryReader = new BinaryReader(stream)) {
                     int num = binaryReader.ReadInt32();
-                    for (int i = 0; i < num; i++)
-                    {
-                        if (mesh != null)
-                        {
+                    for (int i = 0; i < num; i++) {
+                        if (mesh != null) {
                             mesh.VertexCount = list.Count - mesh.VertexStart;
                         }
                         mesh = new Mesh();
@@ -36,78 +32,58 @@ namespace Celeste
                         mesh.VertexStart = list.Count;
                         objModel.Meshes.Add(mesh);
                         int num2 = binaryReader.ReadInt32();
-                        for (int j = 0; j < num2; j++)
-                        {
+                        for (int j = 0; j < num2; j++) {
                             float x = binaryReader.ReadSingle();
                             float y = binaryReader.ReadSingle();
                             float z = binaryReader.ReadSingle();
                             list2.Add(new Vector3(x, y, z));
                         }
                         int num3 = binaryReader.ReadInt32();
-                        for (int k = 0; k < num3; k++)
-                        {
+                        for (int k = 0; k < num3; k++) {
                             float x2 = binaryReader.ReadSingle();
                             float y2 = binaryReader.ReadSingle();
                             list3.Add(new Vector2(x2, y2));
                         }
                         int num4 = binaryReader.ReadInt32();
-                        for (int l = 0; l < num4; l++)
-                        {
+                        for (int l = 0; l < num4; l++) {
                             int index = binaryReader.ReadInt32() - 1;
                             int index2 = binaryReader.ReadInt32() - 1;
-                            list.Add(new VertexPositionTexture
-                            {
+                            list.Add(new VertexPositionTexture {
                                 Position = list2[index],
                                 TextureCoordinate = list3[index2]
                             });
                         }
                     }
                 }
-            }
-            else
-            {
-                using (StreamReader streamReader = new StreamReader(stream))
-                {
+            } else {
+                using (StreamReader streamReader = new StreamReader(stream)) {
                     string text;
-                    while ((text = streamReader.ReadLine()) != null)
-                    {
+                    while ((text = streamReader.ReadLine()) != null) {
                         string[] array = text.Split(' ');
-                        if (array.Length != 0)
-                        {
+                        if (array.Length != 0) {
                             string a = array[0];
-                            if (a == "o")
-                            {
-                                if (mesh != null)
-                                {
+                            if (a == "o") {
+                                if (mesh != null) {
                                     mesh.VertexCount = list.Count - mesh.VertexStart;
                                 }
                                 mesh = new Mesh();
                                 mesh.Name = array[1];
                                 mesh.VertexStart = list.Count;
                                 objModel.Meshes.Add(mesh);
-                            }
-                            else if (a == "v")
-                            {
+                            } else if (a == "v") {
                                 Vector3 item = new Vector3(Float(array[1]), Float(array[2]), Float(array[3]));
                                 list2.Add(item);
-                            }
-                            else if (a == "vt")
-                            {
+                            } else if (a == "vt") {
                                 Vector2 item2 = new Vector2(Float(array[1]), Float(array[2]));
                                 list3.Add(item2);
-                            }
-                            else if (a == "f")
-                            {
-                                for (int m = 1; m < Math.Min(4, array.Length); m++)
-                                {
+                            } else if (a == "f") {
+                                for (int m = 1; m < Math.Min(4, array.Length); m++) {
                                     VertexPositionTexture item3 = default(VertexPositionTexture);
                                     string[] array2 = array[m].Split('/');
-                                    if (array2[0].Length > 0)
-                                    {
+                                    if (array2[0].Length > 0) {
                                         item3.Position = list2[int.Parse(array2[0]) - 1];
                                     }
-                                    if (array2[1].Length > 0)
-                                    {
+                                    if (array2[1].Length > 0) {
                                         item3.TextureCoordinate = list3[int.Parse(array2[1]) - 1];
                                     }
                                     list.Add(item3);
@@ -117,8 +93,7 @@ namespace Celeste
                     }
                 }
             }
-            if (mesh != null)
-            {
+            if (mesh != null) {
                 mesh.VertexCount = list.Count - mesh.VertexStart;
             }
             ((patch_ObjModel)objModel).verts = list.ToArray();
@@ -129,16 +104,10 @@ namespace Celeste
         private VertexPositionTexture[] verts;
 
         [MonoModIgnore]
-        private bool ResetVertexBuffer()
-        {
-            return true;
-        }
+        private extern bool ResetVertexBuffer();
 
         [MonoModIgnore]
-        private static float Float(string data)
-        {
-            return float.Parse(data, CultureInfo.InvariantCulture);
-        }
+        private static extern float Float(string data);
     }
 
     public static class ObjModelExt
@@ -146,7 +115,7 @@ namespace Celeste
 
         // Mods can't access patch_ classes directly.
         // We thus expose any new members through extensions.
-        
+
         /// <summary>
         /// Create a new ObjModel from a stream
         /// The filename is mainly just to check if it's a .export


### PR DESCRIPTION
Allows mods to create custom mountains in the overworld. Edit the .meta.yaml  of a map to have a MountainModelDirectory or a MountainTextureDirectory. MountainModelDirectory is relative to the root of your mod, and holds the models. MountainTextureDirectory is relative to Graphics/Atlases/Mountain (aka in the Mountain Atlas) and holds the textures.