### PR TITLE
Add deathCount attribute to Dialog Cutscene and xOnly/yOnly to Smooth Camera Offset

### DIFF
--- a/Celeste.Mod.mm/Mod/Entities/DialogCutsceneTrigger.cs
+++ b/Celeste.Mod.mm/Mod/Entities/DialogCutsceneTrigger.cs
@@ -9,19 +9,25 @@ namespace Celeste.Mod.Entities {
         private EntityID id;
         private bool onlyOnce;
         private bool endLevel;
+        private int deathCount;
 
         public DialogCutsceneTrigger(EntityData data, Vector2 offset, EntityID entId)
             : base(data, offset) {
             dialogEntry = data.Attr("dialogId");
             onlyOnce = data.Bool("onlyOnce", true);
             endLevel = data.Bool("endLevel", false);
+            deathCount = data.Int("deathCount", -1);
             triggered = false;
             id = entId;
         }
 
         public override void OnEnter(Player player) {
-            if (triggered || (Scene as Level).Session.GetFlag("DoNotLoad" + id))
+            if (triggered || (Scene as Level).Session.GetFlag("DoNotLoad" + id) ||
+                (deathCount >= 0 && SceneAs<Level>().Session.DeathsInCurrentLevel != deathCount)) {
+
                 return;
+            }
+
             triggered = true;
 
             Scene.Add(new DialogCutscene(dialogEntry, player, endLevel));

--- a/Celeste.Mod.mm/Mod/Entities/SmoothCameraOffsetTrigger.cs
+++ b/Celeste.Mod.mm/Mod/Entities/SmoothCameraOffsetTrigger.cs
@@ -17,6 +17,8 @@ namespace Celeste.Mod.Entities {
         private Vector2 offsetTo;
         private PositionModes positionMode;
         private bool onlyOnce;
+        private bool xOnly;
+        private bool yOnly;
 
         public SmoothCameraOffsetTrigger(EntityData data, Vector2 offset) : base(data, offset) {
             // parse the trigger attributes. Multiplying X dimensions by 48 and Y ones by 32 replicates the vanilla offset trigger behavior.
@@ -24,11 +26,19 @@ namespace Celeste.Mod.Entities {
             offsetTo = new Vector2(data.Float("offsetXTo") * 48f, data.Float("offsetYTo") * 32f);
             positionMode = data.Enum<PositionModes>("positionMode");
             onlyOnce = data.Bool("onlyOnce");
+            xOnly = data.Bool("xOnly");
+            yOnly = data.Bool("yOnly");
         }
 
         public override void OnStay(Player player) {
             base.OnStay(player);
-            SceneAs<Level>().CameraOffset = Vector2.Lerp(offsetFrom, offsetTo, GetPositionLerp(player, positionMode));
+
+            if (!yOnly) {
+                SceneAs<Level>().CameraOffset.X = MathHelper.Lerp(offsetFrom.X, offsetTo.X, GetPositionLerp(player, positionMode));
+            }
+            if (!xOnly) {
+                SceneAs<Level>().CameraOffset.Y = MathHelper.Lerp(offsetFrom.Y, offsetTo.Y, GetPositionLerp(player, positionMode));
+            }
         }
 
         public override void OnLeave(Player player) {


### PR DESCRIPTION
Those attributes were requested for the Spring Collab, respectively by fishtank_overflow and NeoKat. 

- deathCount on Dialog Cutscene Trigger: works the same way as deathCount on Minitextbox Trigger. Specify a non-negative number of deaths, and the cutscene will only trigger when this number of deaths is exactly reached. Defaults to -1 (don't take death count into account).
- xOnly and yOnly on Smooth Camera Offset Trigger: if enabled, the trigger will only affect one axis. The attribute names were stolen from Camera Target Trigger. Default to false to match the current behavior.

Grouping both in the same PR to avoid multiplying reviews / Everest updates, since those are minor edits.