### PR TITLE
Custom font loading and merging

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Content.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Content.cs
@@ -38,6 +38,7 @@ namespace Celeste.Mod {
     public sealed class AssetTypeGUIDs { private AssetTypeGUIDs() { } }
     public sealed class AssetTypeAhorn { private AssetTypeAhorn() { } }
     public sealed class AssetTypeDecalRegistry { private AssetTypeDecalRegistry() { } }
+    public sealed class AssetTypeFont { private AssetTypeFont() { } }
 
     // Delegate types.
     public delegate string TypeGuesser(string file, out Type type, out string format);
@@ -668,6 +669,10 @@ namespace Celeste.Mod {
 
                 } else if (file.EndsWith(".lua")) {
                     type = typeof(AssetTypeLua);
+                    file = file.Substring(0, file.Length - 4);
+
+                } else if (file.EndsWith(".fnt")) {
+                    type = typeof(AssetTypeFont);
                     file = file.Substring(0, file.Length - 4);
 
                 } else if (OnGuessType != null) {

--- a/Celeste.Mod.mm/Mod/Helpers/DirectoryProxy.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/DirectoryProxy.cs
@@ -29,6 +29,5 @@ namespace Celeste.Mod.Helpers {
                 ).Union(fs).ToArray();
             }
         }
-
     }
 }

--- a/Celeste.Mod.mm/MonoModRules.cs
+++ b/Celeste.Mod.mm/MonoModRules.cs
@@ -229,6 +229,12 @@ namespace MonoMod {
     [MonoModCustomMethodAttribute("PatchSpinnerCreateSprites")]
     class PatchSpinnerCreateSpritesAttribute : Attribute { };
 
+    /// <summary>
+    /// Patches the Fonts.Prepare method to also include custom fonts.
+    /// </summary>
+    [MonoModCustomMethodAttribute("PatchFontsPrepare")]
+    class PatchFontsPrepareAttribute : Attribute { };
+
 
     static class MonoModRules {
 
@@ -1836,6 +1842,21 @@ namespace MonoMod {
                 }
                 if (instrs[instri].OpCode == OpCodes.Ldc_R4 && ((float) instrs[instri].Operand) == 24f) {
                     instrs[instri].Operand = 576f;
+                }
+            }
+        }
+
+
+        public static void PatchFontsPrepare(MethodDefinition method, CustomAttribute attrib) {
+            MethodDefinition m_GetFiles = method.DeclaringType.FindMethod("System.String[] _GetFiles(System.String,System.String,System.IO.SearchOption)");
+            if (m_GetFiles == null)
+                return;
+
+            ILProcessor il = method.Body.GetILProcessor();
+            Mono.Collections.Generic.Collection<Instruction> instrs = method.Body.Instructions;
+            for (int instri = 0; instri < instrs.Count; instri++) {
+                if (instrs[instri].OpCode == OpCodes.Call && (instrs[instri].Operand as MethodReference).Name == "GetFiles") {
+                    instrs[instri].Operand = m_GetFiles;
                 }
             }
         }

--- a/Celeste.Mod.mm/Patches/Fonts.cs
+++ b/Celeste.Mod.mm/Patches/Fonts.cs
@@ -8,6 +8,7 @@ using Monocle;
 using MonoMod;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -23,5 +24,20 @@ namespace Celeste {
             return font;
         }
 
+        // don't change anything in this method, except for also listing custom fonts from mods
+        [MonoModIgnore]
+        [ProxyFileCalls]
+        [PatchFontsPrepare]
+        public static extern void Prepare();
+
+        private static string[] _GetFiles(string path, string searchPattern, SearchOption searchOption) {
+            string[] vanillaFiles = Directory.GetFiles(path, searchPattern, searchOption);
+
+            return Everest.Content.Map.Values
+                .Where(asset => asset.Type == typeof(AssetTypeFont))
+                .Select(asset => Path.Combine(Engine.ContentDirectory, asset.PathVirtual + "." + asset.Format).Replace('/', Path.DirectorySeparatorChar))
+                .Union(vanillaFiles)
+                .ToArray();
+        }
     }
 }

