### PR TITLE
Merge pull request #88 from max4805/updater_logic_update

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Updater.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Updater.cs
@@ -185,9 +185,17 @@ namespace Celeste.Mod {
                     if (all.Count == 0)
                         return;
 
+                    // look up the installed version in the table (or the latest one by default).
+                    int currentBuildIndex = all.FindIndex(entry => entry.Build == Build);
+                    if (currentBuildIndex == -1) currentBuildIndex = 0;
+
+                    // find the latest version (highest build number), taking only the elements that are higher in the list into account.
                     Newest = all[0];
-                    if (Newest.Build < Build)
-                        Newest = all.OrderByDescending(entry => entry.Build).First();
+                    for (int i = 1; i <= currentBuildIndex; i++) {
+                        if (all[i].Build > Newest.Build) {
+                            Newest = all[i];
+                        }
+                    }
                 });
             }
 


### PR DESCRIPTION
The current logic is: "the first entry in the list (latest stable) is the latest version, unless the installed version is higher than that. In this case, the highest build number in the list is the one with the biggest build number". This works with only "stable" and "master" branches, but can lead to master > subchapters and subchapters > master updates in the current setup.

This PR suggests the following behavior: "the latest version is the one with the highest build number _taking only the installed version and the ones above in the list into account_". This way, you can only update to a version that is higher in the list. Combined with https://github.com/EverestAPI/Everest/commit/29870a2fb3e73d07952eebcacbda076eeac7d1ec, this will restrict updates to master > master or stable, subchapters > subchapters or stable, and stable > stable.