### PR TITLE
Allow subdirectories in the Tutorials folder

### DIFF
--- a/Celeste.Mod.mm/Patches/PlaybackData.cs
+++ b/Celeste.Mod.mm/Patches/PlaybackData.cs
@@ -15,9 +15,43 @@ using Microsoft.Xna.Framework;
 namespace Celeste {
     static class patch_PlaybackData {
 
-        [MonoModIgnore] // We don't want to change anything about the method...
-        [ProxyFileCalls] // ... except for proxying all System.IO.File.* calls to Celeste.Mod.FileProxy.*
-        public static extern void Load();
+        // expose the Tutorials field and vanilla methods to our patch.
+        public static Dictionary<string, List<Player.ChaserState>> Tutorials;
+
+        public static extern void orig_Load();
+
+        [MonoModIgnore]
+        public static extern List<Player.ChaserState> Import(byte[] buffer);
+
+        public static void Load() {
+            // load vanilla tutorials
+            orig_Load();
+
+            // load mod tutorials
+            if (Everest.Content.TryGet<AssetTypeDirectory>("Tutorials", out ModAsset dir, true)) {
+                // crawl in the Tutorials directory
+                loadTutorialsInDirectory(dir);
+            }
+        }
+
+        private static void loadTutorialsInDirectory(ModAsset dir) {
+            foreach (ModAsset child in dir.Children) {
+                if (child.Type == typeof(AssetTypeDirectory)) {
+                    // crawl in subdirectory.
+                    loadTutorialsInDirectory(child);
+                } else if (child.Type == typeof(AssetTypeTutorial)) {
+                    // remove Tutorials/ from the tutorial path.
+                    string tutorialPath = child.PathVirtual;
+                    if (tutorialPath.StartsWith("Tutorials/")) tutorialPath = tutorialPath.Substring("Tutorials/".Length);
+
+                    // load tutorial.
+                    Logger.Log("PlaybackData", $"Loading tutorial: {tutorialPath}");
+                    byte[] buffer = child.Data;
+                    List<Player.ChaserState> tutorial = Import(buffer);
+                    Tutorials.Add(tutorialPath, tutorial);
+                }
+            }
+        }
 
     }
 }


### PR DESCRIPTION
This PR aims to allow putting tutorial files in subdirectories of the Tutorials folder. For example, putting a tutorial file in `Mods/Test/Tutorials/max480/test.bin` allows it to be used with a player playback entity by specifying `max480/test`.