### PR TITLE
[Suggestion] Add [SettingMaxLength] attribute for string module settings

### DIFF
--- a/Celeste.Mod.mm/Mod/Module/EverestModule.cs
+++ b/Celeste.Mod.mm/Mod/Module/EverestModule.cs
@@ -421,13 +421,16 @@ namespace Celeste.Mod {
                     ;
 
                 } else if (!inGame && propType == typeof(string)) {
+                    int maxValueLength = prop.GetCustomAttribute<SettingMaxLengthAttribute>()?.Max ?? 12;
+
                     item =
                         new TextMenu.Button(name + ": " + value)
                         .Pressed(() => {
                             Audio.Play(SFX.ui_main_savefile_rename_start);
                             menu.SceneAs<Overworld>().Goto<OuiModOptionString>().Init<OuiModOptions>(
                                 (string) value,
-                                v => prop.SetValue(settings, v)
+                                v => prop.SetValue(settings, v),
+                                maxValueLength
                             );
                         })
                     ;

--- a/Celeste.Mod.mm/Mod/Module/EverestModuleSettings.cs
+++ b/Celeste.Mod.mm/Mod/Module/EverestModuleSettings.cs
@@ -55,6 +55,17 @@ namespace Celeste.Mod {
     }
 
     /// <summary>
+    /// Allows to set the maximum length of string settings.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public class SettingMaxLengthAttribute : Attribute {
+        public int Max;
+        public SettingMaxLengthAttribute(int max) {
+            Max = max;
+        }
+    }
+
+    /// <summary>
     /// Any options with this attribute will notify the user that a restart is required to apply the changes.
     /// </summary>
     [AttributeUsage(AttributeTargets.Property)]


### PR DESCRIPTION
For example, having this in a class extending EverestModuleSettings:
```cs
        [SettingMaxLength(30)]
        public string ThirtyCharacters { get; set; } = "Thirty";
```
will generate a string input screen limited to 30 characters, as opposed to the default 12.

Not using the attribute will still use the default max length of 12.

[Test mod with 3 options in case you want to test that.](https://github.com/EverestAPI/Everest/files/4008548/SettingLengthTest.zip)
