### PR TITLE
StrawberryRegistry for "just works" support for mod berries

### DIFF
--- a/Celeste.Mod.mm/Celeste.Mod.mm.csproj
+++ b/Celeste.Mod.mm/Celeste.Mod.mm.csproj
@@ -154,6 +154,7 @@
     <Compile Include="Mod\Entities\TriggerSpikesOriginal.cs" />
     <Compile Include="Mod\Helpers\EndUserException.cs" />
     <Compile Include="Mod\Helpers\SafeRoutine.cs" />
+    <Compile Include="Mod\Registry\StrawberryRegistry.cs" />
     <Compile Include="Mod\UI\AutoModUpdater.cs" />
     <Compile Include="Mod\UI\OuiDependencyDownloader.cs" />
     <Compile Include="Mod\UI\OuiHelper_ChapterSelect_Reload.cs" />

--- a/Celeste.Mod.mm/Celeste.Mod.mm.csproj
+++ b/Celeste.Mod.mm/Celeste.Mod.mm.csproj
@@ -125,6 +125,7 @@
     <Compile Include="Mod\Entities\CustomNPC.cs" />
     <Compile Include="Mod\Entities\LavaBlockerTrigger.cs" />
     <Compile Include="Mod\Entities\CustomEntityAttribute.cs" />
+    <Compile Include="Mod\Entities\RegisterStrawberryAttribute.cs" />
     <Compile Include="Mod\Entities\StarClimbGraphicsController.cs" />
     <Compile Include="Mod\Entities\MusicLayerTrigger.cs" />
     <Compile Include="Mod\Everest\Everest.LuaLoader.Caches.cs" />

--- a/Celeste.Mod.mm/Mod/Core/CoreMapDataProcessor.cs
+++ b/Celeste.Mod.mm/Mod/Core/CoreMapDataProcessor.cs
@@ -18,6 +18,14 @@ namespace Celeste.Mod.Core {
             Strawberry = 0;
             StrawberryInCheckpoint = 0;
             CheckpointsAuto = Mode.Checkpoints == null ? new List<CheckpointData>() : null;
+
+            foreach (KeyValuePair<string, Action<BinaryPacker.Element>> action in StrawberryRegistry.GetBerriesToInject(this.Context))
+            {
+                if (action.Key == "strawberry")
+                    continue;
+                if (!this.Steps.Keys.Contains<string>(action.Key))
+                    this.Steps.Add(action.Key, action.Value);
+            }
         }
 
         public override Dictionary<string, Action<BinaryPacker.Element>> Init()
@@ -183,6 +191,7 @@ namespace Celeste.Mod.Core {
                         entity.SetAttr("checkpointID", Checkpoint);
                     if (entity.AttrInt("order", -1) == -1)
                         entity.SetAttr("order", StrawberryInCheckpoint);
+
                     Strawberry++;
                     StrawberryInCheckpoint++;
                 } }

--- a/Celeste.Mod.mm/Mod/Core/CoreMapDataProcessor.cs
+++ b/Celeste.Mod.mm/Mod/Core/CoreMapDataProcessor.cs
@@ -18,14 +18,6 @@ namespace Celeste.Mod.Core {
             Strawberry = 0;
             StrawberryInCheckpoint = 0;
             CheckpointsAuto = Mode.Checkpoints == null ? new List<CheckpointData>() : null;
-
-            foreach (KeyValuePair<string, Action<BinaryPacker.Element>> action in StrawberryRegistry.GetBerriesToInject(this.Context))
-            {
-                if (action.Key == "strawberry")
-                    continue;
-                if (!this.Steps.Keys.Contains<string>(action.Key))
-                    this.Steps.Add(action.Key, action.Value);
-            }
         }
 
         public override Dictionary<string, Action<BinaryPacker.Element>> Init()
@@ -191,13 +183,18 @@ namespace Celeste.Mod.Core {
                         entity.SetAttr("checkpointID", Checkpoint);
                     if (entity.AttrInt("order", -1) == -1)
                         entity.SetAttr("order", StrawberryInCheckpoint);
-
                     Strawberry++;
                     StrawberryInCheckpoint++;
                 } }
             };
 
