### PR TITLE
Restore position when coming from 'string input' submenu

### DIFF
--- a/Celeste.Mod.mm/Mod/UI/OuiModOptionString.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiModOptionString.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 
 namespace Celeste.Mod.UI {
     // Based on OuiFileNaming
-    public class OuiModOptionString : Oui {
+    public class OuiModOptionString : Oui, OuiModOptions.ISubmenu {
 
         // TODO: OuiModOptionString is a hellscape of decompiled code.
 
@@ -345,8 +345,10 @@ namespace Celeste.Mod.UI {
             End:
 
             if (wasFocused && !Focused) {
-                if (Input.ESC)
+                if (Input.ESC) {
                     Cancel();
+                    wasFocused = false;
+                }
             }
 
             Focused = wasFocused;

--- a/Celeste.Mod.mm/Mod/UI/OuiModOptions.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiModOptions.cs
@@ -11,6 +11,11 @@ using System.Threading.Tasks;
 namespace Celeste.Mod.UI {
     public class OuiModOptions : Oui {
 
+        /// <summary>
+        /// Interface used to "tag" mod options submenus.
+        /// </summary>
+        public interface ISubmenu { }
+
         public static OuiModOptions Instance;
 
         private TextMenu menu;
@@ -19,6 +24,8 @@ namespace Celeste.Mod.UI {
         private const float offScreenX = 2880f;
 
         private float alpha = 0f;
+
+        private int savedMenuIndex = -1;
 
         public OuiModOptions() {
             Instance = this;
@@ -66,6 +73,12 @@ namespace Celeste.Mod.UI {
         public override IEnumerator Enter(Oui from) {
             ReloadMenu();
 
+            // restore selection if coming from a submenu.
+            if (savedMenuIndex != -1 && typeof(ISubmenu).IsAssignableFrom(from.GetType())) {
+                menu.Selection = Math.Min(savedMenuIndex, menu.LastPossibleSelection);
+                menu.Position.Y = menu.ScrollTargetY;
+            }
+
             menu.Visible = Visible = true;
             menu.Focused = false;
 
@@ -81,6 +94,9 @@ namespace Celeste.Mod.UI {
         public override IEnumerator Leave(Oui next) {
             Audio.Play(SFX.ui_main_whoosh_large_out);
             menu.Focused = false;
+
+            // save the menu position in case we want to restore it.
+            savedMenuIndex = menu.Selection;
 
             yield return Everest.SaveSettings();
 


### PR DESCRIPTION
The change in `OuiModOptionString.Update()` is a fix for a bug I noticed while doing this: when no controller is attached and cancelling out of the menu with Escape, the transition to Mod Options could happen multiple times.

The idea behind the `ISubmenu` interface is that mods (such like, uh, Extended Variants) can also define custom submenus and have the position in Mod Options restored when you come back from them. (Extended Variants currently hooks OuiModOptions to do that...)

_Ready to be merged._