### PR TITLE
Make TotalHeartGems "campaign-local" and patch some usages of it

### DIFF
--- a/Celeste.Mod.mm/Celeste.Mod.mm.csproj
+++ b/Celeste.Mod.mm/Celeste.Mod.mm.csproj
@@ -193,6 +193,7 @@
     <Compile Include="Patches\Maddy3D.cs" />
     <Compile Include="Patches\ModeProperties.cs" />
     <Compile Include="Patches\MountainRenderer.cs" />
+    <Compile Include="Patches\OuiJournalGlobal.cs" />
     <Compile Include="Patches\Pathfinder.cs" />
     <Compile Include="Patches\CheckpointData.cs" />
     <Compile Include="Patches\SlashFx.cs" />

--- a/Celeste.Mod.mm/Patches/HeartGem.cs
+++ b/Celeste.Mod.mm/Patches/HeartGem.cs
@@ -61,5 +61,8 @@ namespace Celeste {
             return value;
         }
 
+        [MonoModIgnore] // don't change anything in the method...
+        [PatchTotalHeartGemChecks] // except for replacing TotalHeartGems with TotalHeartGemsInVanilla through MonoModRules
+        private extern void RegisterAsCollected(Level level, string poemID);
     }
 }

--- a/Celeste.Mod.mm/Patches/OuiFileSelectSlot.cs
+++ b/Celeste.Mod.mm/Patches/OuiFileSelectSlot.cs
@@ -46,6 +46,11 @@ namespace Celeste {
             // no-op. MonoMod ignores this - we only need this to make the compiler shut up.
         }
 
+        [MonoModConstructor]
+        [MonoModIgnore] // don't change anything in the method...
+        [PatchTotalHeartGemChecks] // except for replacing TotalHeartGems with TotalHeartGemsInVanilla through MonoModRules
+        public extern void ctor(int index, OuiFileSelect fileSelect, SaveData data);
+
         public extern void orig_Show();
         public new void Show() {
             // Temporarily set the current save data to the file slot's save data.

--- a/Celeste.Mod.mm/Patches/OuiJournalGlobal.cs
+++ b/Celeste.Mod.mm/Patches/OuiJournalGlobal.cs
@@ -1,0 +1,16 @@
+using MonoMod;
+
+namespace Celeste {
+    class patch_OuiJournalGlobal : OuiJournalGlobal {
+        public patch_OuiJournalGlobal(OuiJournal journal)
+            : base(journal) {
+            // no-op. MonoMod ignores this - we only need this to make the compiler shut up.
+        }
+
+        [MonoModConstructor]
+        [MonoModIgnore] // don't change anything in the method...
+        [PatchOuiJournalStatsHeartGemCheck] // except for replacing TotalHeartGems with TotalHeartGemsInVanilla through MonoModRules
+        public extern void ctor(OuiJournal journal);
+
+    }
+}

--- a/Celeste.Mod.mm/Patches/OverworldLoader.cs
+++ b/Celeste.Mod.mm/Patches/OverworldLoader.cs
@@ -6,6 +6,7 @@ using Microsoft.Xna.Framework;
 using Monocle;
 using MonoMod;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -45,5 +46,12 @@ namespace Celeste {
             }
         }
 
+        [MonoModIgnore] // don't change anything in the method...
+        [PatchTotalHeartGemChecks] // except for replacing TotalHeartGems with TotalHeartGemsInVanilla through MonoModRules
+        private extern void CheckVariantsPostcardAtLaunch();
+
+        [MonoModIgnore] // don't change anything in the method...
+        [PatchTotalHeartGemChecksInRoutine] // except for replacing TotalHeartGems with TotalHeartGemsInVanilla through MonoModRules
+        private extern IEnumerator Routine(Session session);
     }
 }

--- a/Celeste.Mod.mm/Patches/SaveData.cs
+++ b/Celeste.Mod.mm/Patches/SaveData.cs
@@ -119,6 +119,15 @@ namespace Celeste {
             }
         }
 
+        // Make TotalHeartGems return the crystal heart count for the current level set, like TotalStrawberries does.
+        public new int TotalHeartGems {
+            [MonoModReplace]
+            get {
+                return LevelSetStats.TotalHeartGems;
+            }
+        }
+
+        public int TotalHeartGemsInVanilla => GetLevelSetStatsFor("Celeste").TotalHeartGems;
 
         [MonoModLinkFrom("System.Collections.Generic.List`1<Celeste.AreaStats> Celeste.SaveData::Areas_Unsafe")]
         public new List<AreaStats> Areas;


### PR DESCRIPTION
Getting 3 hearts in vanilla and 1 in some mod campaign allowed to enter Core... that felt _wrong_.

This PR aims at making `TotalHeartGems` only count crystal hearts for the current campaign, and also creates another property named `TotalHeartGemsInVanilla`, to be used in some cases when considering vanilla crystal hearts only makes more sense.

**`TotalHeartGems` usages:**
- `HeartGemDoor.HeartGems`: number of hearts collected to the heart doors' point of view. We want the heart count for the campaign here
- `AutoSplitterInfo.Update`: info for the auto-splitter...? We certainly want to keep the heart count for the active campaign here.
- `Commands.CmdHearts`: just displays the total heart count in the console. Unsure we care about that enough to patch it to something else as the heart count for the current mod campaign?
- `SaveData.CompletionPercent`: used to compute the completion percent for a campaign. Of course we want the heart count for the campaign here

**`TotalHeartGemsInVanilla` usages:**
- `OverworldLoader.CheckVariantsPostcardAtLaunch`: checks for 24 hearts on startup to unlock variants
- `OverworldLoader.Routine`: checks for 24 hearts upon exiting a level to unlock variants
- `HeartGem.RegisterAsCollected`: checks for 24 hearts to unlock the C-Sides achievement
- `OuiFileSelectSlot constructor`: checks for 24 hearts, again, to unlock variants

Another usage for `TotalHeartGems` was replaced with a check on `UnlockedModes`: this is used in the `OuiJournalGlobal` class to display or hide the "Total Golden Strawberries" row in the global Steam stats, only if goldens are unlocked (more than 16 heart gems). (Note: I got someone to send me an itch.io Celeste.exe long, long ago, and yes, `OuiJournalGlobal` is in this version as well. The journal page is just hidden.)

