### PR TITLE
Tweak the spinner connection code for better performance

### DIFF
--- a/Celeste.Mod.mm/Patches/CrystalStaticSpinner.cs
+++ b/Celeste.Mod.mm/Patches/CrystalStaticSpinner.cs
@@ -20,9 +20,19 @@ namespace Celeste {
 
         private CrystalColor color;
 
+        private int ID;
+
         public patch_CrystalStaticSpinner(Vector2 position, bool attachToSolid, CrystalColor color)
             : base(position, attachToSolid, color) {
             // no-op. MonoMod ignores this - we only need this to make the compiler shut up.
+        }
+
+        public extern void orig_ctor(EntityData data, Vector2 offset, CrystalColor color);
+
+        [MonoModConstructor]
+        public void ctor(EntityData data, Vector2 offset, CrystalColor color) {
+            orig_ctor(data, offset, color);
+            ID = data.ID;
         }
 
         public extern void orig_Awake(Scene scene);
@@ -38,6 +48,10 @@ namespace Celeste {
 
             orig_Awake(scene);
         }
+
+        [MonoModIgnore] // do not change anything in the method...
+        [PatchSpinnerCreateSprites] // ... except manually manipulating it via MonoModRules
+        private extern void CreateSprites();
 
         [MonoModIgnore]
         private class CoreModeListener : Component {


### PR DESCRIPTION
Spinners are known to cause slowdown for some users. Here is a small tweak on how they connect to each other.

Replaces:
```cs
if (item != this && item.AttachToSolid == AttachToSolid && item.X >= base.X && (item.Position - Position).Length() < 24f)
```

with:
```cs
if (item.ID > ID && item.AttachToSolid == AttachToSolid && (item.Position - Position).LengthSquared() < 576f)
```

So, instead of having "connect only to spinners that are on the right or on the same X position", we have "only connect to spinners that have a higher ID than us". So, if spinners 11 and 31 connect, spinner 11 connects to 31, and 31 doesn't connect to 11. This removes useless double connections.

The distance is also computed with LengthSquared instead of Length, to skip having to compute the square root of it.