### PR TITLE
Unhardcode stamps and compute a lot of totals dynamically

### DIFF
--- a/Celeste.Mod.mm/Mod/Core/CoreMapDataProcessor.cs
+++ b/Celeste.Mod.mm/Mod/Core/CoreMapDataProcessor.cs
@@ -197,14 +197,12 @@ namespace Celeste.Mod.Core {
 
         public override void Run(string stepName, BinaryPacker.Element el)
         {
-            if (stepName.Length > 7)
-            {
-                if (StrawberryRegistry.TrackableContains(el))
-                    stepName = "entity:strawberry";
+            if (StrawberryRegistry.TrackableContains(el))
+                stepName = "entity:strawberry";
 
-                if (StrawberryRegistry.GetRegisteredBerries().Any(berry => berry.entityName == el.Name))
-                    TotalStrawberriesIncludingUntracked++;
-            }
+            if (StrawberryRegistry.GetRegisteredBerries().Any(berry => berry.entityName == el.Name))
+                TotalStrawberriesIncludingUntracked++;
+
             base.Run(stepName, el);
         }
 

--- a/Celeste.Mod.mm/Mod/Core/CoreMapDataProcessor.cs
+++ b/Celeste.Mod.mm/Mod/Core/CoreMapDataProcessor.cs
@@ -195,8 +195,7 @@ namespace Celeste.Mod.Core {
                 } }
             };
 
