### PR TITLE
Merge pull request #97 from max4805/mod_loading_error_on_main_menu

### DIFF
--- a/Celeste.Mod.mm/Celeste.Mod.mm.csproj
+++ b/Celeste.Mod.mm/Celeste.Mod.mm.csproj
@@ -163,6 +163,7 @@
     <Compile Include="Mod\Registry\IStrawberrySeeded.cs" />
     <Compile Include="Mod\Registry\StrawberryRegistry.cs" />
     <Compile Include="Mod\UI\AutoModUpdater.cs" />
+    <Compile Include="Mod\UI\MainMenuModOptionsButton.cs" />
     <Compile Include="Mod\UI\OuiDependencyDownloader.cs" />
     <Compile Include="Mod\UI\OuiHelper_ChapterSelect_Reload.cs" />
     <Compile Include="Mod\UI\OuiModUpdateList.cs" />

--- a/Celeste.Mod.mm/Content/Dialog/English.txt
+++ b/Celeste.Mod.mm/Content/Dialog/English.txt
@@ -28,6 +28,9 @@
 	MENU_MAPLIST= 			Map List
 	MENU_MODOPTIONS= 		Mod Options
 	MENU_PAUSE_MODOPTIONS= 	Mod Options
+	
+	MENU_MODOPTIONS_ONE_MOD_FAILEDTOLOAD=		1 mod failed to load
+	MENU_MODOPTIONS_MULTIPLE_MODS_FAILEDTOLOAD=	{0} mods failed to load
 
 # Mod Options
 	MODOPTIONS_TITLE= 										EVEREST

--- a/Celeste.Mod.mm/Content/Dialog/French.txt
+++ b/Celeste.Mod.mm/Content/Dialog/French.txt
@@ -10,6 +10,9 @@
 	MENU_MAPLIST= 			Liste des maps
 	MENU_MODOPTIONS= 		Options des mods
 	MENU_PAUSE_MODOPTIONS= 	Options des mods
+	
+	MENU_MODOPTIONS_ONE_MOD_FAILEDTOLOAD=		1 mod n'a pas pu être chargé
+	MENU_MODOPTIONS_MULTIPLE_MODS_FAILEDTOLOAD=	{0} mods n'ont pas pu être chargés
 
 # Mod Options
 	MODOPTIONS_TITLE= 										EVEREST

