### PR TITLE
Fix the 'water zipping' issue (warps/crashes when coming out of water from the sides)

### DIFF
--- a/Celeste.Mod.mm/Patches/Player.cs
+++ b/Celeste.Mod.mm/Patches/Player.cs
@@ -70,6 +70,7 @@ namespace Celeste {
             TrailManager.Add(this, scale, GetCurrentTrailColor());
         }
 
+        [PatchPlayerOrigUpdate] // Manipulate the method via MonoModRules
         public extern void orig_Update();
         public override void Update() {
             orig_Update();
@@ -81,6 +82,13 @@ namespace Celeste {
                 framesAlive++;
             if (framesAlive >= 8)
                 diedInGBJ = 0;
+        }
+
+        public bool _IsOverWater() {
+            // check if we are 2 pixels over water (or less).
+            Rectangle bounds = Collider.Bounds;
+            bounds.Height += 2;
+            return Scene.CollideCheck<Water>(bounds);
         }
 
         public extern PlayerDeadBody orig_Die(Vector2 direction, bool evenIfInvincible, bool registerDeathInStats);


### PR DESCRIPTION
When the player is in the "Swim" state and is going up at a normal speed (0 to 60), the game moves the player down until they are in water... this doesn't end well when coming out of the sides of floating water.

This PR adds a check before zipping the player down, to check if there is water 2 pixels below the player before doing so. (Maybe this is not enough?) From my testing on a floating square of water, this check only returned `false` when I came out from the sides, so the behavior in other cases (coming out from the top/bottom) should be unchanged.

The MonoModRule here is kinda heavy since it has to support both Steam branches. I don't know if there is a simpler way to do this. :confused: 