### PR TITLE
Display mod berries on debug map

### DIFF
--- a/Celeste.Mod.mm/Celeste.Mod.mm.csproj
+++ b/Celeste.Mod.mm/Celeste.Mod.mm.csproj
@@ -166,6 +166,7 @@
     <Compile Include="Mod\UI\OuiDependencyDownloader.cs" />
     <Compile Include="Mod\UI\OuiHelper_ChapterSelect_Reload.cs" />
     <Compile Include="Mod\UI\OuiModUpdateList.cs" />
+    <Compile Include="Patches\LevelTemplate.cs" />
     <Compile Include="Patches\MountainModel.cs" />
     <Compile Include="Patches\MTN.cs" />
     <Compile Include="Patches\ObjModel.cs" />

--- a/Celeste.Mod.mm/Patches/LevelTemplate.cs
+++ b/Celeste.Mod.mm/Patches/LevelTemplate.cs
@@ -1,0 +1,15 @@
+﻿using MonoMod;
+
+namespace Celeste.Editor {
+    class patch_LevelTemplate : LevelTemplate {
+        public patch_LevelTemplate(LevelData data)
+            : base(data) {
+            // no-op. MonoMod ignores this - we only need this to make the compiler shut up.
+        }
+
+        [MonoModConstructor]
+        [MonoModIgnore] // we don't want to change anything in the method...
+        [PatchTrackableStrawberryCheck] // except manipulating it with MonoModRules
+        public extern void ctor(LevelData data);
+    }
+}

--- a/Celeste.Mod.mm/Patches/MapData.cs
+++ b/Celeste.Mod.mm/Patches/MapData.cs
@@ -36,7 +36,9 @@ namespace Celeste {
             // no-op. MonoMod ignores this - we only need this to make the compiler shut up.
         }
 
+        [PatchTrackableStrawberryCheck]
         private extern void orig_Load();
+
         [PatchMapDataLoader] // Manually manipulate the method via MonoModRules
         private void Load() {
             // reset those fields to prevent them from stacking up when reloading the map.


### PR DESCRIPTION
This aims to solve one of the last things remaining in issue #83. This was low priority, but pretty simple to do.

![image](https://user-images.githubusercontent.com/52103563/72687855-4f9ec500-3b02-11ea-9b8b-089c2f3ffd31.png)
(strawberries 0 and 1 are glass berries, strawberry 2 is vanilla and strawberry 3 is a diagonal dash winged strawberry from Spring Collab 2020.)