### PR TITLE
Better formatting for the mod names in mod updater

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Extensions.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Extensions.cs
@@ -113,7 +113,7 @@ namespace Celeste.Mod {
             StringBuilder builder = new StringBuilder();
             for (int i = 0; i < input.Length; i++) {
                 char c = input[i];
-                if (i > 0 && char.IsUpper(c) && input[i - 1] != ' ')
+                if (i > 0 && char.IsUpper(c) && char.IsLower(input[i - 1]))
                     builder.Append(' ');
                 builder.Append(c);
             }

--- a/Celeste.Mod.mm/Mod/Helpers/ModUpdaterHelper.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/ModUpdaterHelper.cs
@@ -170,5 +170,10 @@ namespace Celeste.Mod.Helpers {
 
             return availableUpdates;
         }
+
+        public static string FormatModName(string modNameRaw) {
+            string overrideName = $"modname_{modNameRaw.DialogKeyify()}".DialogCleanOrNull();
+            return overrideName ?? modNameRaw.SpacedPascalCase();
+        }
     }
 }

--- a/Celeste.Mod.mm/Mod/UI/AutoModUpdater.cs
+++ b/Celeste.Mod.mm/Mod/UI/AutoModUpdater.cs
@@ -84,7 +84,7 @@ namespace Celeste.Mod.UI {
             // iterate through all mods to update now.
             foreach (ModUpdateInfo update in updateList.Keys) {
                 // common beginning for all messages: f.e. [1/3] Auto-updating Polygon Dreams
-                string progressString = $"[{currentlyUpdatedModIndex}/{updateList.Count}] {Dialog.Clean("AUTOUPDATECHECKER_UPDATING")} {update.Name.SpacedPascalCase()}:";
+                string progressString = $"[{currentlyUpdatedModIndex}/{updateList.Count}] {Dialog.Clean("AUTOUPDATECHECKER_UPDATING")} {ModUpdaterHelper.FormatModName(update.Name)}:";
 
                 try {
                     // download it...

--- a/Celeste.Mod.mm/Mod/UI/OuiModUpdateList.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiModUpdateList.cs
@@ -233,7 +233,7 @@ namespace Celeste.Mod.UI {
 
             try {
                 // download it...
-                button.Label = $"{update.Name.SpacedPascalCase()} ({Dialog.Clean("MODUPDATECHECKER_DOWNLOADING")})";
+                button.Label = $"{ModUpdaterHelper.FormatModName(update.Name)} ({Dialog.Clean("MODUPDATECHECKER_DOWNLOADING")})";
                 downloadMod(update, button, zipPath);
 
                 // verify its checksum
@@ -243,16 +243,16 @@ namespace Celeste.Mod.UI {
                 shouldRestart = true;
 
                 // install it
-                button.Label = $"{update.Name.SpacedPascalCase()} ({Dialog.Clean("MODUPDATECHECKER_INSTALLING")})";
+                button.Label = $"{ModUpdaterHelper.FormatModName(update.Name)} ({Dialog.Clean("MODUPDATECHECKER_INSTALLING")})";
                 ModUpdaterHelper.InstallModUpdate(update, mod, zipPath);
 
                 // done!
-                button.Label = $"{update.Name.SpacedPascalCase()} ({Dialog.Clean("MODUPDATECHECKER_UPDATED")})";
+                button.Label = $"{ModUpdaterHelper.FormatModName(update.Name)} ({Dialog.Clean("MODUPDATECHECKER_UPDATED")})";
 
                 return true;
             } catch (Exception e) {
                 // update failed
-                button.Label = $"{update.Name.SpacedPascalCase()} ({Dialog.Clean("MODUPDATECHECKER_FAILED")})";
+                button.Label = $"{ModUpdaterHelper.FormatModName(update.Name)} ({Dialog.Clean("MODUPDATECHECKER_FAILED")})";
                 Logger.Log("OuiModUpdateList", $"Updating {update.Name} failed");
                 Logger.LogDetailed(e);
 
@@ -273,9 +273,9 @@ namespace Celeste.Mod.UI {
 
             Everest.Updater.DownloadFileWithProgress(update.URL, zipPath, (position, length, speed) => {
                 if (length > 0) {
-                    button.Label = $"{update.Name.SpacedPascalCase()} ({((int) Math.Floor(100D * (position / (double) length)))}% @ {speed} KiB/s)";
+                    button.Label = $"{ModUpdaterHelper.FormatModName(update.Name)} ({((int) Math.Floor(100D * (position / (double) length)))}% @ {speed} KiB/s)";
                 } else {
-                    button.Label = $"{update.Name.SpacedPascalCase()} ({((int) Math.Floor(position / 1000D))}KiB @ {speed} KiB/s)";
+                    button.Label = $"{ModUpdaterHelper.FormatModName(update.Name)} ({((int) Math.Floor(position / 1000D))}KiB @ {speed} KiB/s)";
                 }
             });
         }


### PR DESCRIPTION
Change the strategy of SpacedPascalCase to "add a space if there is a lowercase letter followed by an uppercase letter". It works fine 95% of the time (`CelesteTAS => Celeste TAS`, `ExtendedVariantMode => Extended Variant Mode`, `Ezel's CC-Sides => Ezel's CC-Sides`). Here is a sample of mods converted using this method: [sample.txt](https://github.com/EverestAPI/Everest/files/4363518/sample.txt)

For the few cases where this fails, this PR sets up an alternate way: defining a dialog key `modname_{mod ID}`. For example, DJMapHelper is rendered as `DJMap Helper`, this can be fixed with:
```
modname_djmaphelper= DJ Map Helper
```
This could also be used to _visually_ rename mods in the updater without changing their IDs.