-
+        public override void Run(string stepName, BinaryPacker.Element el)
+        {
+            List<string> berries = StrawberryRegistry.GetBerryNames().ToList();
+            if (stepName.Length > 7 && berries.Contains(stepName.Remove(0, 7)))
+                stepName = "entity:strawberry";
+            base.Run(stepName, el);
+        }
 
         public override void End() {
             if (Mode.Checkpoints == null)

--- a/Celeste.Mod.mm/Mod/Entities/RegisterStrawberryAttribute.cs
+++ b/Celeste.Mod.mm/Mod/Entities/RegisterStrawberryAttribute.cs
@@ -1,0 +1,24 @@
+﻿using FMOD.Studio;
+using Microsoft.Xna.Framework;
+using Monocle;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Celeste.Mod.Entities
+{
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public class RegisterStrawberryAttribute : Attribute
+    {
+        public bool isTracked;
+        public bool blocksNormalCollection;
+        public RegisterStrawberryAttribute(bool tracked, bool blocksCollection)
+        {
+            isTracked = tracked;
+            blocksNormalCollection = blocksCollection;
+        }
+    }
+}

--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -483,6 +483,22 @@ namespace Celeste.Mod {
                         patch_Level.EntityLoaders[id] = loader;
                     }
                 }
+                // Register with the StrawberryRegistry all entities marked with RegisterStrawberryAttribute.
+                foreach (RegisterStrawberryAttribute attrib in type.GetCustomAttributes<RegisterStrawberryAttribute>())
+                {
+                    List<string> names = new List<string>();
+                    foreach (CustomEntityAttribute nameAttrib in type.GetCustomAttributes<CustomEntityAttribute>())
+                        foreach (string idFull in nameAttrib.IDs)
+                            names.Add(idFull);
+                    if (names.Count == 0)
+                        goto NoDefinedBerryNames; // no customnames? skip out on registering berry
+
+                    foreach (string name in names)
+                    {
+                        StrawberryRegistry.Register(type, name, attrib.isTracked, attrib.blocksNormalCollection);
+                    }
+                }
+            NoDefinedBerryNames:;
             }
 
             module.LoadSettings();

--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -489,7 +489,15 @@ namespace Celeste.Mod {
                     List<string> names = new List<string>();
                     foreach (CustomEntityAttribute nameAttrib in type.GetCustomAttributes<CustomEntityAttribute>())
                         foreach (string idFull in nameAttrib.IDs)
-                            names.Add(idFull);
+                        {
+                            string[] split = idFull.Split('=');
+                            if(split.Length == 0)
+                            {
+                                Logger.Log(LogLevel.Warn, "core", $"Invalid number of custom entity ID elements: {idFull} ({type.FullName})");
+                                continue;
+                            }
+                            names.Add(split[0]);
+                        }
                     if (names.Count == 0)
                         goto NoDefinedBerryNames; // no customnames? skip out on registering berry
 

--- a/Celeste.Mod.mm/Mod/Registry/StrawberryRegistry.cs
+++ b/Celeste.Mod.mm/Mod/Registry/StrawberryRegistry.cs
@@ -60,20 +60,20 @@ namespace Celeste.Mod
         }
 
         // Register the strawberry or similar collectible with the Strawberry Registry, allowing it to be auto-collected at level end and be trackable.
-        public static void Register(Type type, string name, bool tracked = true, bool alternateCollectionRules = false)
+        public static void Register(Type type, string name, bool tracked = true, bool blocksNormalCollection = false)
         {
-            registeredBerries.Add(new RegisteredBerry(type, name, tracked, alternateCollectionRules));
+            registeredBerries.Add(new RegisteredBerry(type, name, tracked, blocksNormalCollection));
         }
 
         // Register the strawberry or similar collectible with the Strawberry Registry, allowing it to be auto-collected at level end and be trackable.
-        public static void Register(Type type, bool tracked = true, bool alternateCollectionRules = false)
+        public static void Register(Type type, bool tracked = true, bool blocksNormalCollection = false)
         {
             if (Attribute.IsDefined(type, typeof(CustomEntityAttribute)))
             {
                 CustomEntityAttribute attr = Attribute.GetCustomAttribute(type, typeof(CustomEntityAttribute)) as CustomEntityAttribute;
                 foreach (string id in attr.IDs)
                 {
-                    Register(type, id, tracked, alternateCollectionRules);
+                    Register(type, id, tracked, blocksNormalCollection);
                 }
             }
         }

