### PR TITLE
Make Everest ignore case on mod language file names

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Content.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Content.cs
@@ -764,7 +764,18 @@ namespace Celeste.Mod {
                         AssetReloadHelper.ReloadLevel();
                     } else if (next.Type == typeof(AssetTypeDialog) || next.Type == typeof(AssetTypeDialogExport)) {
                         AssetReloadHelper.Do($"Reloading dialog: {name}", () => {
-                            Dialog.LoadLanguage(Path.Combine(PathContentOrig, path + ".txt"));
+                            string languageFilePath = path + ".txt";
+
+                            // fix the language case if broken.
+                            string languageRoot = Path.Combine(Engine.ContentDirectory, "Dialog");
+                            foreach (string vanillaFilePath in patch_Dialog.GetVanillaLanguageFileList(languageRoot, "*.txt", SearchOption.AllDirectories)) {
+                                if (vanillaFilePath.Equals(languageFilePath, StringComparison.InvariantCultureIgnoreCase)) {
+                                    languageFilePath = vanillaFilePath;
+                                    break;
+                                }
+                            }
+
+                            Dialog.LoadLanguage(Path.Combine(PathContentOrig, languageFilePath));
                             patch_Dialog.RefreshLanguages();
                         });
                     }


### PR DESCRIPTION
Three parts in 3 files:
- Dialog.cs: when listing existing languages, only add languages that don't exist in vanilla (_case-insensitive_) to the language list. For example, if vanilla has "English" and "French", and mods have "english", "Owonese" and "owonese", the resulting list will be "English", "French", "Owonese" and nothing else.
- Language.cs: when crawling mod content looking for a mod language, match the file path ignoring case. So, if what is to be loaded is Dialog/English, Dialog/english gets loaded too.
- Everest.Content.cs: when hot-reloading Dialog/english.txt, ask the game to reload Dialog/English.txt instead ("fix" the case).

This aims at preventing a mod shipping a Dialog/english.txt file to break mod dialogue entirely.