### PR TITLE
Implement the [SettingNeedsRelaunch] attribute

### DIFF
--- a/Celeste.Mod.mm/Content/Dialog/English.txt
+++ b/Celeste.Mod.mm/Content/Dialog/English.txt
@@ -31,6 +31,7 @@
 
 # Mod Options
 	MODOPTIONS_TITLE= 										EVEREST
+	MODOPTIONS_NEEDSRELAUNCH=								Requires a restart to take effect
 
 # Core Module Options
 	MODOPTIONS_COREMODULE_UPDATE= 							Update Everest to ((version))

--- a/Celeste.Mod.mm/Content/Dialog/French.txt
+++ b/Celeste.Mod.mm/Content/Dialog/French.txt
@@ -13,6 +13,7 @@
 
 # Mod Options
 	MODOPTIONS_TITLE= 										EVEREST
+	MODOPTIONS_NEEDSRELAUNCH=								Prendra effet après le redémarrage
 
 # Core Module Options
 	MODOPTIONS_COREMODULE_UPDATE= 							Mettre à jour vers ((version))

--- a/Celeste.Mod.mm/Mod/Everest/Extensions.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Extensions.cs
@@ -185,17 +185,33 @@ namespace Celeste.Mod {
         /// Add an Enter and Leave handler, notifying the user that a relaunch is required to apply the changes.
         /// </summary>
         /// <param name="option">The input TextMenu.Item option.</param>
+        /// <param name="containingMenu">The menu containing the TextMenu.Item option.</param>
         /// <param name="needsRelaunch">This method does nothing if this is set to false.</param>
         /// <returns>The passed option.</returns>
-        public static TextMenu.Item NeedsRelaunch(this TextMenu.Item option, bool needsRelaunch = true) {
+        public static TextMenu.Item NeedsRelaunch(this TextMenu.Item option, TextMenu containingMenu, bool needsRelaunch = true) {
             if (!needsRelaunch)
                 return option;
+
+            // build the "Restart is required" text menu entry
+            TextMenuExt.EaseInSubHeaderExt needsRelaunchText = new TextMenuExt.EaseInSubHeaderExt(Dialog.Clean("MODOPTIONS_NEEDSRELAUNCH"), false, containingMenu) {
+                TextColor = Color.OrangeRed,
+                HeightExtra = 0f
+            };
+
+            List<TextMenu.Item> items = containingMenu.GetItems();
+            if (items.Contains(option)) {
+                // insert the text after the option that needs relaunch.
+                containingMenu.Insert(items.IndexOf(option) + 1, needsRelaunchText);
+            }
+
             return option
             .Enter(() => {
-                // TODO: Show "needs relaunch" warning.
+                // make the text appear.
+                needsRelaunchText.FadeVisible = true;
             })
             .Leave(() => {
-                // TODO: Hide "needs relaunch" warning.
+                // make the text disappear.
+                needsRelaunchText.FadeVisible = false;
             });
         }
 

--- a/Celeste.Mod.mm/Mod/Module/EverestModule.cs
+++ b/Celeste.Mod.mm/Mod/Module/EverestModule.cs
@@ -439,10 +439,10 @@ namespace Celeste.Mod {
                 if (item == null)
                     continue;
 
-                if (needsRelaunch)
-                    item = item.NeedsRelaunch();
-
                 menu.Add(item);
+
+                if (needsRelaunch)
+                    item = item.NeedsRelaunch(menu);
             }
 
         }

--- a/Celeste.Mod.mm/Mod/UI/TextMenuExt.cs
+++ b/Celeste.Mod.mm/Mod/UI/TextMenuExt.cs
@@ -188,5 +188,55 @@ namespace Celeste {
 
         }
 
+        /// <summary>
+        /// Sub-header that eases in/out when FadeVisible is changed.
+        /// </summary>
+        public class EaseInSubHeaderExt : SubHeaderExt {
+
+            /// <summary>
+            /// Toggling this will make the header ease in/out.
+            /// </summary>
+            public bool FadeVisible { get; set; } = true;
+
+            private float uneasedAlpha;
+            private TextMenu containingMenu;
+
+            /// <summary>
+            /// Creates a EaseInSubHeaderExt.
+            /// </summary>
+            /// <param name="title">The sub-header title</param>
+            /// <param name="initiallyVisible">The initial value for FadeVisible</param>
+            /// <param name="containingMenu">The menu containing this SubHeader</param>
+            /// <param name="icon">An icon for the sub-header</param>
+            public EaseInSubHeaderExt(string title, bool initiallyVisible, TextMenu containingMenu, string icon = null)
+                : base(title, icon) {
+
+                this.containingMenu = containingMenu;
+
+                FadeVisible = initiallyVisible;
+                Alpha = FadeVisible ? 1 : 0;
+                uneasedAlpha = Alpha;
+            }
+
+            // the fade has to take into account the item spacing as well, or the other options will abruptly shift up when Visible is switched to false.
+            public override float Height() => MathHelper.Lerp(-containingMenu.ItemSpacing, base.Height(), Alpha);
+
+            public override void Update() {
+                base.Update();
+
+                // gradually make the sub-header fade in or out. (~333ms fade)
+                float targetAlpha = FadeVisible ? 1 : 0;
+                if (uneasedAlpha != targetAlpha) {
+                    uneasedAlpha = Calc.Approach(uneasedAlpha, targetAlpha, Engine.DeltaTime * 3f);
+
+                    if (FadeVisible)
+                        Alpha = Ease.SineOut(uneasedAlpha);
+                    else
+                        Alpha = Ease.SineIn(uneasedAlpha);
+                }
+
+                Visible = (Alpha != 0);
+            }
+        }
     }
 }


### PR DESCRIPTION
> Any options with this attribute will notify the user that a restart is required to apply the changes.

Here is what it looks like:
![image](https://user-images.githubusercontent.com/52103563/71643476-79f72280-2cba-11ea-9aa7-ca1f171b5ef9.png)

This warning is only visible when the option is focused. I did my best to make the "ease in" animation for that warning look good ~~but I'm unsure I'm any good at that~~, [here is a short video of it](https://cdn.discordapp.com/attachments/445236692136230943/661968708360601620/Celeste_2020-01-01_17-24-27.mp4). Suggestions are welcome!

If everything looks good, this is ready to be merged.

_My first PR of 2020, wishing you a happy new year! Hope my PR flood is not too annoying._