### PR TITLE
Fix strawberry-checkpoint assignment when both are in a same room

### DIFF
--- a/Celeste.Mod.mm/Patches/MapData.cs
+++ b/Celeste.Mod.mm/Patches/MapData.cs
@@ -202,38 +202,42 @@ namespace Celeste {
                     foreach (BinaryPacker.Element levelChild in level.Children) {
                         switch (levelChild.Name) {
                             case "entities":
+                                // check if the room has a checkpoint first.
+                                foreach (BinaryPacker.Element entity in levelChild.Children) {
+                                    if (entity.Name == "checkpoint") {
+                                        if (checkpointsAuto != null) {
+                                            MapMeta modeMeta = area.GetModeMeta(Area.Mode);
+                                            CheckpointData c = new CheckpointData(
+                                                levelName,
+                                                (area.GetSID() + "_" + levelName).DialogKeyify(),
+                                                MapMeta.GetInventory(entity.Attr("inventory")),
+                                                entity.Attr("dreaming") == "" ? modeMeta.Dreaming ?? area.Dreaming : entity.AttrBool("dreaming"),
+                                                null
+                                            );
+                                            if (entity.Attr("coreMode") == "") {
+                                                c.CoreMode = modeMeta.CoreMode ?? area.CoreMode;
+                                            }
+                                            else {
+                                                entity.AttrIf("coreMode", v => c.CoreMode = (Session.CoreModes) Enum.Parse(typeof(Session.CoreModes), v, true));
+                                            }
+                                                
+                                            int id = entity.AttrInt("checkpointID", -1);
+                                            if (id == -1) {
+                                                checkpointsAuto.Add(c);
+                                            } else {
+                                                while (checkpointsAuto.Count <= id)
+                                                    checkpointsAuto.Add(null);
+                                                checkpointsAuto[id] = c;
+                                            }
+                                        }
+                                        checkpoint++;
+                                        strawberryInCheckpoint = 0;
+                                    }
+                                }
+
+                                // then, auto-assign strawberries and cassettes to checkpoints.
                                 foreach (BinaryPacker.Element entity in levelChild.Children) {
                                     switch (entity.Name) {
-                                        case "checkpoint":
-                                            if (checkpointsAuto != null) {
-                                                MapMeta modeMeta = area.GetModeMeta(Area.Mode);
-                                                CheckpointData c = new CheckpointData(
-                                                    levelName,
-                                                    (area.GetSID() + "_" + levelName).DialogKeyify(),
-                                                    MapMeta.GetInventory(entity.Attr("inventory")),
-                                                    entity.Attr("dreaming") == "" ? modeMeta.Dreaming ?? area.Dreaming : entity.AttrBool("dreaming"),
-                                                    null
-                                                );
-                                                if (entity.Attr("coreMode") == "") {
-                                                    c.CoreMode = modeMeta.CoreMode ?? area.CoreMode;
-                                                }
-                                                else {
-                                                    entity.AttrIf("coreMode", v => c.CoreMode = (Session.CoreModes) Enum.Parse(typeof(Session.CoreModes), v, true));
-                                                }
-                                                
-                                                int id = entity.AttrInt("checkpointID", -1);
-                                                if (id == -1) {
-                                                    checkpointsAuto.Add(c);
-                                                } else {
-                                                    while (checkpointsAuto.Count <= id)
-                                                        checkpointsAuto.Add(null);
-                                                    checkpointsAuto[id] = c;
-                                                }
-                                            }
-                                            checkpoint++;
-                                            strawberryInCheckpoint = 0;
-                                            break;
-
                                         case "cassette":
                                             if (area.CassetteCheckpointIndex < 0)
                                                 area.CassetteCheckpointIndex = checkpoint;


### PR DESCRIPTION
If you place a strawberry and a checkpoint in the same room, the strawberry can end up being assigned to the previous checkpoint instead, if the strawberry comes first in level data. Placing a berry, the checkpoint, then another berry in Ahorn ends up with having one berry assigned to the checkpoint we just placed, and one assigned to the previous checkpoint.

This PR moves checkpoint processing before strawberry/cassette processing. I consider this is ready to be merged, but I'm submitting that as a PR since I feel this requires approval (in particular for impacts on existing maps).