### PR TITLE
Don't slow down the wake up animation when in space

### DIFF
--- a/Celeste.Mod.mm/Patches/Player.cs
+++ b/Celeste.Mod.mm/Patches/Player.cs
@@ -91,6 +91,16 @@ namespace Celeste {
             return Scene.CollideCheck<Water>(bounds);
         }
 
+        private extern void orig_UpdateSprite();
+        private void UpdateSprite() {
+            orig_UpdateSprite();
+
+            // don't slow down the sprite (even if in space) for "intro wake up", because that makes that intro twice longer.
+            if (StateMachine.State == StIntroWakeUp) {
+                Sprite.Rate = 1f;
+            }
+        }
+
         public extern PlayerDeadBody orig_Die(Vector2 direction, bool evenIfInvincible, bool registerDeathInStats);
         public new PlayerDeadBody Die(Vector2 direction, bool evenIfInvincible = false, bool registerDeathInStats = true) {
             Level level = Scene as Level;


### PR DESCRIPTION
`UpdateSprite` finishes with this piece of code:
```cs
if (StateMachine.State != 11) {
	if (level.InSpace) {
		Sprite.Rate = 0.5f;
	} else {
		Sprite.Rate = 1f;
	}
}
```
so, in space, animations are twice as slow.

This causes the "intro wake up" animation to be twice as long, making it quite annoying. This patch turns the sprite rate back to `1f` when Madeline's state is `IntroWakeUp`.