### PR TITLE
Fix boosts from walljumping on upwards-moving solids

### DIFF
--- a/Celeste.Mod.mm/Patches/Player.cs
+++ b/Celeste.Mod.mm/Patches/Player.cs
@@ -131,6 +131,20 @@ namespace Celeste {
                 orig_WindMove(move);
         }
 
+        private extern void orig_WallJump(int dir);
+        private void WallJump(int dir) {
+            if ((Scene as Level).Session.Area.GetLevelSet() != "Celeste") {
+                // Fix vertical boost from upwards-moving solids not being applied correctly when dir != -1
+                if (LiftSpeed == Vector2.Zero) {
+                    Solid solid = CollideFirst<Solid>(Position + Vector2.UnitX * 3f * -dir);
+                    if (solid != null) {
+                        LiftSpeed = solid.LiftSpeed;
+                    }
+                }
+            }
+            orig_WallJump(dir);
+        }
+
         [MethodImpl(MethodImplOptions.NoInlining)]
         public Color GetCurrentTrailColor() => GetTrailColor(wasDashB);
         [MethodImpl(MethodImplOptions.NoInlining)]


### PR DESCRIPTION
Celeste's implementation of Player.WallJump has a bug where it adds 3 to the x coordinate when checking for solids to boost off of, instead of adding in the direction of the wall. This means that under specific circumstances (specifically upwards-moving solids), boosts work off of the left side, but not the right side.

This adds a patch to correctly check for solids in the direction of the wall, meaning boosts work on both sides of moving solids.