### PR TITLE
Remove 'offspring' thread when quick full restarting

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -686,20 +686,16 @@ namespace Celeste.Mod {
             }
 
             Events.Celeste.OnShutdown += () => {
-                // If the game was installed via Steam, it should restart in a Steam context on its own.
-                Thread offspring = new Thread(() => {
-                    Process game = new Process();
-                    // Unix-likes use the wrapper script
-                    if (Environment.OSVersion.Platform == PlatformID.Unix ||
-                        Environment.OSVersion.Platform == PlatformID.MacOSX) {
-                        game.StartInfo.FileName = Path.Combine(PathGame, "Celeste");
-                    } else {
-                        game.StartInfo.FileName = Path.Combine(PathGame, "Celeste.exe");
-                    }
-                    game.StartInfo.WorkingDirectory = PathGame;
-                    game.Start();
-                });
-                offspring.Start();
+                Process game = new Process();
+                // Unix-likes use the wrapper script
+                if (Environment.OSVersion.Platform == PlatformID.Unix ||
+                    Environment.OSVersion.Platform == PlatformID.MacOSX) {
+                    game.StartInfo.FileName = Path.Combine(PathGame, "Celeste");
+                } else {
+                    game.StartInfo.FileName = Path.Combine(PathGame, "Celeste.exe");
+                }
+                game.StartInfo.WorkingDirectory = PathGame;
+                game.Start();
             };
 
             Engine.Instance.Exit();


### PR DESCRIPTION
Possibly prevents the thread from being killed if we get real unlucky, and the game not restarting as a result. Doesn't seem to break anything on Steam (both branches on Windows + Linux).