--- a/Celeste.Mod.mm/Mod/Registry/StrawberryRegistry.cs
+++ b/Celeste.Mod.mm/Mod/Registry/StrawberryRegistry.cs
@@ -19,6 +19,7 @@ namespace Celeste.Mod
         private static ReadOnlyCollection<RegisteredBerry> _getRegisteredBerries;
         private static ReadOnlyCollection<RegisteredBerry> _getTrackableBerries;
         private static ReadOnlyCollection<Type> _getBerryTypes;
+        private static ReadOnlyCollection<string> _getBerryNames;
 
         // Return caches or create new ones
         public static ReadOnlyCollection<RegisteredBerry> GetRegisteredBerries()
@@ -43,6 +44,19 @@ namespace Celeste.Mod
                 _getBerryTypes = types.AsReadOnly();
             }
             return _getBerryTypes;
+        }
+        public static ReadOnlyCollection<string> GetBerryNames()
+        {
+            if (_getBerryNames == null)
+            {
+                List<string> berryNames = new List<string>();
+                foreach (RegisteredBerry berry in registeredBerries)
+                {
+                    berryNames.Add(berry.entityName);
+                }
+                _getBerryNames = berryNames.AsReadOnly();
+            }
+            return _getBerryNames;
         }
 
         // Register the strawberry or similar collectible with the Strawberry Registry, allowing it to be auto-collected at level end and be trackable.
@@ -117,19 +131,6 @@ namespace Celeste.Mod
                 }
             }
             return true;
-        }
-
-        // Called by CoreMapDataProcessor in order to inject mod berries into the step list for fixup.
-        public static Dictionary<string, Action<BinaryPacker.Element>> GetBerriesToInject(MapDataFixup context)
-        {
-            Dictionary<string, Action<BinaryPacker.Element>> trackDict = new Dictionary<string, Action<BinaryPacker.Element>>();
-            ReadOnlyCollection<RegisteredBerry> berries = GetRegisteredBerries();
-            foreach (RegisteredBerry berry in berries)
-            {
-                trackDict.Add(String.Concat("entity:", berry.entityName), entity => { context.Run("entity:strawberry", entity); });
-            }
-
-            return trackDict;
         }
 
         public class RegisteredBerry

--- a/Celeste.Mod.mm/Mod/Registry/StrawberryRegistry.cs
+++ b/Celeste.Mod.mm/Mod/Registry/StrawberryRegistry.cs
@@ -85,28 +85,32 @@ namespace Celeste.Mod
             // we need it searchable and Find doesn't work on a ReadOnlyCollection aaaaa
             List<RegisteredBerry> berries = registeredBerries.ToList();
             ReadOnlyCollection<Type> types = GetBerryTypes();
