### PR TITLE
Share error handling code + call Level.OnEnter on Ctrl+F5

### DIFF
--- a/Celeste.Mod.mm/Patches/OuiChapterPanel.cs
+++ b/Celeste.Mod.mm/Patches/OuiChapterPanel.cs
@@ -158,21 +158,7 @@ namespace Celeste {
                 Overworld.RendererList.MoveToFront(Overworld.Snow);
             }
             yield return 0.5f;
-
-            try {
-                LevelEnter.Go(new Session(Area, checkpoint), false);
-            } catch (Exception e) {
-                Mod.Logger.Log(LogLevel.Warn, "misc", $"Failed entering area {Area}");
-                e.LogDetailed();
-
-                string message = Dialog.Get("postcard_levelloadfailed")
-                    .Replace("((player))", SaveData.Instance.Name)
-                    .Replace("((sid))", Area.GetSID())
-                ;
-
-                LevelEnterExt.ErrorMessage = message;
-                LevelEnter.Go(new Session(Area), false);
-            }
+            LevelEnter.Go(new Session(Area, checkpoint), false);
         }
 
     }

--- a/Celeste.Mod.mm/Patches/OuiTitleScreen.cs
+++ b/Celeste.Mod.mm/Patches/OuiTitleScreen.cs
@@ -54,7 +54,7 @@ namespace Celeste {
                     if (slot == -1)
                         save.DebugMode = true;
                     if (save.CurrentSession?.InArea ?? false) {
-                        Engine.Scene = new LevelLoader(save.CurrentSession);
+                        LevelEnter.Go(save.CurrentSession, true);
                     } else {
                         Overworld.Goto<OuiChapterSelect>();
                     }


### PR DESCRIPTION
1/ Instead of catching errors only when entering a level from the chapter panel, handle it directly in `LevelEnter.Go`, so that they are handled elsewhere as well.
2/ Call it when restoring a save after a Ctrl+F5, so that `Everest.Events.Level.OnEnter` is called.