### PR TITLE
Allow selecting starting level set for new save with Left/Right

### DIFF
--- a/Celeste.Mod.mm/Celeste.Mod.mm.csproj
+++ b/Celeste.Mod.mm/Celeste.Mod.mm.csproj
@@ -166,6 +166,7 @@
     <Compile Include="Mod\UI\AutoModUpdater.cs" />
     <Compile Include="Mod\UI\MainMenuModOptionsButton.cs" />
     <Compile Include="Mod\UI\OuiDependencyDownloader.cs" />
+    <Compile Include="Mod\UI\OuiFileSelectSlotLevelSetPicker.cs" />
     <Compile Include="Mod\UI\OuiHelper_ChapterSelect_Reload.cs" />
     <Compile Include="Mod\UI\OuiModUpdateList.cs" />
     <Compile Include="Patches\LevelTemplate.cs" />

--- a/Celeste.Mod.mm/Mod/UI/OuiFileSelectSlotLevelSetPicker.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiFileSelectSlotLevelSetPicker.cs
@@ -1,0 +1,75 @@
+﻿using Microsoft.Xna.Framework;
+using System;
+
+namespace Celeste.Mod.UI {
+    class OuiFileSelectSlotLevelSetPicker : patch_OuiFileSelectSlot.Button {
+        public string NewGameLevelSet { get; private set; }
+
+        private OuiFileSelectSlot selectSlot;
+        private Vector2 arrowOffset;
+        private int lastDirection;
+
+        public OuiFileSelectSlotLevelSetPicker(OuiFileSelectSlot selectSlot) {
+            this.selectSlot = selectSlot;
+
+            Label = DialogExt.CleanLevelSet(NewGameLevelSet ?? "Celeste");
+            Scale = 0.5f;
+            Action = () => changeStartingLevelSet(1);
+
+            // find out what is the width of the biggest level set out there.
+            float levelSetNameWidth = 0;
+            foreach (AreaData areaData in AreaData.Areas) {
+                levelSetNameWidth = Math.Max(levelSetNameWidth, ActiveFont.Measure(DialogExt.CleanLevelSet(areaData.GetLevelSet())).X);
+            }
+            arrowOffset = new Vector2(20f + levelSetNameWidth / 2 * Scale, 0f);
+        }
+
+        public void Update(bool selected) {
+            if (selected) {
+                if (Input.MenuLeft.Pressed) {
+                    changeStartingLevelSet(-1);
+                } else if (Input.MenuRight.Pressed) {
+                    changeStartingLevelSet(1);
+                }
+            } else {
+                lastDirection = 0;
+            }
+        }
+
+        public void Render(Vector2 position, bool currentlySelected, float wigglerOffset) {
+            Vector2 wigglerShift = Vector2.UnitX * (currentlySelected ? wigglerOffset : 0f);
+            Color color = selectSlot.SelectionColor(currentlySelected);
+
+            Vector2 leftArrowWigglerShift = lastDirection <= 0 ? wigglerShift : Vector2.Zero;
+            Vector2 rightArrowWigglerShift = lastDirection >= 0 ? wigglerShift : Vector2.Zero;
+
+            ActiveFont.DrawOutline("<", position + leftArrowWigglerShift - arrowOffset, new Vector2(0.5f, 0f), Vector2.One * Scale, color, 2f, Color.Black);
+            ActiveFont.DrawOutline(">", position + rightArrowWigglerShift + arrowOffset, new Vector2(0.5f, 0f), Vector2.One * Scale, color, 2f, Color.Black);
+        }
+
+        private void changeStartingLevelSet(int direction) {
+            lastDirection = direction;
+            Audio.Play((direction > 0) ? "event:/ui/main/button_toggle_on" : "event:/ui/main/button_toggle_off");
+
+            if (NewGameLevelSet == null)
+                NewGameLevelSet = "Celeste";
+
+            int id;
+            if (direction > 0) {
+                id = AreaData.Areas.FindLastIndex(area => area.GetLevelSet() == NewGameLevelSet) + direction;
+            } else {
+                id = AreaData.Areas.FindIndex(area => area.GetLevelSet() == NewGameLevelSet) + direction;
+            }
+
+            if (id >= AreaData.Areas.Count)
+                id = 0;
+            if (id < 0)
+                id = AreaData.Areas.Count - 1;
+
+            NewGameLevelSet = AreaData.Areas[id].GetLevelSet();
+
+            Label = DialogExt.CleanLevelSet(NewGameLevelSet ?? "Celeste");
+            ((patch_OuiFileSelectSlot) selectSlot).WiggleMenu();
+        }
+    }
+}


### PR DESCRIPTION
Have a specific file select slot button with arrows (like text menu options) to select the starting level set. The level set can be selected with Left and Right. Pressing Confirm still works too.

Also made the OuiFileSelectSlot.Button class public along the way. Is what I did a good way to do this? If so, this is ready to be merged.