-            //RegisteredBerry detectedBerry = berries.Find(b => b.GetType() == self.GetType());
-            //if (detectedBerry != null)
-            //if (detectedBerry == null)
-            //    return false;
 
             for (int i = follow.FollowIndex - 1; i >= 0; i--)
             {
                 Entity strawberry = follow.Leader.Followers[i].Entity;
+                Type t = strawberry.GetType();
+                RegisteredBerry berry = berries.Find(b => b.berryClass == t);
+
+                // Is the "strawberry" registered? If not, bail immediately.
+                // This is a safety check and should _never_ fail.
+                bool isRegistered = types.Contains(strawberry.GetType());
+
+                // Does the strawberry not collect in the normal way?
+                // If it does, we need to defer "leader" to another berry.
+                bool blocksCollect = berry.blocksNormalCollection;
+
+                // Is it a vanilla Gold Strawberry?
+                // This needs to defer "leader" to another berry.
                 bool goldenCheck = false;
                 if (strawberry as Strawberry != null)
                     goldenCheck = (strawberry as Strawberry).Golden;
 
-                //Strawberry vanillaStraw = strawberry as Strawberry;
-                //if (vanillaStraw != null && !vanillaStraw.Golden)
-                //{
-                //    return false;
-                //}
-                Type t = follow.Entity.GetType();
-                RegisteredBerry berry = berries.Find(b => b.berryClass == t);
-                bool blocksCollect = berry.blocksNormalCollection;
+                // Did we find a berry closer to the front that doesn't defer?
+                // It must be registered, must NOT block collection, and is NOT a gold berry
+                // in order to be a valid leader.
                 if (types.Contains(strawberry.GetType()) && 
-                    berry.blocksNormalCollection == false && 
+                    !blocksCollect && 
                     !goldenCheck)
                 {
                     return false;

--- a/Celeste.Mod.mm/Mod/Registry/StrawberryRegistry.cs
+++ b/Celeste.Mod.mm/Mod/Registry/StrawberryRegistry.cs
@@ -20,6 +20,7 @@ namespace Celeste.Mod
         private static ReadOnlyCollection<RegisteredBerry> _getTrackableBerries;
         private static ReadOnlyCollection<Type> _getBerryTypes;
 
+        // Return caches or create new ones
         public static ReadOnlyCollection<RegisteredBerry> GetRegisteredBerries()
         {
             if (_getRegisteredBerries == null)
@@ -44,8 +45,7 @@ namespace Celeste.Mod
             return _getBerryTypes;
         }
 
-        // Register the strawberry or similar collectible with the Strawberry Registry, allowing it to be auto-collected at level end and be trackable.<para />
-        // Only use this version if your strawberry class does not use the CustomEntity(entityname) attribute.
+        // Register the strawberry or similar collectible with the Strawberry Registry, allowing it to be auto-collected at level end and be trackable.
         public static void Register(Type type, string name, bool tracked = true, bool alternateCollectionRules = false)
         {
             registeredBerries.Add(new RegisteredBerry(type, name, tracked, alternateCollectionRules));
@@ -59,7 +59,7 @@ namespace Celeste.Mod
                 CustomEntityAttribute attr = Attribute.GetCustomAttribute(type, typeof(CustomEntityAttribute)) as CustomEntityAttribute;
                 foreach (string id in attr.IDs)
                 {
-                    registeredBerries.Add(new RegisteredBerry(type, id, tracked, alternateCollectionRules));
+                    Register(type, id, tracked, alternateCollectionRules);
                 }
             }
         }
@@ -134,16 +134,18 @@ namespace Celeste.Mod
 
         public class RegisteredBerry
         {
-            // registered berry as a Type
+            // The registered berry as a Type
             public readonly Type berryClass;
 
-            // entity:<passed berry's defined name>
+            // The custom name for the berry.
             public readonly string entityName;
 
             // T: add berry to tracker and auto-assign checkpoint + order
             // F: berry is secret, only auto-handle last ditch collections
             public readonly bool isTracked;
 
+            // T: berry defers "leadership" of the berry train so that berries that follow redberry collection rules can be collected
+            // F: berry doesn't have a special collection rule and can be a "leader" of the berry train
             public readonly bool blocksNormalCollection;
 
             public RegisteredBerry(Type berry, string name, bool track, bool blockCollect)

--- a/Celeste.Mod.mm/Mod/Registry/StrawberryRegistry.cs
+++ b/Celeste.Mod.mm/Mod/Registry/StrawberryRegistry.cs
@@ -1,0 +1,154 @@
+﻿using Celeste.Mod.Entities;
+using Monocle;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace Celeste.Mod
+{
+    /// <summary>
+    /// Allows mods to register their own strawberry-type collectible objects.<para />
+    /// Registered strawberries can be tracked or secret, and will attempt to autocollect when appropriate e.g. level end.
+    /// </summary>
+    public static class StrawberryRegistry
+    {
+        private static HashSet<RegisteredBerry> registeredBerries = new HashSet<RegisteredBerry>() { new RegisteredBerry(typeof(Strawberry), "strawberry", true, false) };
+
+        // Caches
+        private static ReadOnlyCollection<RegisteredBerry> _getRegisteredBerries;
+        private static ReadOnlyCollection<RegisteredBerry> _getTrackableBerries;
+        private static ReadOnlyCollection<Type> _getBerryTypes;
+
+        public static ReadOnlyCollection<RegisteredBerry> GetRegisteredBerries()
+        {
+            if (_getRegisteredBerries == null)
+                _getRegisteredBerries = registeredBerries.ToList().AsReadOnly();
+            return _getRegisteredBerries;
+        }
+        public static ReadOnlyCollection<RegisteredBerry> GetTrackableBerries()
+        {
+            if (_getTrackableBerries == null)
+                _getTrackableBerries = registeredBerries.ToList().FindAll(berry => berry.isTracked).AsReadOnly();
+            return _getTrackableBerries;
+        }
+        public static ReadOnlyCollection<Type> GetBerryTypes()
+        {
+            if (_getBerryTypes == null)
+            {
+                List<Type> types = new List<Type>();
+                foreach (RegisteredBerry b in registeredBerries)
+                    types.Add(b.berryClass);
+                _getBerryTypes = types.AsReadOnly();
+            }
+            return _getBerryTypes;
+        }
+
+        // Register the strawberry or similar collectible with the Strawberry Registry, allowing it to be auto-collected at level end and be trackable.<para />
+        // Only use this version if your strawberry class does not use the CustomEntity(entityname) attribute.
+        public static void Register(Type type, string name, bool tracked = true, bool alternateCollectionRules = false)
+        {
+            registeredBerries.Add(new RegisteredBerry(type, name, tracked, alternateCollectionRules));
+        }
+
+        // Register the strawberry or similar collectible with the Strawberry Registry, allowing it to be auto-collected at level end and be trackable.
+        public static void Register(Type type, bool tracked = true, bool alternateCollectionRules = false)
+        {
+            if (Attribute.IsDefined(type, typeof(CustomEntityAttribute)))
+            {
+                CustomEntityAttribute attr = Attribute.GetCustomAttribute(type, typeof(CustomEntityAttribute)) as CustomEntityAttribute;
+                foreach (string id in attr.IDs)
+                {
+                    registeredBerries.Add(new RegisteredBerry(type, id, tracked, alternateCollectionRules));
+                }
+            }
+        }
+
+        public static bool TrackableContains(string name)
+        {
+            ReadOnlyCollection<RegisteredBerry> berries = GetTrackableBerries();
+            foreach (RegisteredBerry berry in berries)
+            {
+                if (berry.entityName == name)
+                    return true;
+            }
+            return false;
+        }
+
+        // Is it the first normally collectable strawberry in the train?
+        public static bool IsFirstStrawberry(Entity self)
+        {
+            Follower follow = self.Components.Get<Follower>();
+            if (follow == null)
+                return false;
+
+            // we need it searchable and Find doesn't work on a ReadOnlyCollection aaaaa
+            List<RegisteredBerry> berries = registeredBerries.ToList();
+            ReadOnlyCollection<Type> types = GetBerryTypes();
+            //RegisteredBerry detectedBerry = berries.Find(b => b.GetType() == self.GetType());
+            //if (detectedBerry != null)
+            //if (detectedBerry == null)
+            //    return false;
+
+            for (int i = follow.FollowIndex - 1; i >= 0; i--)
+            {
+                Entity strawberry = follow.Leader.Followers[i].Entity;
+                bool goldenCheck = false;
+                if (strawberry as Strawberry != null)
+                    goldenCheck = (strawberry as Strawberry).Golden;
+
+                //Strawberry vanillaStraw = strawberry as Strawberry;
+                //if (vanillaStraw != null && !vanillaStraw.Golden)
+                //{
+                //    return false;
+                //}
+                Type t = follow.Entity.GetType();
+                RegisteredBerry berry = berries.Find(b => b.berryClass == t);
+                bool blocksCollect = berry.blocksNormalCollection;
+                if (types.Contains(strawberry.GetType()) && 
+                    berry.blocksNormalCollection == false && 
+                    !goldenCheck)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        // Called by CoreMapDataProcessor in order to inject mod berries into the step list for fixup.
+        public static Dictionary<string, Action<BinaryPacker.Element>> GetBerriesToInject(MapDataFixup context)
+        {
+            Dictionary<string, Action<BinaryPacker.Element>> trackDict = new Dictionary<string, Action<BinaryPacker.Element>>();
+            ReadOnlyCollection<RegisteredBerry> berries = GetRegisteredBerries();
+            foreach (RegisteredBerry berry in berries)
+            {
+                trackDict.Add(String.Concat("entity:", berry.entityName), entity => { context.Run("entity:strawberry", entity); });
+            }
+
+            return trackDict;
+        }
+
+        public class RegisteredBerry
+        {
+            // registered berry as a Type
+            public readonly Type berryClass;
+
+            // entity:<passed berry's defined name>
+            public readonly string entityName;
+
+            // T: add berry to tracker and auto-assign checkpoint + order
+            // F: berry is secret, only auto-handle last ditch collections
+            public readonly bool isTracked;
+
+            public readonly bool blocksNormalCollection;
+
+            public RegisteredBerry(Type berry, string name, bool track, bool blockCollect)
+            {
+                berryClass = berry;
+                entityName = name;
+                isTracked = track;
+                blocksNormalCollection = blockCollect;
+            }
+        }
+    }
+}

--- a/Celeste.Mod.mm/Patches/HeartGem.cs
+++ b/Celeste.Mod.mm/Patches/HeartGem.cs
@@ -25,10 +25,6 @@ namespace Celeste {
             // no-op. MonoMod ignores this - we only need this to make the compiler shut up.
         }
 
-        /*[MonoModIgnore] // We don't want to change anything about the method...
-        [PatchHeartGemCollectRoutine] // ... except for manually manipulating the method via MonoModRules
-        private extern IEnumerator CollectRoutine(Player player);*/
-
         private extern IEnumerator orig_CollectRoutine(Player player);
         [PatchHeartGemCollectRoutine]
         private IEnumerator CollectRoutine(Player player)

--- a/Celeste.Mod.mm/Patches/HeartGem.cs
+++ b/Celeste.Mod.mm/Patches/HeartGem.cs
@@ -13,6 +13,9 @@ using System.Xml;
 using Microsoft.Xna.Framework;
 using System.Collections;
 using Celeste.Mod.Meta;
+using System.Collections.ObjectModel;
+using static Celeste.Mod.StrawberryRegistry;
+using System.Reflection;
 
 namespace Celeste {
     class patch_HeartGem : HeartGem {
@@ -22,9 +25,43 @@ namespace Celeste {
             // no-op. MonoMod ignores this - we only need this to make the compiler shut up.
         }
 
-        [MonoModIgnore] // We don't want to change anything about the method...
+        /*[MonoModIgnore] // We don't want to change anything about the method...
         [PatchHeartGemCollectRoutine] // ... except for manually manipulating the method via MonoModRules
-        private extern IEnumerator CollectRoutine(Player player);
+        private extern IEnumerator CollectRoutine(Player player);*/
+
+        private extern IEnumerator orig_CollectRoutine(Player player);
+        [PatchHeartGemCollectRoutine]
+        private IEnumerator CollectRoutine(Player player)
+        {
+            Level level = Scene as Level;
+
+            bool heartIsEnd = false;
+            MapMetaModeProperties mapMetaModeProperties = (level != null) ? level.Session.MapData.GetMeta() : null;
+            if (mapMetaModeProperties != null && mapMetaModeProperties.HeartIsEnd != null)
+            {
+                heartIsEnd = mapMetaModeProperties.HeartIsEnd.Value;
+            }
+
+            if (heartIsEnd)
+            {
+                List<Entity> strawbs = new List<Entity>();
+                ReadOnlyCollection<Type> regBerries = StrawberryRegistry.GetBerryTypes();
+                foreach (Follower follower in player.Leader.Followers)
+                {
+                    
+                    if (regBerries.Contains(follower.Entity.GetType()))
+                    {
+                        strawbs.Add(follower.Entity);
+                    }
+                }
+                foreach (Entity strawb in strawbs)
+                {
+                    strawb.GetType().InvokeMember("OnCollect", BindingFlags.Public | BindingFlags.Instance | BindingFlags.InvokeMethod, Type.DefaultBinder, strawb, null);
+                }
+            }
+
+            return orig_CollectRoutine(player);
+        }
 
         private bool IsCompleteArea(bool value) {
             MapMetaModeProperties meta = (Scene as Level)?.Session.MapData.GetMeta();

--- a/Celeste.Mod.mm/Patches/Level.cs
+++ b/Celeste.Mod.mm/Patches/Level.cs
@@ -52,10 +52,9 @@ namespace Celeste {
         [PatchLevelUpdate] // ... except for manually manipulating the method via MonoModRules
         public extern new void Update();
 
-        public extern void orig_RegisterAreaComplete();
+        [MonoModReplace]
         public new void RegisterAreaComplete() {
             bool completed = Completed;
-            //orig_RegisterAreaComplete();
             if (!completed)
             {
                 Player player = base.Tracker.GetEntity<Player>();

--- a/Celeste.Mod.mm/Patches/Level.cs
+++ b/Celeste.Mod.mm/Patches/Level.cs
@@ -17,6 +17,8 @@ using System.Linq;
 using Celeste.Mod.Meta;
 using MonoMod.Utils;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Reflection;
 
 namespace Celeste {
     class patch_Level : Level {
@@ -53,8 +55,28 @@ namespace Celeste {
         public extern void orig_RegisterAreaComplete();
         public new void RegisterAreaComplete() {
             bool completed = Completed;
-            orig_RegisterAreaComplete();
-            if (!completed) {
+            //orig_RegisterAreaComplete();
+            if (!completed)
+            {
+                Player player = base.Tracker.GetEntity<Player>();
+                if (player != null)
+                {
+                    List<Entity> strawbs = new List<Entity>();
+                    ReadOnlyCollection<Type> regBerries = StrawberryRegistry.GetBerryTypes();
+                    foreach (Follower follower in player.Leader.Followers)
+                    {
+
+                        if (regBerries.Contains(follower.Entity.GetType()))
+                        {
+                            strawbs.Add(follower.Entity);
+                        }
+                    }
+                    foreach (Entity strawb in strawbs)
+                    {
+                        strawb.GetType().InvokeMember("OnCollect", BindingFlags.Public | BindingFlags.Instance | BindingFlags.InvokeMethod, Type.DefaultBinder, strawb, null);
+                    }
+                }
+                Completed = true;
                 Everest.Events.Level.Complete(this);
             }
         }

--- a/Celeste.Mod.mm/Patches/LevelData.cs
+++ b/Celeste.Mod.mm/Patches/LevelData.cs
@@ -17,6 +17,7 @@ namespace Celeste {
         public extern void orig_ctor(BinaryPacker.Element data);
 
         [MonoModConstructor]
+        [PatchLevelDataBerryTracker]
         public void ctor(BinaryPacker.Element data) {
             orig_ctor(data);
             if(!Everest.Flags.IsDisabled)

--- a/Celeste.Mod.mm/Patches/Strawberry.cs
+++ b/Celeste.Mod.mm/Patches/Strawberry.cs
@@ -27,5 +27,20 @@ namespace Celeste {
             Everest.Discord.OnStrawberryCollect();
         }
 
+        public extern void orig_Update();
+        [PatchStrawberryTrainCollectionOrder]
+        public new void Update()
+        {
+            orig_Update();
+        }
+
+        /*[MonoModReplace]
+        private new bool IsFirstStrawberry
+        {
+            get
+            {
+                return StrawberryRegistry.IsFirstStrawberry(this);
+            }
+        }*/
     }
 }

--- a/Celeste.Mod.mm/Patches/Strawberry.cs
+++ b/Celeste.Mod.mm/Patches/Strawberry.cs
@@ -33,14 +33,5 @@ namespace Celeste {
         {
             orig_Update();
         }
-
-        /*[MonoModReplace]
-        private new bool IsFirstStrawberry
-        {
-            get
-            {
-                return StrawberryRegistry.IsFirstStrawberry(this);
-            }
-        }*/
     }
 }


### PR DESCRIPTION
Berries may be added via `Celeste.Mod.StrawberryRegistry.Register(Type type, bool tracked = true, bool alternateCollectionRules = false)`

`type` - The Type of your registered berry, obtained via `typeof(MyBerry)` or similar.
`tracked` - Allow the registered berry to appear in the "maximum" berry count, checkpoint cards, and pause menu tracker.
`alternateCollectionRules` - Whether the berry defers "first in line" to another registered berry which does not have this flag set.

`CoreMapDataProcessor` reads data from the registry to dynamically inject MapDataFixup steps into itself, so all mod berries will correctly auto-assign checkpoints and orders if given `-1:-1`.