--- a/Celeste.Mod.mm/Patches/Monocle/PixelFont.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/PixelFont.cs
@@ -1,0 +1,80 @@
+﻿using Celeste.Mod;
+using Celeste.Mod.Helpers;
+using MonoMod;
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml;
+
+namespace Monocle {
+    public class patch_PixelFont : PixelFont {
+        public patch_PixelFont(string face) : base(face) {
+            // this constructor is ignored
+        }
+
+        [MonoModReplace]
+        public new PixelFontSize AddFontSize(string path, Atlas atlas = null, bool outline = false) {
+            Logger.Log("PixelFont", $"Loading font: {path}");
+
+            PixelFontSize loadedSize = null;
+
+            // load the vanilla font if it exists.
+            if (patch_Calc.orig_XMLExists(path)) {
+                Logger.Log("PixelFont", "=> vanilla font file");
+                XmlElement data = patch_Calc.orig_LoadXML(path)["font"];
+                loadedSize = AddFontSize(path, data, atlas, outline);
+                Sizes.Remove(loadedSize);
+            }
+
+            // load custom fonts
+            string modPath = FileProxy._Modize(path);
+            foreach (ModAsset modAsset in Everest.Content.Mods
+                .Select(mod => mod.Map)
+                .Where(map => map.ContainsKey(modPath))
+                .Select(map => map[modPath])) {
+
+                Logger.Log("PixelFont", $"=> mod font file from {modAsset.Source.Name}");
+                XmlElement data = loadXMLFromModAsset(modAsset)["font"];
+                PixelFontSize newFontSize = AddFontSize(path, data, atlas, outline);
+                Sizes.Remove(newFontSize);
+                loadedSize = mergeFonts(loadedSize, newFontSize);
+            }
+
+            // add the merged font into the list of existing fonts.
+            Sizes.Add(loadedSize);
+            Sizes.Sort((PixelFontSize a, PixelFontSize b) => Math.Sign(a.Size - b.Size));
+
+            return loadedSize;
+        }
+
+        private XmlDocument loadXMLFromModAsset(ModAsset modAsset) {
+            XmlDocument xmlDocument = new XmlDocument();
+            using (Stream inStream = modAsset.Stream) {
+                xmlDocument.Load(inStream);
+                return xmlDocument;
+            }
+        }
+
+        private PixelFontSize mergeFonts(PixelFontSize originalSize, PixelFontSize newSize) {
+            if (originalSize == null) {
+                // nothing to merge, the current font size does not exist.
+                return newSize;
+            }
+
+            int newCharacterCount = 0;
+            foreach (int character in newSize.Characters.Keys) {
+                // add new characters into the existing font.
+                if (!originalSize.Characters.ContainsKey(character)) {
+                    originalSize.Characters[character] = newSize.Characters[character];
+                    newCharacterCount++;
+                }
+            }
+
+            // associate the textures for the new font to the existing font.
+            originalSize.Textures.AddRange(newSize.Textures);
+
+            Logger.Log("PixelFont", $"==> Imported {newCharacterCount} new characters");
+            return originalSize;
+        }
+    }
+}


### PR DESCRIPTION
This PR aims to cover some needs for custom characters in languages like Korean and Chinese. The game's files only contain the characters the game actually uses, and some mods may want to use more of them. This PR also covers fully custom fonts at the same time.

Here are 2 example mods that use that:
- purely custom font: [Celeste in Comic Sans](https://cdn.discordapp.com/attachments/445236692136230943/690582152399552542/CelesteInComicSans.zip) (_sorry_). You can select a new "Comic Sans" language using that font.
```
[PixelFont] Loading font: D:\SteamLibrary\steamapps\common\Celeste\Content\Dialog\Fonts\renogare192.fnt
[PixelFont] => vanilla font file
[PixelFont] Loading font: D:\SteamLibrary\steamapps\common\Celeste\Content\Dialog\Fonts\renogare64.fnt
[PixelFont] => vanilla font file
[PixelFont] Loading font: D:\SteamLibrary\steamapps\common\Celeste\Content\Dialog\Fonts\comic_sans.fnt
[PixelFont] => mod font file from CelesteInComicSans
```
- custom characters for an existing font: [Extended Variants](https://cdn.discordapp.com/attachments/445236692136230943/690582122028728330/ExtendedVariantMode-TestBuild.zip) (modified version that uses this feature instead of hooks). For fonts to be merged, they have to have the exact same path. Here, Extended Variants adds 15 characters to the Korean font:
```
[PixelFont] Loading font: D:\SteamLibrary\steamapps\common\Celeste\Content\Dialog\Fonts\renogare192.fnt
[PixelFont] => vanilla font file
[PixelFont] Loading font: D:\SteamLibrary\steamapps\common\Celeste\Content\Dialog\Fonts\renogare64.fnt
[PixelFont] => vanilla font file
[PixelFont] Loading font: D:\SteamLibrary\steamapps\common\Celeste\Content\Dialog\Fonts\korean.fnt
[PixelFont] => vanilla font file
[PixelFont] => mod font file from ExtendedVariantMode
[PixelFont] ==> Imported 15 new characters
```

This is the output of the `fonts` debug command with both those installed. We can see "Comic Sans MS" has been registered:
![image](https://user-images.githubusercontent.com/52103563/77179727-25995d00-6ac9-11ea-8500-0dd7a1a23573.png)

This works in two parts:
- in `Fonts.Prepare`, we want vanilla and custom fonts to be added to the list of files to be loaded.
- in `PixelFont.AddFontSize`, we load vanilla and custom fonts, and merge all of them that have the same fnt file name.