### PR TITLE
Implement Decal Registry

### DIFF
--- a/Celeste.Mod.mm/Celeste.Mod.mm.csproj
+++ b/Celeste.Mod.mm/Celeste.Mod.mm.csproj
@@ -159,6 +159,7 @@
     <Compile Include="Mod\Entities\TriggerSpikesOriginal.cs" />
     <Compile Include="Mod\Helpers\EndUserException.cs" />
     <Compile Include="Mod\Helpers\SafeRoutine.cs" />
+    <Compile Include="Mod\Registry\DecalRegistry.cs" />
     <Compile Include="Mod\Registry\IStrawberry.cs" />
     <Compile Include="Mod\Registry\IStrawberrySeeded.cs" />
     <Compile Include="Mod\Registry\StrawberryRegistry.cs" />

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Content.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Content.cs
@@ -37,6 +37,7 @@ namespace Celeste.Mod {
     public sealed class AssetTypeBank { private AssetTypeBank() { } }
     public sealed class AssetTypeGUIDs { private AssetTypeGUIDs() { } }
     public sealed class AssetTypeAhorn { private AssetTypeAhorn() { } }
+    public sealed class AssetTypeDecalRegistry { private AssetTypeDecalRegistry() { } }
 
     // Delegate types.
     public delegate string TypeGuesser(string file, out Type type, out string format);
@@ -618,6 +619,10 @@ namespace Celeste.Mod {
                     file = file.Substring(0, file.Length - (file.EndsWith(".yaml") ? 5 : 4));
                     format = ".yml";
 
+                } else if (file == "DecalRegistry.xml") {
+                    Logger.Log("Decal Registry", "found DecalRegistry.xml");
+                    type = typeof(AssetTypeDecalRegistry);
+                    file = file.Substring(0, file.Length - 4);
                 } else if (file.EndsWith(".yaml")) {
                     type = typeof(AssetTypeYaml);
                     file = file.Substring(0, file.Length - 5);
@@ -750,7 +755,13 @@ namespace Celeste.Mod {
                         // It isn't known if the reloaded xml is part of the currently loaded level.
                         // Let's reload just to be safe.
                         AssetReloadHelper.ReloadLevel();
-
+                    } else if (next.Type == typeof(AssetTypeDecalRegistry)) {
+                        string fileContents;
+                        using (StreamReader reader = new StreamReader(next.Stream)) {
+                            fileContents = reader.ReadToEnd();
+                        }
+                        DecalRegistry.ReadDecalRegistryXml(fileContents);
+                        AssetReloadHelper.ReloadLevel();
                     } else if (next.Type == typeof(AssetTypeDialog) || next.Type == typeof(AssetTypeDialogExport)) {
                         AssetReloadHelper.Do($"Reloading dialog: {name}", () => {
                             Dialog.LoadLanguage(Path.Combine(PathContentOrig, path + ".txt"));

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Events.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Events.cs
@@ -20,6 +20,7 @@ using _OuiMainMenu = Celeste.OuiMainMenu;
 using _Level = Celeste.Level;
 using _Player = Celeste.Player;
 using _OuiJournal = Celeste.OuiJournal;
+using _Decal = Celeste.Decal;
 
 namespace Celeste.Mod {
     public static partial class Everest {
@@ -140,6 +141,13 @@ namespace Celeste.Mod {
                 public static event EnterHandler OnEnter;
                 internal static void Enter(_OuiJournal journal, Oui from)
                     => OnEnter?.Invoke(journal, from);
+            }
+
+            public static class Decal {
+                public delegate void DecalRegistryHandler(_Decal decal, DecalRegistry.DecalInfo decalInfo);
+                public static event DecalRegistryHandler OnHandleDecalRegistry;
+                internal static void HandleDecalRegistry(_Decal decal, DecalRegistry.DecalInfo decalInfo)
+                    => OnHandleDecalRegistry?.Invoke(decal, decalInfo);
             }
 
         }

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
@@ -177,6 +177,16 @@ namespace Celeste.Mod {
                             }
                             continue;
                         }
+                        if (entry.FileName == "DecalRegistry.xml") {
+                            using (MemoryStream stream = entry.ExtractStream())
+                            using (StreamReader reader = new StreamReader(stream)) {
+                                try {
+                                    DecalRegistry.ReadXml(reader.ReadToEnd());
+                                } catch (Exception e) {
+                                    Logger.Log(LogLevel.Warn, "loader", $"Failed parsing DecalRegistry.xml in {archive}: {e}");
+                                }
+                            }
+                        }
                         if (entry.FileName == "icon.png") {
                             using (Stream stream = entry.ExtractStream())
                                 icon = Texture2D.FromStream(Celeste.Instance.GraphicsDevice, stream);
@@ -276,6 +286,14 @@ namespace Celeste.Mod {
                             Logger.Log(LogLevel.Warn, "loader", $"Failed parsing everest.yaml in {dir}: {e}");
                         }
                     }
+                string decalRegistryPath = Path.Combine(dir, "decalRegistry.xml");
+                if (File.Exists(decalRegistryPath)) {
+                    try {
+                        DecalRegistry.ReadXml(File.ReadAllText(decalRegistryPath));
+                    } catch (Exception e) {
+                        Logger.Log(LogLevel.Warn, "loader", $"Failed parsing DecalRegistry.xml in {dir}: {e}");
+                    }
+                }
 
                 FileSystemModContent contentMeta = new FileSystemModContent(dir);
                 EverestModuleMetadata contentMetaParent = null;

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
@@ -177,16 +177,6 @@ namespace Celeste.Mod {
                             }
                             continue;
                         }
-                        if (entry.FileName == "DecalRegistry.xml") {
-                            using (MemoryStream stream = entry.ExtractStream())
-                            using (StreamReader reader = new StreamReader(stream)) {
-                                try {
-                                    DecalRegistry.ReadXml(reader.ReadToEnd());
-                                } catch (Exception e) {
-                                    Logger.Log(LogLevel.Warn, "loader", $"Failed parsing DecalRegistry.xml in {archive}: {e}");
-                                }
-                            }
-                        }
                         if (entry.FileName == "icon.png") {
                             using (Stream stream = entry.ExtractStream())
                                 icon = Texture2D.FromStream(Celeste.Instance.GraphicsDevice, stream);
@@ -286,14 +276,6 @@ namespace Celeste.Mod {
                             Logger.Log(LogLevel.Warn, "loader", $"Failed parsing everest.yaml in {dir}: {e}");
                         }
                     }
-                string decalRegistryPath = Path.Combine(dir, "decalRegistry.xml");
-                if (File.Exists(decalRegistryPath)) {
-                    try {
-                        DecalRegistry.ReadXml(File.ReadAllText(decalRegistryPath));
-                    } catch (Exception e) {
-                        Logger.Log(LogLevel.Warn, "loader", $"Failed parsing DecalRegistry.xml in {dir}: {e}");
-                    }
-                }
 
                 FileSystemModContent contentMeta = new FileSystemModContent(dir);
                 EverestModuleMetadata contentMetaParent = null;

--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -402,6 +402,8 @@ namespace Celeste.Mod {
             foreach (EverestModule mod in _Modules)
                 mod.Initialize();
             _Initialized = true;
+
+            DecalRegistry.LoadDecalRegistry();
         }
 
         /// <summary>

--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistry.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistry.cs
@@ -1,0 +1,135 @@
+﻿using Microsoft.Xna.Framework;
+using Monocle;
+using System.Collections.Generic;
+using System.IO;
+using System.Xml;
+
+namespace Celeste.Mod {
+    /// <summary>
+    /// Allows custom decals to have properties that are otherwise hardcoded, such as reflections, parallax, etc.
+    /// </summary>
+    public static class DecalRegistry {
+
+        public static Dictionary<string, DecalInfo> RegisteredDecals = new Dictionary<string, DecalInfo>() {
+
+        };
+        
+        /// <summary>
+        /// Reads a DecalRegistry.xml file
+        /// </summary>
+        public static void ReadXml(string fileContents) {
+            //XmlElement file = Calc.LoadXML(path)["decals"];
+            XmlDocument doc = new XmlDocument();
+            doc.LoadXml(fileContents);
+            XmlElement file = doc["decals"];
+            foreach (XmlNode node in file) {
+                if (node is XmlElement decal) {
+                    string decalPath = decal.Attr("path", null);
+                    if (decalPath == null) {
+                        Logger.Log(LogLevel.Warn, "Decal Registry", "Decal didn't have a path attribute!");
+                        continue;
+                    }
+                    DecalInfo info = new DecalInfo();
+                    info.CustomProperties = new Dictionary<string, XmlAttributeCollection>();
+                    info.Depth = decal.AttrInt("depth", -1);
+                    info.AnimationSpeed = decal.AttrFloat("animationSpeed", -1f);
+                    // Read all the properties
+                    foreach (XmlNode node2 in decal.ChildNodes) {
+                        if (node2 is XmlElement property) {
+                            switch (property.Name) {
+                                case "parallax":
+                                    info.ParallaxAmt = property.AttrFloat("amount", 0f);
+                                    break;
+                                case "smoke":
+                                    info.Smoke = true;
+                                    info.SmokeOffset = property.AttrVector2("offsetX", "offsetY", Vector2.Zero);
+                                    info.SmokeInBg = property.AttrBool("inbg", false);
+                                    break;
+                                case "mirror":
+                                    info.Mirror = true;
+                                    info.MirrorKeepOffsetsClose = property.AttrBool("keepOffsetsClose", false);
+                                    break;
+                                case "floaty":
+                                    info.Floaty = true;
+                                    break;
+                                case "banner":
+                                    info.Banner = true;
+                                    info.BannerAmplitude = property.AttrFloat("amplitude", 2f);
+                                    info.BannerEaseDown = property.AttrBool("easeDown", false);
+                                    info.BannerOffset = property.AttrFloat("offset", 0f);
+                                    info.BannerOnlyIfWindy = property.AttrBool("onlyIfWindy", false);
+                                    info.BannerSliceSinIncrement = property.AttrFloat("sliceSinIncrement", 0.05f);
+                                    info.BannerSliceSize = property.AttrInt("sliceSize", 1);
+                                    info.BannerSpeed = property.AttrFloat("speed", 2f);
+                                    break;
+                                case "coreSwap":
+                                    info.CoreSwap = true;
+                                    info.CoreSwapColdPath = property.Attr("coldPath", decalPath);
+                                    info.CoreSwapHotPath = property.Attr("hotPath", decalPath);
+                                    break;
+                                case "bloom":
+                                    info.Bloom = true;
+                                    info.BloomAlpha = property.AttrFloat("alpha", 1f);
+                                    info.BloomOffset = property.AttrVector2("offsetX", "offsetY", Vector2.Zero);
+                                    info.BloomRadius = property.AttrFloat("radius", 16f);
+                                    break;
+                                case "sound":
+                                    info.Sound = property.Attr("event", null);
+                                    break;
+                                default:
+                                    // Unrecognized property, might still be used for mods
+                                    info.CustomProperties.Add(property.Name, property.Attributes);
+                                    break;
+                            }
+                        }
+                    }
+                    Logger.Log("Decal Registry", $"Registered decal {decalPath}");
+                    RegisteredDecals.Add(decalPath, info);
+                }
+            }
+        }
+
+        public struct DecalInfo {
+            // parallax
+            public float ParallaxAmt;
+            // smoke
+            public bool Smoke;
+            public Vector2 SmokeOffset;
+            public bool SmokeInBg;
+            // mirror
+            public bool Mirror;
+            public bool MirrorKeepOffsetsClose;
+            // floaty
+            public bool Floaty;
+            // banner
+            public bool Banner;
+            public float BannerSpeed;
+            public float BannerAmplitude;
+            public int BannerSliceSize;
+            public float BannerSliceSinIncrement;
+            public bool BannerEaseDown;
+            public float BannerOffset;
+            public bool BannerOnlyIfWindy;
+            // depth
+            public int Depth;
+            // coreSwap
+            public bool CoreSwap;
+            public string CoreSwapColdPath;
+            public string CoreSwapHotPath;
+            // bloom
+            public bool Bloom;
+            public Vector2 BloomOffset;
+            public float BloomAlpha;
+            public float BloomRadius;
+            // sound
+            public string Sound;
+            // animationSpeed
+            public float AnimationSpeed;
+            /// <summary>
+            /// These are not recognized by Everest, but still may be used by mods.
+            /// PropertyName -> AttributeCollection
+            /// </summary>
+            public Dictionary<string, XmlAttributeCollection> CustomProperties;
+        }
+    }
+}

--- a/Celeste.Mod.mm/Patches/Decal.cs
+++ b/Celeste.Mod.mm/Patches/Decal.cs
@@ -97,7 +97,6 @@ namespace Celeste {
                 // Handle properties
                 foreach (KeyValuePair<string, XmlAttributeCollection> property in info.CustomProperties) {
                     if (DecalRegistry.PropertyHandlers.ContainsKey(property.Key)) {
-                        Logger.Log("a", $"Handling {property.Key}");
                         DecalRegistry.PropertyHandlers[property.Key].Invoke(this, property.Value);
                     } else {
                         Logger.Log(LogLevel.Warn,"Decal Registry", $"Unknown property {property.Key} in decal {text}");

--- a/Celeste.Mod.mm/Patches/Decal.cs
+++ b/Celeste.Mod.mm/Patches/Decal.cs
@@ -93,7 +93,6 @@ namespace Celeste {
                 Remove(image);
                 image = null;
                 DecalRegistry.DecalInfo info = DecalRegistry.RegisteredDecals[text];
-<<<<<<< HEAD
                    
                 // Handle properties
                 foreach (KeyValuePair<string, XmlAttributeCollection> property in info.CustomProperties) {
@@ -105,33 +104,6 @@ namespace Celeste {
                     }
                 }
 
-=======
-                if (info.CoreSwap) {
-                    Add(image = new CoreSwapImage(GFX.Game[$"decals/{info.CoreSwapHotPath}"], GFX.Game[$"decals/{info.CoreSwapColdPath}"]));
-                }
-                if (info.AnimationSpeed != -1f) {
-                    AnimationSpeed = info.AnimationSpeed;
-                }
-                if (info.Depth != -1)
-                    Depth = info.Depth;
-                if (info.ParallaxAmt != 0f) 
-                    MakeParallax(info.ParallaxAmt);
-                if (info.Smoke)
-                    CreateSmoke(info.SmokeOffset, info.SmokeInBg);
-                if (info.Mirror)
-                    MakeMirror(text, info.MirrorKeepOffsetsClose);
-                if (info.Floaty)
-                    MakeFloaty();
-                if (info.Banner)
-                    MakeBanner(info.BannerSpeed, info.BannerAmplitude, info.BannerSliceSize, info.BannerSliceSinIncrement, info.BannerEaseDown, info.BannerOffset, info.BannerOnlyIfWindy);
-                if (info.Bloom)
-                    Add(new BloomPoint(info.BloomOffset, info.BloomAlpha, info.BloomRadius));
-                if (info.Sound != null)
-                    Add(new SoundSource(info.Sound));
-                if (image == null) {
-                    Add(image = new DecalImage());
-                }
->>>>>>> 6ae97c39d114da971ac261189d57ef9595f04f2d
                 Everest.Events.Decal.HandleDecalRegistry(this, info);
                 if (image == null) {
                     Add(image = new DecalImage());


### PR DESCRIPTION
The Decal Registry allows custom decals to make use of the otherwise hardcoded properties without code mods.
To use it, create a DecalRegistry.xml file in your Mod's root (same place as the everest.yaml file). An example file can be seen here: https://pastebin.com/UtSGb182
Other mods are able of extending this by using the new Everest.Events.Decal.OnHandleDecalRegistry event.