### PR TITLE
Speed up the map list animation if many mods are installed

### DIFF
--- a/Celeste.Mod.mm/Mod/UI/OuiMapList.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiMapList.cs
@@ -151,17 +151,22 @@ namespace Celeste.Mod.UI {
                 items.Add(button);
             }
 
+            // compute a delay so that options don't take more than a second to show up if many mods are installed.
+            float delayBetweenOptions = 0.03f;
+            if (items.Count > 0)
+                delayBetweenOptions = Math.Min(0.03f, 1f / items.Count);
+
             // Do this afterwards as the menu has now properly updated its size.
             for (int i = 0; i < items.Count; i++)
-                Add(new Coroutine(FadeIn(i, items[i])));
+                Add(new Coroutine(FadeIn(i, delayBetweenOptions, items[i])));
 
             if (menu.Height > menu.ScrollableMinSize) {
                 menu.Position.Y = menu.ScrollTargetY;
             }
         }
 
-        private IEnumerator FadeIn(int i, TextMenuExt.IItemExt item) {
-            yield return 0.03f * i;
+        private IEnumerator FadeIn(int i, float delayBetweenOptions, TextMenuExt.IItemExt item) {
+            yield return delayBetweenOptions * i;
             float ease = 0f;
 
             Vector2 offset = item.Offset;


### PR DESCRIPTION
Some people on Discord reported that the map list (Escape on chapter select) can take time to "load" if there are many maps installed. That's actually the animation taking too long, and if you have an insane setup like mine, you can wait up to 4.5 seconds to get the list to display.

Here is ~~yet another~~ small tweak to ensure the animation won't take more than 1 second no matter what.