-        public override void Run(string stepName, BinaryPacker.Element el)
-        {
+        public override void Run(string stepName, BinaryPacker.Element el) {
             if (StrawberryRegistry.TrackableContains(el))
                 stepName = "entity:strawberry";
 

--- a/Celeste.Mod.mm/Mod/Registry/StrawberryRegistry.cs
+++ b/Celeste.Mod.mm/Mod/Registry/StrawberryRegistry.cs
@@ -5,14 +5,12 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 
-namespace Celeste.Mod
-{
+namespace Celeste.Mod {
     /// <summary>
     /// Allows mods to register their own strawberry-type collectible objects.<para />
     /// Registered strawberries can be tracked or secret, and will attempt to autocollect when appropriate e.g. level end.
     /// </summary>
-    public static class StrawberryRegistry
-    {
+    public static class StrawberryRegistry {
         private static HashSet<RegisteredBerry> registeredBerries = new HashSet<RegisteredBerry>() {
             new RegisteredBerry(typeof(Strawberry), "strawberry", true, false), // red berries
             new RegisteredBerry(typeof(Strawberry), "goldenBerry", false, true), // golden berries
@@ -26,22 +24,18 @@ namespace Celeste.Mod
         private static ReadOnlyCollection<string> _getBerryNames;
 
         // Return caches or create new ones
-        public static ReadOnlyCollection<RegisteredBerry> GetRegisteredBerries()
-        {
+        public static ReadOnlyCollection<RegisteredBerry> GetRegisteredBerries() {
             if (_getRegisteredBerries == null)
                 _getRegisteredBerries = registeredBerries.ToList().AsReadOnly();
             return _getRegisteredBerries;
         }
-        public static ReadOnlyCollection<RegisteredBerry> GetTrackableBerries()
-        {
+        public static ReadOnlyCollection<RegisteredBerry> GetTrackableBerries() {
             if (_getTrackableBerries == null)
                 _getTrackableBerries = registeredBerries.ToList().FindAll(berry => berry.isTracked).AsReadOnly();
             return _getTrackableBerries;
         }
-        public static ReadOnlyCollection<Type> GetBerryTypes()
-        {
-            if (_getBerryTypes == null)
-            {
+        public static ReadOnlyCollection<Type> GetBerryTypes() {
+            if (_getBerryTypes == null) {
                 List<Type> types = new List<Type>();
                 foreach (RegisteredBerry b in registeredBerries)
                     if (!types.Contains(b.berryClass)) // enumerate each type once. a berry can have multiple names.
@@ -51,13 +45,10 @@ namespace Celeste.Mod
             }
             return _getBerryTypes;
         }
-        public static ReadOnlyCollection<string> GetBerryNames()
-        {
-            if (_getBerryNames == null)
-            {
+        public static ReadOnlyCollection<string> GetBerryNames() {
+            if (_getBerryNames == null) {
                 List<string> berryNames = new List<string>();
-                foreach (RegisteredBerry berry in registeredBerries)
-                {
+                foreach (RegisteredBerry berry in registeredBerries) {
                     berryNames.Add(berry.entityName);
                 }
                 _getBerryNames = berryNames.AsReadOnly();
@@ -66,37 +57,30 @@ namespace Celeste.Mod
         }
 
         // Register the strawberry or similar collectible with the Strawberry Registry, allowing it to be auto-collected at level end and be trackable.
-        public static void Register(Type type, string name, bool tracked = true, bool blocksNormalCollection = false)
-        {
+        public static void Register(Type type, string name, bool tracked = true, bool blocksNormalCollection = false) {
             registeredBerries.Add(new RegisteredBerry(type, name, tracked, blocksNormalCollection));
         }
 
         // Register the strawberry or similar collectible with the Strawberry Registry, allowing it to be auto-collected at level end and be trackable.
-        public static void Register(Type type, bool tracked = true, bool blocksNormalCollection = false)
-        {
-            if (Attribute.IsDefined(type, typeof(CustomEntityAttribute)))
-            {
+        public static void Register(Type type, bool tracked = true, bool blocksNormalCollection = false) {
+            if (Attribute.IsDefined(type, typeof(CustomEntityAttribute))) {
                 CustomEntityAttribute attr = Attribute.GetCustomAttribute(type, typeof(CustomEntityAttribute)) as CustomEntityAttribute;
-                foreach (string id in attr.IDs)
-                {
+                foreach (string id in attr.IDs) {
                     Register(type, id, tracked, blocksNormalCollection);
                 }
             }
         }
 
-        public static bool TrackableContains(string name)
-        {
+        public static bool TrackableContains(string name) {
             ReadOnlyCollection<RegisteredBerry> berries = GetTrackableBerries();
-            foreach (RegisteredBerry berry in berries)
-            {
+            foreach (RegisteredBerry berry in berries) {
                 if (berry.entityName == name)
                     return true;
             }
             return false;
         }
 
-        public static bool TrackableContains(BinaryPacker.Element target)
-        {
+        public static bool TrackableContains(BinaryPacker.Element target) {
             if (target.AttrBool("moon", false))
                 return false;
 
@@ -104,8 +88,7 @@ namespace Celeste.Mod
         }
 
         // Is it the first normally collectable strawberry in the train?
-        public static bool IsFirstStrawberry(Entity self)
-        {
+        public static bool IsFirstStrawberry(Entity self) {
             Follower follow = self.Components.Get<Follower>();
             if (follow == null)
                 return false;
@@ -114,8 +97,7 @@ namespace Celeste.Mod
             List<RegisteredBerry> berries = registeredBerries.ToList();
             ReadOnlyCollection<Type> types = GetBerryTypes();
 
-            for (int i = follow.FollowIndex - 1; i >= 0; i--)
-            {
+            for (int i = follow.FollowIndex - 1; i >= 0; i--) {
                 Entity strawberry = follow.Leader.Followers[i].Entity;
                 Type t = strawberry.GetType();
                 RegisteredBerry berry = berries.Find(b => b.berryClass == t);
@@ -139,18 +121,16 @@ namespace Celeste.Mod
                 // Did we find a berry closer to the front that doesn't defer?
                 // It must be registered, must NOT block collection, and is NOT a gold berry
                 // in order to be a valid leader.
-                if (types.Contains(strawberry.GetType()) && 
-                    !blocksCollect && 
-                    !goldenCheck)
-                {
+                if (types.Contains(strawberry.GetType()) &&
+                    !blocksCollect &&
+                    !goldenCheck) {
                     return false;
                 }
             }
             return true;
         }
 
-        public class RegisteredBerry
-        {
+        public class RegisteredBerry {
             // The registered berry as a Type
             public readonly Type berryClass;
 
@@ -165,8 +145,7 @@ namespace Celeste.Mod
             // F: berry doesn't have a special collection rule and can be a "leader" of the berry train
             public readonly bool blocksNormalCollection;
 
-            public RegisteredBerry(Type berry, string name, bool track, bool blockCollect)
-            {
+            public RegisteredBerry(Type berry, string name, bool track, bool blockCollect) {
                 berryClass = berry;
                 entityName = name;
                 isTracked = track;

--- a/Celeste.Mod.mm/Mod/Registry/StrawberryRegistry.cs
+++ b/Celeste.Mod.mm/Mod/Registry/StrawberryRegistry.cs
@@ -13,7 +13,11 @@ namespace Celeste.Mod
     /// </summary>
     public static class StrawberryRegistry
     {
-        private static HashSet<RegisteredBerry> registeredBerries = new HashSet<RegisteredBerry>() { new RegisteredBerry(typeof(Strawberry), "strawberry", true, false) };
+        private static HashSet<RegisteredBerry> registeredBerries = new HashSet<RegisteredBerry>() {
+            new RegisteredBerry(typeof(Strawberry), "strawberry", true, false), // red berries
+            new RegisteredBerry(typeof(Strawberry), "goldenBerry", false, true), // golden berries
+            new RegisteredBerry(typeof(Strawberry), "memorialTextController", false, true) // dashless golden berry
+        };
 
         // Caches
         private static ReadOnlyCollection<RegisteredBerry> _getRegisteredBerries;
@@ -40,7 +44,9 @@ namespace Celeste.Mod
             {
                 List<Type> types = new List<Type>();
                 foreach (RegisteredBerry b in registeredBerries)
-                    types.Add(b.berryClass);
+                    if (!types.Contains(b.berryClass)) // enumerate each type once. a berry can have multiple names.
+                        types.Add(b.berryClass);
+
                 _getBerryTypes = types.AsReadOnly();
             }
             return _getBerryTypes;

--- a/Celeste.Mod.mm/MonoModRules.cs
+++ b/Celeste.Mod.mm/MonoModRules.cs
@@ -265,7 +265,8 @@ namespace MonoMod {
             Version version = new Version();
             if (versionString != null) {
                 version = new Version(versionString);
-            } if (versionInts == null || versionInts.Length == 0) {
+            }
+            if (versionInts == null || versionInts.Length == 0) {
                 // ???
             } else if (versionInts.Length == 2) {
                 version = new Version(versionInts[0], versionInts[1]);
@@ -409,8 +410,7 @@ namespace MonoMod {
                 }
 
                 // Strawberry count adjustments
-                if (instr.OpCode == OpCodes.Ldstr && (instr.Operand as string) == "strawberry")
-                {
+                if (instr.OpCode == OpCodes.Ldstr && (instr.Operand as string) == "strawberry") {
                     instr.OpCode = OpCodes.Nop;
                     instrs[instri + 1].Operand = m_TrackableContains;
                     instri++;
@@ -419,8 +419,7 @@ namespace MonoMod {
 
         }
 
-        public static void PatchLevelDataBerryTracker(MethodDefinition method, CustomAttribute attrib)
-        {
+        public static void PatchLevelDataBerryTracker(MethodDefinition method, CustomAttribute attrib) {
             // Our actual target method is the orig_ method.
             method = method.DeclaringType.FindMethod(method.GetID(name: method.GetOriginalName()));
 
@@ -438,8 +437,7 @@ namespace MonoMod {
 
             Mono.Collections.Generic.Collection<Instruction> instrs = method.Body.Instructions;
             ILProcessor il = method.Body.GetILProcessor();
-            for (int instri = 0; instri < instrs.Count; instri++)
-            {
+            for (int instri = 0; instri < instrs.Count; instri++) {
                 Instruction instr = instrs[instri];
 
                 /* 
@@ -453,8 +451,7 @@ namespace MonoMod {
                 */
 
                 // Strawberry tracker adjustments
-                if (instr.OpCode == OpCodes.Ldstr && (instr.Operand as string) == "strawberry")
-                {
+                if (instr.OpCode == OpCodes.Ldstr && (instr.Operand as string) == "strawberry") {
 
                     instr.OpCode = OpCodes.Nop;
                     instrs[instri - 1].OpCode = OpCodes.Nop;
@@ -464,8 +461,7 @@ namespace MonoMod {
             }
         }
 
-        public static void PatchStrawberryTrainCollectionOrder(MethodDefinition method, CustomAttribute attrib)
-        {
+        public static void PatchStrawberryTrainCollectionOrder(MethodDefinition method, CustomAttribute attrib) {
             // Our actual target method is the orig_ method.
             method = method.DeclaringType.FindMethod(method.GetID(name: method.GetOriginalName()));
 
@@ -483,13 +479,11 @@ namespace MonoMod {
 
             Mono.Collections.Generic.Collection<Instruction> instrs = method.Body.Instructions;
             ILProcessor il = method.Body.GetILProcessor();
-            for (int instri = 0; instri < instrs.Count; instri++)
-            {
+            for (int instri = 0; instri < instrs.Count; instri++) {
                 Instruction instr = instrs[instri];
 
                 // Rip out the vanilla code call and replace it with vanilla-considerate code
-                if (instr.OpCode == OpCodes.Callvirt && (instr.Operand as MethodReference)?.GetID().Contains("IsFirstStrawberry") == true)
-                {
+                if (instr.OpCode == OpCodes.Callvirt && (instr.Operand as MethodReference)?.GetID().Contains("IsFirstStrawberry") == true) {
                     instr.OpCode = OpCodes.Call;
                     instr.Operand = m_IsFirst;
                     instri++;
@@ -884,8 +878,7 @@ namespace MonoMod {
 
         }
 
-        public static void PatchHeartGemCollectRoutine(MethodDefinition method, CustomAttribute attrib)
-        {
+        public static void PatchHeartGemCollectRoutine(MethodDefinition method, CustomAttribute attrib) {
             // Our actual target method is the orig_ method.
             method = method.DeclaringType.FindMethod(method.GetID(name: method.GetOriginalName()));
 
@@ -1426,11 +1419,9 @@ namespace MonoMod {
             }
         }
 
-        public static void PatchStrawberryInterface(ICustomAttributeProvider provider, CustomAttribute attrib)
-        {
+        public static void PatchStrawberryInterface(ICustomAttributeProvider provider, CustomAttribute attrib) {
             //MonoModRule.Modder.FindType("Celeste.Mod.IStrawberry");
-            if (IStrawberry == null)
-            {
+            if (IStrawberry == null) {
                 IStrawberry = new InterfaceImplementation(MonoModRule.Modder.FindType("Celeste.Mod.IStrawberry"));
             }
             if (IStrawberry == null)
@@ -1439,8 +1430,7 @@ namespace MonoMod {
             ((TypeDefinition)provider).Interfaces.Add(IStrawberry);
         }
 
-        public static void PatchInterface(MethodDefinition method, CustomAttribute attrib)
-        {
+        public static void PatchInterface(MethodDefinition method, CustomAttribute attrib) {
             MethodAttributes flags = MethodAttributes.Virtual | MethodAttributes.Final | MethodAttributes.NewSlot;
             method.Attributes = method.Attributes | flags;
         }
@@ -1480,7 +1470,7 @@ namespace MonoMod {
             Mono.Collections.Generic.Collection<Instruction> instrs = method.Body.Instructions;
             ILProcessor il = method.Body.GetILProcessor();
             for (int instri = 0; instri < instrs.Count - 8; instri++) {
-                if (instrs[instri].OpCode == OpCodes.Ldc_I4 && (int) instrs[instri].Operand == 175) {
+                if (instrs[instri].OpCode == OpCodes.Ldc_I4 && (int)instrs[instri].Operand == 175) {
                     instrs[instri].OpCode = OpCodes.Ldarg_0;
                     instrs.Insert(instri + 1, il.Create(OpCodes.Ldfld, f_maxStrawberryCount));
                 }
@@ -1492,8 +1482,8 @@ namespace MonoMod {
 
                 if (instrs[instri].OpCode == OpCodes.Ldfld && (instrs[instri].Operand as FieldReference).Name == "SaveData"
                     && instrs[instri + 1].OpCode == OpCodes.Callvirt && (instrs[instri + 1].Operand as MethodReference).Name == "get_TotalHeartGems"
-                    && instrs[instri + 2].OpCode == OpCodes.Ldc_I4_S && (sbyte) instrs[instri + 2].Operand == 16) {
-                    
+                    && instrs[instri + 2].OpCode == OpCodes.Ldc_I4_S && (sbyte)instrs[instri + 2].Operand == 16) {
+
                     instrs[instri].OpCode = OpCodes.Ldfld;
                     instrs[instri].Operand = f_totalHeartGems;
 
@@ -1502,13 +1492,13 @@ namespace MonoMod {
                     instrs[instri + 2].OpCode = OpCodes.Ldfld;
                     instrs[instri + 2].Operand = f_maxCrystalHeartsExcludingCSides;
                 }
-                
-                if (instrs[instri].OpCode == OpCodes.Ldc_I4_S && (sbyte) instrs[instri].Operand == 24) {
+
+                if (instrs[instri].OpCode == OpCodes.Ldc_I4_S && (sbyte)instrs[instri].Operand == 24) {
                     instrs[instri].OpCode = OpCodes.Ldarg_0;
                     instrs.Insert(instri + 1, il.Create(OpCodes.Ldfld, f_maxCrystalHearts));
                 }
-                
-                if (instrs[instri].OpCode == OpCodes.Ldc_I4_S && (sbyte) instrs[instri].Operand == 25) {
+
+                if (instrs[instri].OpCode == OpCodes.Ldc_I4_S && (sbyte)instrs[instri].Operand == 25) {
                     instrs[instri].OpCode = OpCodes.Ldarg_0;
                     instrs.Insert(instri + 1, il.Create(OpCodes.Ldfld, f_maxGoldenStrawberryCount));
                 }
@@ -1534,7 +1524,7 @@ namespace MonoMod {
 
                     }
 
-                    if (instrs[instri + 3].OpCode == OpCodes.Ldc_I4_S && (sbyte) instrs[instri + 3].Operand == 10) {
+                    if (instrs[instri + 3].OpCode == OpCodes.Ldc_I4_S && (sbyte)instrs[instri + 3].Operand == 10) {
                         // remove everything but this
                         instri++;
                         for (int i = 0; i < 8; i++) instrs.RemoveAt(instri);

--- a/Celeste.Mod.mm/Patches/Commands.cs
+++ b/Celeste.Mod.mm/Patches/Commands.cs
@@ -38,6 +38,31 @@ namespace Celeste {
                 Engine.Commands.Log("FILE NOT FOUND");
             }
         }
+        
+        [Command("print_counts", "Prints the max count for cassettes, berries, etc. To be used with a save loaded")]
+        private static void CmdPrintCounts() {
+            if (SaveData.Instance == null) {
+                Engine.Commands.Log("No save loaded!");
+                return;
+            }
 
+            LevelSetStats stats = SaveData.Instance.GetLevelSetStats();
+            Engine.Commands.Log($"** Level Set Stats: {stats.Name} **");
+            Engine.Commands.Log($"Max strawberry count = {stats.MaxStrawberries}");
+            Engine.Commands.Log($"Max golden strawberry count = {stats.MaxGoldenStrawberries}");
+            Engine.Commands.Log($"Max strawberry count including untracked = {stats.MaxStrawberriesIncludingUntracked}");
+            Engine.Commands.Log($"Max cassettes = {stats.MaxCassettes}");
+            Engine.Commands.Log($"Max crystal hearts = {stats.MaxHeartGems}");
+            Engine.Commands.Log($"Max crystal hearts excluding C-sides = {stats.MaxHeartGemsExcludingCSides}");
+            Engine.Commands.Log($"Chapter count = {stats.MaxCompletions}");
+            Engine.Commands.Log("====");
+            Engine.Commands.Log($"Owned strawberries = {stats.TotalStrawberries}");
+            Engine.Commands.Log($"Owned golden strawberries = {stats.TotalGoldenStrawberries}");
+            Engine.Commands.Log($"Owned cassettes = {stats.TotalCassettes}");
+            Engine.Commands.Log($"Owned crystal hearts = {stats.TotalHeartGems}");
+            Engine.Commands.Log($"Completed chapters = {stats.TotalCompletions}");
+            Engine.Commands.Log("====");
+            Engine.Commands.Log($"Completion percent = {stats.CompletionPercent}");
+        }
     }
 }

--- a/Celeste.Mod.mm/Patches/Commands.cs
+++ b/Celeste.Mod.mm/Patches/Commands.cs
@@ -38,7 +38,7 @@ namespace Celeste {
                 Engine.Commands.Log("FILE NOT FOUND");
             }
         }
-        
+
         [Command("print_counts", "Prints the max count for cassettes, berries, etc. To be used with a save loaded")]
         private static void CmdPrintCounts() {
             if (SaveData.Instance == null) {

--- a/Celeste.Mod.mm/Patches/MapData.cs
+++ b/Celeste.Mod.mm/Patches/MapData.cs
@@ -19,6 +19,7 @@ namespace Celeste {
 
         public bool DetectedCassette;
         public int DetectedStrawberriesIncludingUntracked;
+        public List<EntityData> DashlessGoldenberries = new List<EntityData>();
 
         public MapMetaModeProperties Meta {
             get {
@@ -43,11 +44,19 @@ namespace Celeste {
             DetectedHeartGem = false;
             DetectedRemixNotes = false;
             Goldenberries = new List<EntityData>();
+            DashlessGoldenberries = new List<EntityData>();
             DetectedCassette = false;
             DetectedStrawberriesIncludingUntracked = 0;
 
             try {
                 orig_Load();
+
+                foreach (LevelData level in Levels) {
+                    foreach (EntityData entity in level.Entities) {
+                        if (entity.Name == "memorialTextController") // aka "dashless golden"
+                            DashlessGoldenberries.Add(entity);
+                    }
+                }
             } catch (Exception e) {
                 Mod.Logger.Log(LogLevel.Warn, "misc", $"Failed loading MapData {Area}");
                 e.LogDetailed();
@@ -199,5 +208,11 @@ namespace Celeste {
         internal static void SetDetectedStrawberriesIncludingUntracked(this MapData self, int count) {
             ((patch_MapData)self).DetectedStrawberriesIncludingUntracked = count;
         }
+
+        /// <summary>
+        /// Returns the list of dashless goldens in the map.
+        /// </summary>
+        public static List<EntityData> GetDashlessGoldenberries(this MapData self)
+            => ((patch_MapData) self).DashlessGoldenberries;
     }
 }

--- a/Celeste.Mod.mm/Patches/MapData.cs
+++ b/Celeste.Mod.mm/Patches/MapData.cs
@@ -25,8 +25,8 @@ namespace Celeste {
             get {
                 MapMeta metaAll = AreaData.Get(Area).GetMeta();
                 return
-                    (metaAll?.Modes?.Length ?? 0) > (int) Area.Mode ?
-                    metaAll.Modes[(int) Area.Mode] :
+                    (metaAll?.Modes?.Length ?? 0) > (int)Area.Mode ?
+                    metaAll.Modes[(int)Area.Mode] :
                     null;
             }
         }
@@ -81,7 +81,7 @@ namespace Celeste {
         private static BinaryPacker.Element _Process(BinaryPacker.Element root, MapData self) {
             if (self.Area.GetLevelSet() == "Celeste")
                 return root;
-            return ((patch_MapData) self).Process(root);
+            return ((patch_MapData)self).Process(root);
         }
 
         private BinaryPacker.Element Process(BinaryPacker.Element root) {
@@ -89,7 +89,7 @@ namespace Celeste {
                 return root;
 
             // make sure parse meta first, because checkpoint entity needs to read meta
-            if(root.Children.Find(element => element.Name == "meta") is BinaryPacker.Element meta) 
+            if (root.Children.Find(element => element.Name == "meta") is BinaryPacker.Element meta)
                 ProcessMeta(meta);
 
             new MapDataFixup(this).Process(root);
@@ -104,7 +104,7 @@ namespace Celeste {
             if (mode == AreaMode.Normal) {
                 new MapMeta(meta).ApplyTo(area);
                 Area = area.ToKey();
-                
+
                 // Backup A-Side's Metadata. Only back up useful data.
                 area.SetASideAreaDataBackup(new AreaData {
                     IntroType = area.IntroType,
@@ -128,7 +128,7 @@ namespace Celeste {
                 MapMeta mapMeta = new MapMeta(meta) {
                     Modes = area.GetMeta().Modes
                 };
-                area.Mode[(int) mode].SetMapMeta(mapMeta);
+                area.Mode[(int)mode].SetMapMeta(mapMeta);
             }
         }
 
@@ -181,13 +181,13 @@ namespace Celeste {
         /// Get the mod mode metadata of the map.
         /// </summary>
         public static MapMetaModeProperties GetMeta(this MapData self)
-            => ((patch_MapData) self).Meta;
+            => ((patch_MapData)self).Meta;
 
         /// <summary>
         /// Returns whether the map contains a cassette or not.
         /// </summary>
         public static bool GetDetectedCassette(this MapData self)
-            => ((patch_MapData) self).DetectedCassette;
+            => ((patch_MapData)self).DetectedCassette;
 
         /// <summary>
         /// To be called by the CoreMapDataProcessor when a cassette is detected in a map.
@@ -200,7 +200,7 @@ namespace Celeste {
         /// Returns the number of strawberries in the map, including untracked ones (goldens, moons).
         /// </summary>
         public static int GetDetectedStrawberriesIncludingUntracked(this MapData self)
-            => ((patch_MapData) self).DetectedStrawberriesIncludingUntracked;
+            => ((patch_MapData)self).DetectedStrawberriesIncludingUntracked;
 
         /// <summary>
         /// To be called by the CoreMapDataProcessor when processing a map is over, to register the detected berry count.
@@ -213,6 +213,6 @@ namespace Celeste {
         /// Returns the list of dashless goldens in the map.
         /// </summary>
         public static List<EntityData> GetDashlessGoldenberries(this MapData self)
-            => ((patch_MapData) self).DashlessGoldenberries;
+            => ((patch_MapData)self).DashlessGoldenberries;
     }
 }

--- a/Celeste.Mod.mm/Patches/MapData.cs
+++ b/Celeste.Mod.mm/Patches/MapData.cs
@@ -17,6 +17,9 @@ using System.Xml;
 namespace Celeste {
     class patch_MapData : MapData {
 
+        public bool DetectedCassette;
+        public int DetectedStrawberriesIncludingUntracked;
+
         public MapMetaModeProperties Meta {
             get {
                 MapMeta metaAll = AreaData.Get(Area).GetMeta();
@@ -40,6 +43,8 @@ namespace Celeste {
             DetectedHeartGem = false;
             DetectedRemixNotes = false;
             Goldenberries = new List<EntityData>();
+            DetectedCassette = false;
+            DetectedStrawberriesIncludingUntracked = 0;
 
             try {
                 orig_Load();
@@ -169,5 +174,30 @@ namespace Celeste {
         public static MapMetaModeProperties GetMeta(this MapData self)
             => ((patch_MapData) self).Meta;
 
+        /// <summary>
+        /// Returns whether the map contains a cassette or not.
+        /// </summary>
+        public static bool GetDetectedCassette(this MapData self)
+            => ((patch_MapData) self).DetectedCassette;
+
+        /// <summary>
+        /// To be called by the CoreMapDataProcessor when a cassette is detected in a map.
+        /// </summary>
+        internal static void SetDetectedCassette(this MapData self) {
+            ((patch_MapData)self).DetectedCassette = true;
+        }
+
+        /// <summary>
+        /// Returns the number of strawberries in the map, including untracked ones (moons). Does not include goldens.
+        /// </summary>
+        public static int GetDetectedStrawberriesIncludingUntracked(this MapData self)
+            => ((patch_MapData) self).DetectedStrawberriesIncludingUntracked;
+
+        /// <summary>
+        /// To be called by the CoreMapDataProcessor when processing a map is over, to register the detected berry count.
+        /// </summary>
+        internal static void SetDetectedStrawberriesIncludingUntracked(this MapData self, int count) {
+            ((patch_MapData)self).DetectedStrawberriesIncludingUntracked = count;
+        }
     }
 }

--- a/Celeste.Mod.mm/Patches/MapData.cs
+++ b/Celeste.Mod.mm/Patches/MapData.cs
@@ -188,7 +188,7 @@ namespace Celeste {
         }
 
         /// <summary>
-        /// Returns the number of strawberries in the map, including untracked ones (moons). Does not include goldens.
+        /// Returns the number of strawberries in the map, including untracked ones (goldens, moons).
         /// </summary>
         public static int GetDetectedStrawberriesIncludingUntracked(this MapData self)
             => ((patch_MapData) self).DetectedStrawberriesIncludingUntracked;

--- a/Celeste.Mod.mm/Patches/OuiFileSelectSlot.cs
+++ b/Celeste.Mod.mm/Patches/OuiFileSelectSlot.cs
@@ -47,7 +47,7 @@ namespace Celeste {
         }
 
         public extern void orig_Show();
-        public void Show() {
+        public new void Show() {
             // Temporarily set the current save data to the file slot's save data.
             // This enables filtering the areas by the save data's current levelset.
             SaveData prev = SaveData.Instance;
@@ -65,7 +65,7 @@ namespace Celeste {
                 if(stats.Name == "Celeste") {
                     // never mess with vanilla.
                     maxStrawberryCount = 175;
-                    maxGoldenStrawberryCount = 25;
+                    maxGoldenStrawberryCount = 25; // vanilla is wrong (there are 26 including dashless), but don't mess with vanilla.
                     maxStrawberryCountIncludingUntracked = 202;
 
                     maxCassettes = 8;

--- a/Celeste.Mod.mm/Patches/OuiFileSelectSlot.cs
+++ b/Celeste.Mod.mm/Patches/OuiFileSelectSlot.cs
@@ -24,32 +24,97 @@ namespace Celeste {
         private patch_Button NewGameLevelSetButton;
         private string NewGameLevelSet;
 
+        // computed maximums for stamp rendering
+        private int maxStrawberryCount;
+        private int maxGoldenStrawberryCount;
+        private int maxStrawberryCountIncludingUntracked;
+        private int maxCassettes;
+        private int maxCrystalHeartsExcludingCSides;
+        private int maxCrystalHearts;
+
+        private bool summitStamp;
+        private bool farewellStamp;
+
+        private int totalGoldenStrawberries;
+        private int totalHeartGems;
+        private int totalCassettes;
+
+        private bool Golden => !Corrupted && Exists && SaveData.TotalStrawberries >= maxStrawberryCountIncludingUntracked;
+
         public patch_OuiFileSelectSlot(int index, OuiFileSelect fileSelect, SaveData data)
             : base(index, fileSelect, data) {
             // no-op. MonoMod ignores this - we only need this to make the compiler shut up.
         }
 
-        // Patching constructors is ugly.
-        public extern void orig_ctor(int index, OuiFileSelect fileSelect, SaveData data);
-        [MonoModConstructor]
-        public void ctor(int index, OuiFileSelect fileSelect, SaveData data) {
+        public extern void orig_Show();
+        public void Show() {
             // Temporarily set the current save data to the file slot's save data.
             // This enables filtering the areas by the save data's current levelset.
             SaveData prev = SaveData.Instance;
-            SaveData.Instance = data;
+            SaveData.Instance = SaveData;
 
-            orig_ctor(index, fileSelect, data);
-
-            LevelSetStats stats = data?.GetLevelSetStats();
+            LevelSetStats stats = SaveData?.GetLevelSetStats();
 
             if (stats != null) {
                 StrawberriesCounter strawbs = Strawberries;
                 strawbs.Amount = stats.TotalStrawberries;
                 strawbs.OutOf = stats.MaxStrawberries;
                 strawbs.ShowOutOf = stats.Name != "Celeste" || strawbs.OutOf <= 0;
+                strawbs.CanWiggle = false;
+
+                if(stats.Name == "Celeste") {
+                    // never mess with vanilla.
+                    maxStrawberryCount = 175;
+                    maxGoldenStrawberryCount = 25;
+                    maxStrawberryCountIncludingUntracked = 202;
+
+                    maxCassettes = 8;
+                    maxCrystalHeartsExcludingCSides = 16;
+                    maxCrystalHearts = 24;
+
+                    summitStamp = SaveData.Areas[7].Modes[0].Completed;
+                    farewellStamp = SaveData.Areas[10].Modes[0].Completed;
+                } else {
+                    // compute the counts for the current level set.
+                    maxStrawberryCount = stats.MaxStrawberries;
+                    maxGoldenStrawberryCount = stats.MaxGoldenStrawberries;
+                    maxStrawberryCountIncludingUntracked = stats.MaxStrawberriesIncludingUntracked;
+
+                    maxCassettes = stats.MaxCassettes;
+                    maxCrystalHearts = stats.MaxHeartGems;
+                    maxCrystalHeartsExcludingCSides = stats.MaxHeartGemsExcludingCSides;
+
+                    // summit stamp is displayed if we finished all areas that are not interludes. (TotalCompletions filters interludes out.)
+                    summitStamp = stats.TotalCompletions >= stats.MaxCompletions;
+                    farewellStamp = false; // what is supposed to be Farewell in mod campaigns anyway??
+                }
+
+                // save the values from the current level set. They will be patched in instead of SaveData.TotalXX.
+                totalGoldenStrawberries = stats.TotalGoldenStrawberries; // The value saved on the file is global for all level sets.
+                totalHeartGems = stats.TotalHeartGems; // this counts from all level sets. 
+                totalCassettes = stats.TotalCassettes; // this relies on SaveData.Instance.
+                
+                // redo what is done on the constructor. This keeps the area name and stats up-to-date with the latest area.
+                FurthestArea = SaveData.UnlockedAreas;
+                Cassettes.Clear();
+                HeartGems.Clear();
+                foreach (AreaStats areaStats in SaveData.Areas) {
+                    if (areaStats.ID > SaveData.UnlockedAreas) break;
+
+                    if (!AreaData.Areas[areaStats.ID].Interlude && AreaData.Areas[areaStats.ID].CanFullClear) {
+                        bool[] hearts = new bool[3];
+                        for (int i = 0; i < hearts.Length; i++) {
+                            hearts[i] = areaStats.Modes[i].HeartGem;
+                        }
+                        Cassettes.Add(areaStats.Cassette);
+                        HeartGems.Add(hearts);
+                    }
+                }
             }
 
             SaveData.Instance = prev;
+
+            orig_Show();
         }
 
         public extern void orig_CreateButtons();
@@ -131,5 +196,9 @@ namespace Celeste {
             public float Scale = 1f;
         }
 
+
+        [MonoModIgnore] // We don't want to change anything about the method...
+        [PatchFileSelectSlotRender] // ... except for manually manipulating the method via MonoModRules
+        public override extern void Render();
     }
 }

--- a/Celeste.Mod.mm/Patches/OuiFileSelectSlot.cs
+++ b/Celeste.Mod.mm/Patches/OuiFileSelectSlot.cs
@@ -62,7 +62,7 @@ namespace Celeste {
                 strawbs.ShowOutOf = stats.Name != "Celeste" || strawbs.OutOf <= 0;
                 strawbs.CanWiggle = false;
 
-                if(stats.Name == "Celeste") {
+                if (stats.Name == "Celeste") {
                     // never mess with vanilla.
                     maxStrawberryCount = 175;
                     maxGoldenStrawberryCount = 25; // vanilla is wrong (there are 26 including dashless), but don't mess with vanilla.
@@ -93,7 +93,7 @@ namespace Celeste {
                 totalGoldenStrawberries = stats.TotalGoldenStrawberries; // The value saved on the file is global for all level sets.
                 totalHeartGems = stats.TotalHeartGems; // this counts from all level sets. 
                 totalCassettes = stats.TotalCassettes; // this relies on SaveData.Instance.
-                
+
                 // redo what is done on the constructor. This keeps the area name and stats up-to-date with the latest area.
                 FurthestArea = SaveData.UnlockedAreas;
                 Cassettes.Clear();

--- a/Celeste.Mod.mm/Patches/SaveData.cs
+++ b/Celeste.Mod.mm/Patches/SaveData.cs
@@ -512,6 +512,8 @@ namespace Celeste {
                         foreach (EntityID strawb in modeSave.Strawberries) {
                             if (modeData.MapData.Goldenberries.Any(berry => berry.ID == strawb.ID && berry.Level.Name == strawb.Level))
                                 count++;
+                            if (modeData.MapData.GetDashlessGoldenberries().Any(berry => berry.ID == strawb.ID && berry.Level.Name == strawb.Level))
+                                count++;
                         }
                     }
                 }
@@ -571,6 +573,7 @@ namespace Celeste {
                         if (mode == null)
                             continue;
                         count += mode.MapData.Goldenberries.Count;
+                        count += mode.MapData.GetDashlessGoldenberries().Count;
                     }
                 }
                 return count;

--- a/Celeste.Mod.mm/Patches/SaveData.cs
+++ b/Celeste.Mod.mm/Patches/SaveData.cs
@@ -301,19 +301,19 @@ namespace Celeste {
                 int count = AreaData.Areas.Count(other => other.GetLevelSet() == set.Name);
                 // Fix IDs
                 for (int i = 0; i < areas.Count; i++)
-                    ((patch_AreaStats) areas[i]).ID_Unsafe = AreaDataExt.Get(areas[i])?.ID ?? int.MaxValue;
+                    ((patch_AreaStats)areas[i]).ID_Unsafe = AreaDataExt.Get(areas[i])?.ID ?? int.MaxValue;
                 // Sort
-                areas.Sort((a, b) => ((patch_AreaStats) a).ID_Unsafe - ((patch_AreaStats) b).ID_Unsafe);
+                areas.Sort((a, b) => ((patch_AreaStats)a).ID_Unsafe - ((patch_AreaStats)b).ID_Unsafe);
                 // Remove leftovers
-                while (areas.Count > 0 && ((patch_AreaStats) areas[areas.Count - 1]).ID_Unsafe == int.MaxValue)
+                while (areas.Count > 0 && ((patch_AreaStats)areas[areas.Count - 1]).ID_Unsafe == int.MaxValue)
                     areas.RemoveAt(areas.Count - 1);
                 // Fill gaps
                 for (int i = 0; i < count; i++)
-                    if (i >= areas.Count || ((patch_AreaStats) areas[i]).ID_Unsafe != offset + i)
+                    if (i >= areas.Count || ((patch_AreaStats)areas[i]).ID_Unsafe != offset + i)
                         areas.Insert(i, new AreaStats(offset + i));
                 // Resync SIDs
                 for (int i = 0; i < areas.Count; i++)
-                    ((patch_AreaStats) areas[i]).ID_Safe = ((patch_AreaStats) areas[i]).ID_Unsafe;
+                    ((patch_AreaStats)areas[i]).ID_Safe = ((patch_AreaStats)areas[i]).ID_Unsafe;
 
                 int lastCompleted = -1;
                 for (int i = 0; i < count; i++) {
@@ -425,7 +425,7 @@ namespace Celeste {
             }
 
             // Remove any checkpoints which don't exist in the level.
-            ModeProperties mode = AreaData.Get(area).Mode[(int) area.Mode];
+            ModeProperties mode = AreaData.Get(area).Mode[(int)area.Mode];
             if (mode == null) {
                 checkpoints.Clear();
             } else {
@@ -579,7 +579,7 @@ namespace Celeste {
                 return count;
             }
         }
-        
+
         [XmlIgnore]
         public int MaxCassettes {
             get {
@@ -735,7 +735,7 @@ namespace Celeste {
                 value += (MaxCassettes == 0 ? 1 : (float)TotalCassettes / MaxCassettes) * 7f;
                 value += (MaxCompletions == 0 ? 1 : (float)TotalCompletions / MaxCompletions) * 14f;
 
-                return (int) value;
+                return (int)value;
             }
         }
 
@@ -749,12 +749,12 @@ namespace Celeste {
         /// Get the statistics for all level sets.
         /// </summary>
         public static List<LevelSetStats> GetLevelSets(this SaveData self)
-            => ((patch_SaveData) self).LevelSets;
+            => ((patch_SaveData)self).LevelSets;
         /// <summary>
         /// Set the statistics for all level sets.
         /// </summary>
         public static SaveData SetLevelSets(this SaveData self, List<LevelSetStats> value) {
-            ((patch_SaveData) self).LevelSets = value;
+            ((patch_SaveData)self).LevelSets = value;
             return self;
         }
 
@@ -762,19 +762,19 @@ namespace Celeste {
         /// Get the last played level set.
         /// </summary>
         public static string GetLevelSet(this SaveData self)
-            => ((patch_SaveData) self).LevelSet;
+            => ((patch_SaveData)self).LevelSet;
 
         /// <summary>
         /// Get the statistics for the last played level set.
         /// </summary>
         public static LevelSetStats GetLevelSetStats(this SaveData self)
-            => ((patch_SaveData) self).LevelSetStats;
+            => ((patch_SaveData)self).LevelSetStats;
 
         /// <summary>
         /// Get the statistics for a given level set.
         /// </summary>
         public static LevelSetStats GetLevelSetStatsFor(this SaveData self, string name)
-            => ((patch_SaveData) self).GetLevelSetStatsFor(name);
+            => ((patch_SaveData)self).GetLevelSetStatsFor(name);
 
     }
 }

--- a/Celeste.Mod.mm/Patches/SaveData.cs
+++ b/Celeste.Mod.mm/Patches/SaveData.cs
@@ -554,7 +554,7 @@ namespace Celeste {
                         count += mode.MapData.GetDetectedStrawberriesIncludingUntracked();
                     }
                 }
-                return count + MaxGoldenStrawberries;
+                return count;
             }
         }
 
@@ -562,7 +562,7 @@ namespace Celeste {
         public int MaxGoldenStrawberries {
             get {
                 if (Name == "Celeste")
-                    return 25;
+                    return 25; // vanilla is wrong (there are 26 including dashless), but don't mess with vanilla.
 
                 int offset = AreaOffset;
                 int count = 0;


### PR DESCRIPTION
- MonoModRules replacing hardcoded values in the save file slot rendering method, to get correct stamps on mod campaigns
- New attributes on LevelSetStats to get maximum values for many things (cassette count, heart count, golden strawberry count)
- New attributes on MapData to have the total number of berries, including untracked ones, and get if a cassette was detected (much like DetectedHeartGem in vanilla)
- Update tickets each time the save slot is shown, in order to better handle switching between mod campaigns: switching level sets then going back to the file select screen has the slot display the campaign that was just chosen.

If you want to check the computed heart/berry/etc amounts are correct, load a save, switch to a mod campaign and use the `print_counts` command.

Note: the flying golden from ch1 is not counted in TotalGoldenStrawberries or in MaxGoldenStrawberries. This is because it is named memorialTextController instead of goldenBerry, and as such, doesn't get added to MapData.Goldenberries. What should be done to address that?