### PR TITLE
Command to load maps by SID from the debug console

### DIFF
--- a/Celeste.Mod.mm/MonoModRules.cs
+++ b/Celeste.Mod.mm/MonoModRules.cs
@@ -253,6 +253,12 @@ namespace MonoMod {
     [MonoModCustomMethodAttribute("PatchCelesteMain")]
     class PatchCelesteMainAttribute : Attribute { };
 
+    /// <summary>
+    /// Removes the [Command] attribute from the matching vanilla method in Celeste.Commands.
+    /// </summary>
+    [MonoModCustomMethodAttribute("RemoveCommandAttributeFromVanillaLoadMethod")]
+    class RemoveCommandAttributeFromVanillaLoadMethodAttribute : Attribute { };
+
 
     static class MonoModRules {
 
@@ -1940,6 +1946,18 @@ namespace MonoMod {
                 if (instrs[instri].OpCode == OpCodes.Call && (instrs[instri].Operand as MethodReference)?.GetID() == "System.String SDL2.SDL::SDL_GetPlatform()") {
                     instrs[instri].OpCode = OpCodes.Ldstr;
                     instrs[instri].Operand = "Windows";
+                }
+            }
+        }
+
+        public static void RemoveCommandAttributeFromVanillaLoadMethod(MethodDefinition method, CustomAttribute attrib) {
+            // find the method in the same class with the same name, but with a (int, string) signature.
+            Mono.Collections.Generic.Collection<CustomAttribute> attributes = method.DeclaringType.FindMethod($"System.Void {method.Name}(System.Int32,System.String)").CustomAttributes;
+            for (int i = 0; i < attributes.Count; i++) {
+                // remove all Command attributes.
+                if (attributes[i]?.AttributeType.FullName == "Monocle.Command") {
+                    attributes.RemoveAt(i);
+                    i--;
                 }
             }
         }

--- a/Celeste.Mod.mm/Patches/Monocle/Commands.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Commands.cs
@@ -164,12 +164,12 @@ namespace Monocle {
 
         private extern void orig_HandleKey(Keys key);
         private void HandleKey(Keys key) {
-            if (key == Keys.Tab && currentText.StartsWith("load_map ")) {
+            if (key == Keys.Tab && (currentText.StartsWith("load ") || currentText.StartsWith("hard ") || currentText.StartsWith("rmx2 "))) {
                 // handle tab autocomplete for SIDs
 
                 if (sidTabIndex == -1) {
                     // search for SIDs that match what we started typing.
-                    string startOfSid = currentText.Substring("load_map ".Length);
+                    string startOfSid = currentText.Substring(5);
                     sidTabResults = AreaData.Areas.Select(area => area.GetSID()).Where(sid => sid.StartsWith(startOfSid, StringComparison.InvariantCultureIgnoreCase)).ToArray();
                 }
 
@@ -195,7 +195,7 @@ namespace Monocle {
                     sidTabIndex %= sidTabResults.Length;
 
                     // autocomplete
-                    currentText = "load_map " + sidTabResults[sidTabIndex];
+                    currentText = currentText.Substring(0, 5) + sidTabResults[sidTabIndex];
                 }
             } else {
                 if (key != Keys.Tab && key != Keys.LeftShift && key != Keys.RightShift && key != Keys.RightAlt && key != Keys.LeftAlt && key != Keys.RightControl && key != Keys.LeftControl) {


### PR DESCRIPTION
Here is an idea which... was not quite suggested, but that I found nice anyway. Some users were wondering how to load custom maps from the debug console, this is a simpler solution for them than using numerical IDs that can change when installing new maps.

This creates a `load_map` command, allowing to load a map based on its SID. For example: 
- `load_map Celeste/3-CelestialResort B 02` does pretty much the same as `hard 3 02`: load 3B on screen 02
- `load_map 1up/pathofhope C` loads Path of Hope C. The vanilla command to do so on my install is `rmx2 11`.

This PR also implements autocomplete on the SID for this command: typing `load_map 1` and pressing Tab will give `load_map 1up/pathofhope`.