--- a/Celeste.Mod.mm/Mod/Core/CoreModule.cs
+++ b/Celeste.Mod.mm/Mod/Core/CoreModule.cs
@@ -175,7 +175,7 @@ namespace Celeste.Mod.Core {
             else
                 index = buttons.Count - 1;
 
-            buttons.Insert(index, new MainMenuSmallButton("menu_modoptions", "menu/modoptions_new", menu, Vector2.Zero, Vector2.Zero, () => {
+            buttons.Insert(index, new MainMenuModOptionsButton("menu_modoptions", "menu/modoptions_new", menu, Vector2.Zero, Vector2.Zero, () => {
                 Audio.Play(SFX.ui_main_button_select);
                 Audio.Play(SFX.ui_main_whoosh_large_in);
                 menu.Overworld.Goto<OuiModOptions>();

--- a/Celeste.Mod.mm/Mod/UI/MainMenuModOptionsButton.cs
+++ b/Celeste.Mod.mm/Mod/UI/MainMenuModOptionsButton.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.Xna.Framework;
+using Monocle;
+using System;
+
+namespace Celeste.Mod.UI {
+    class MainMenuModOptionsButton : MainMenuSmallButton {
+        private string subText;
+
+        public override float ButtonHeight {
+            get {
+                if (subText == null)
+                    return ActiveFont.LineHeight * 1.25f;
+
+                return ActiveFont.LineHeight * 1.75f;
+            }
+        }
+
+        public MainMenuModOptionsButton(string labelName, string iconName, Oui oui, Vector2 targetPosition, Vector2 tweenFrom, Action onConfirm)
+            : base(labelName, iconName, oui, targetPosition, tweenFrom, onConfirm) {
+
+            int delayedModCount = Everest.Loader.Delayed.Count;
+            if (delayedModCount > 1) {
+                subText = string.Format(Dialog.Get("MENU_MODOPTIONS_MULTIPLE_MODS_FAILEDTOLOAD"), delayedModCount);
+            } else if (delayedModCount == 1) {
+                subText = Dialog.Clean("MENU_MODOPTIONS_ONE_MOD_FAILEDTOLOAD");
+            } else {
+                subText = null;
+            }
+        }
+
+        public override void Render() {
+            base.Render();
+
+            if (subText != null) {
+                Vector2 offset = new Vector2(Ease.CubeInOut(this.GetEase()) * 32f, this.GetWiggler().Value * 8f);
+                ActiveFont.DrawOutline(subText, Position + offset + new Vector2(84f, 84f), new Vector2(0f, 0.5f), Vector2.One * 0.6f, Color.OrangeRed, 2f, Color.Black);
+            }
+        }
+    }
+}

--- a/Celeste.Mod.mm/Patches/MainMenuSmallButton.cs
+++ b/Celeste.Mod.mm/Patches/MainMenuSmallButton.cs
@@ -3,6 +3,7 @@
 using Celeste.Mod;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
+using Monocle;
 using MonoMod;
 using System;
 using System.Collections.Generic;
@@ -13,6 +14,15 @@ using System.Xml;
 
 namespace Celeste {
     class patch_MainMenuSmallButton : MainMenuSmallButton {
+
+#pragma warning disable CS0649 // field is never assigned: it is in vanilla code
+        private float ease;
+        private Wiggler wiggler;
+#pragma warning restore CS0649
+
+        // expose these fields to extending classes.
+        public float Ease => ease;
+        public Wiggler Wiggler => wiggler;
 
         public string LabelName;
         public string IconName;
@@ -48,6 +58,13 @@ namespace Celeste {
         /// </summary>
         public static string GetIconName(this MainMenuSmallButton self)
             => ((patch_MainMenuSmallButton) self).IconName;
+
+        public static float GetEase(this MainMenuSmallButton self) {
+            return ((patch_MainMenuSmallButton) self).Ease;
+        }
+        public static Wiggler GetWiggler(this MainMenuSmallButton self) {
+            return ((patch_MainMenuSmallButton) self).Wiggler;
+        }
 
     }
 }

--- a/Celeste.Mod.mm/Patches/OuiMainMenu.cs
+++ b/Celeste.Mod.mm/Patches/OuiMainMenu.cs
@@ -85,10 +85,23 @@ namespace Celeste {
                     rows[iy] = new List<MenuButton>();
                 }
 
+                // shift Debug before Credits if we find both of these.
+                List<MenuButton> switchedAroundButtons = new List<MenuButton>(buttons);
+                int debugOptionIndex = findButtonIndex("menu_debug", "menu/options");
+                int creditsOptionIndex = findButtonIndex("menu_credits", "menu/credits");
+                if(debugOptionIndex != -1 && creditsOptionIndex != -1) {
+                    MenuButton debugButton = switchedAroundButtons[debugOptionIndex];
+                    switchedAroundButtons.RemoveAt(debugOptionIndex);
+                    if (creditsOptionIndex > debugOptionIndex) {
+                        creditsOptionIndex--;
+                    }
+                    switchedAroundButtons.Insert(creditsOptionIndex, debugButton);
+                }
+
                 int x = 0;
                 int y = 0;
-                for (int i = 0; i < buttons.Count; i++) {
-                    MenuButton button = buttons[i];
+                for (int i = 0; i < switchedAroundButtons.Count; i++) {
+                    MenuButton button = switchedAroundButtons[i];
 
                     Vector2 pos = startPos + itemSize * new Vector2(x, y);
 
@@ -171,6 +184,15 @@ namespace Celeste {
                 }
             }
 
+        }
+
+        private int findButtonIndex(string labelName, string iconName) {
+            return buttons.FindIndex(_ => {
+                MainMenuSmallButton other = (_ as MainMenuSmallButton);
+                if (other == null)
+                    return false;
+                return other.GetLabelName() == labelName && other.GetIconName() == iconName;
+            });
         }
 
         [MonoModReplace]


### PR DESCRIPTION
This aims to make mod loading errors more visible, directly from the main menu. This will help prevent users from wondering why map X doesn't appear anywhere in chapter select if a dependency is missing and they don't think about checking Mod Options.

How it looks in vanilla menu mode:
![image](https://user-images.githubusercontent.com/52103563/72750557-7e2da600-3bbd-11ea-9147-8eb699a43f3c.png)

How it looks in rows menu mode (I changed the Debug option position so that the extra text is on the bottom of the grid, hope that's okay):
![image](https://user-images.githubusercontent.com/52103563/72750580-8e458580-3bbd-11ea-9b8e-341aae54a2c8.png)

The extra text wiggles with the Mod Options text when the option is (un)focused.