### PR TITLE
Call a Discord webhook on successful stable builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,6 +51,7 @@ steps:
     artifactName: 'main'
     publishLocation: 'Container'
 
+# Post-build steps (obsolete).
 - task: PowerShell@2
 # condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
   condition: not(always())
@@ -58,3 +59,10 @@ steps:
   inputs:
     filePath: 'azure-pipelines-postbuild.ps1'
     arguments: '$(S3KEY) $(S3SECRET)'
+
+# Announce new stable versions on Discord (#modding_updates).
+- script: |
+    set /a "BUILD_NUMBER=$(Build.BuildId)+$(Build.BuildIdOffset)"
+    curl -H "Content-Type: application/json" -d "{\"content\": \"**A new Everest stable was just released!**\nThe latest stable version is now **%BUILD_NUMBER%**.\"}" $(WEBHOOK_URL)
+  displayName: 'Celeste Discord webhook'
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/stable'))


### PR DESCRIPTION
Here is a small suggestion of webhook to announce new stable versions in #modding_updates on Discord. I did a bunch of experiments on a sandbox repo yesterday (using the same vm-image as Everest and a webhook posting to an empty Discord server) to ensure it works.

As we already figured when we published 1451, we don't _really_ need to announce any features since they already get announced sonner or later when they get on master. So, here is how it looks (build 17+42):
![image](https://user-images.githubusercontent.com/52103563/77223815-2e893d80-6b60-11ea-8547-fbd0dc1925e1.png)

Of course I'm open to suggestions about the message itself etc.

If we want to set this up, I can create a webhook on the Celeste Discord, and this webhook URL will have to be set up as a secret variable in Azure Pipelines.