### PR TITLE
Add [TrackedAs] attribute to have an entity/component tracked the same way as another one

### DIFF
--- a/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
@@ -1,0 +1,55 @@
+﻿using Celeste.Mod.Helpers;
+using System;
+using System.Collections.Generic;
+
+namespace Monocle {
+    /// <summary>
+    /// When applied on an entity, this attribute makes the entity tracked the same way as another entity.
+    /// </summary>
+    public class TrackedAsAttribute : Attribute {
+        public Type TrackedAsType;
+
+        public TrackedAsAttribute(Type trackedAsType) {
+            TrackedAsType = trackedAsType;
+        }
+    }
+
+    class patch_Tracker : Tracker {
+#pragma warning disable CS0626 // method, operator or getter is tagged external and has no attribute
+        public static extern void orig_Initialize();
+#pragma warning restore CS0626
+
+        public new static void Initialize() {
+            orig_Initialize();
+
+            // search for entities with [TrackedAs]
+            Type[] types = FakeAssembly.GetFakeEntryAssembly().GetTypes();
+            foreach (Type type in types) {
+                object[] customAttributes = type.GetCustomAttributes(typeof(TrackedAsAttribute), inherit: false);
+                foreach (object customAttribute in customAttributes) {
+                    Type trackedAsType = (customAttribute as TrackedAsAttribute).TrackedAsType;
+                    if (typeof(Entity).IsAssignableFrom(type)) {
+                        if (!type.IsAbstract) {
+                            // this is an entity. copy the registered types for the target entity
+                            if (!TrackedEntityTypes.ContainsKey(type)) {
+                                TrackedEntityTypes.Add(type, new List<Type>());
+                            }
+                            TrackedEntityTypes[type].AddRange(TrackedEntityTypes.TryGetValue(trackedAsType, out List<Type> list) ? list : new List<Type>());
+                        }
+                    } else if (typeof(Component).IsAssignableFrom(type)) {
+                        if (!type.IsAbstract) {
+                            // this is an component. copy the registered types for the target component
+                            if (!TrackedComponentTypes.ContainsKey(type)) {
+                                TrackedComponentTypes.Add(type, new List<Type>());
+                            }
+                            TrackedComponentTypes[type].AddRange(TrackedComponentTypes.TryGetValue(trackedAsType, out List<Type> list) ? list : new List<Type>());
+                        }
+                    } else {
+                        // this is neither an entity nor a component. Help!
+                        throw new Exception("Type '" + type.Name + "' cannot be TrackedAs because it does not derive from Entity or Component");
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
The idea of this PR is to enable code modders to tag their entities/components with a `[TrackedAs]` attribute:
```cs
[TrackedAs(typeof(Water))]
public class MyWater : Water { ... }
```

This means "MyWater should be tracked exactly the same way as Water is". So, `CollideCheck<Water>()` will also check collisions with MyWater.

This can be useful when developing an entity extending a tracked vanilla one, when the vanilla one has `[Tracked(false)]` making children not tracked by default.

Used on [that dev branch in Spring Collab 2020](https://github.com/EverestAPI/SpringCollab2020/commit/f10dc0f036413c85406cf74620c73770fc9f4333#diff-ac2b4f77018543f73364af3d905370a6).