### PR TITLE
Fix Ctrl-F5 and updating on linux

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Updater.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Updater.cs
@@ -372,21 +372,17 @@ namespace Celeste.Mod {
                     if (Type.GetType("Mono.Runtime") != null) {
                         installer.StartInfo.FileName = "mono";
                         installer.StartInfo.Arguments = $"\"{installerPath}\"";
-                        if (File.Exists("/bin/bash")) {
-                            installer.StartInfo.FileName = "/bin/bash";
-                            installer.StartInfo.Arguments = $"-c \"cd '{extractedPath}'; unset MONO_PATH LD_LIBRARY_PATH LC_ALL MONO_CONFIG; /usr/bin/mono MiniInstaller.exe &> log.txt\"";
+                        if (File.Exists("/bin/sh")) {
+                            installer.StartInfo.FileName = "/bin/sh";
+                            installer.StartInfo.Arguments = $"-c \"unset MONO_PATH LD_LIBRARY_PATH LC_ALL MONO_CONFIG; mono MiniInstaller.exe\"";
                         }
                     }
                     installer.StartInfo.WorkingDirectory = extractedPath;
                     if (Environment.OSVersion.Platform == PlatformID.Unix) {
                         installer.StartInfo.UseShellExecute = false;
-                        installer.StartInfo.RedirectStandardOutput = true;
-                        installer.OutputDataReceived += (sender, args) => progress.LogLine(args.Data);
                         installer.Start();
-                        progress.LogLine("Patching the game in-place...");
-                        installer.BeginOutputReadLine();
-                        installer.WaitForExit();
-                        progress.LogLine("Finished update, restarting...");
+                        progress.LogLine("Patching the game in-place");
+                        progress.LogLine("Restarting");
                     } else {
                         installer.Start();
                     }

--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -608,11 +608,8 @@ namespace Celeste.Mod {
                 Thread offspring = new Thread(() => {
                     Process game = new Process();
                     // If the game was installed via Steam, it should restart in a Steam context on its own.
-                    if (Environment.OSVersion.Platform == PlatformID.Unix ||
-                        Environment.OSVersion.Platform == PlatformID.MacOSX) {
-                        // The Linux and macOS versions come with a wrapping bash script.
-                        game.StartInfo.FileName = Path.Combine(PathGame, "Celeste");
-                    } else {
+                    if (!(Environment.OSVersion.Platform == PlatformID.Unix ||
+                        Environment.OSVersion.Platform == PlatformID.MacOSX)) {
                         game.StartInfo.FileName = Path.Combine(PathGame, "Celeste.exe");
                     }
                     game.StartInfo.WorkingDirectory = PathGame;
@@ -621,6 +618,15 @@ namespace Celeste.Mod {
                 offspring.Start();
                 patch_Audio.System?.release();
             };
+
+            // Unix-likes can just fork-and-die to start the new game
+            if (Environment.OSVersion.Platform == PlatformID.Unix ||
+                Environment.OSVersion.Platform == PlatformID.MacOSX) {
+                Logger.Log(LogLevel.Info, "info", Path.Combine(PathGame, "Celeste"));
+                Process fork = new Process();
+                fork.StartInfo.FileName = Path.Combine(PathGame, "Celeste");
+                fork.Start();
+            }
 
             Engine.Instance.Exit();
 


### PR DESCRIPTION
Unix-likes now fork-and-die when quick-restarted, and now clean env
variables left over by mono in between downloading the update and running
the installer.