### PR TITLE
Add a delayTime option to trigger spikes (Everest and vanilla)

### DIFF
--- a/Celeste.Mod.mm/Mod/Entities/TriggerSpikesOriginal.cs
+++ b/Celeste.Mod.mm/Mod/Entities/TriggerSpikesOriginal.cs
@@ -32,7 +32,8 @@ namespace Celeste.Mod.Entities {
             => new TriggerSpikesOriginal(entityData, offset, Directions.Right);
 
         private const float RetractTime = 6f;
-        private const float DelayTime = 0.4f;
+        private const float DefaultDelayTime = 0.4f;
+        private float delayTime;
 
         private int size;
         private Directions direction;
@@ -50,14 +51,17 @@ namespace Celeste.Mod.Entities {
         private List<MTexture> spikeTextures;
 
         public TriggerSpikesOriginal(EntityData data, Vector2 offset, Directions dir)
-            : this(data.Position + offset, GetSize(data, dir), dir, data.Attr("type", "default")) {
+            : this(data.Position + offset, GetSize(data, dir), dir, data.Attr("type", "default"), data.Float("delayTime", DefaultDelayTime)) {
         }
 
-        public TriggerSpikesOriginal(Vector2 position, int size, Directions direction, string overrideType)
+        public TriggerSpikesOriginal(Vector2 position, int size, Directions direction, string overrideType) : this(position, size, direction, overrideType, DefaultDelayTime) { }
+
+        public TriggerSpikesOriginal(Vector2 position, int size, Directions direction, string overrideType, float delayTime)
             : base(position) {
             this.size = size;
             this.direction = direction;
             this.overrideType = overrideType;
+            this.delayTime = delayTime;
 
             switch (direction) {
                 case Directions.Up:
@@ -347,7 +351,7 @@ namespace Celeste.Mod.Entities {
                 if (!Triggered) {
                     Audio.Play("event:/game/03_resort/fluff_tendril_touch", Parent.Position + Position);
                     Triggered = true;
-                    DelayTimer = DelayTime;
+                    DelayTimer = Parent.delayTime;
                     RetractTimer = RetractTime;
                     return false;
                 }

--- a/Celeste.Mod.mm/Patches/TriggerSpikes.cs
+++ b/Celeste.Mod.mm/Patches/TriggerSpikes.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.Xna.Framework;
+using MonoMod;
+
+namespace Celeste {
+    public class patch_TriggerSpikes : TriggerSpikes {
+
+        private const float DelayTime = 0.4f;
+        private float customDelayTime;
+
+        public patch_TriggerSpikes(EntityData data, Vector2 offset, Directions dir) : base(data, offset, dir) {
+            // dummy constructor
+        }
+
+        // do some cabling to expose the old constructor unchanged + a new constructor with the new "delayTime" setting
+        // + the (EntityData, Vector2, Directions) constructor wired to the new one.
+
+        [MonoModConstructor]
+        [MonoModIgnore]
+        public extern void ctor(Vector2 position, int size, Directions direction);
+
+        [MonoModIgnore]
+        private static extern int GetSize(EntityData data, Directions dir);
+
+        [MonoModConstructor]
+        [MonoModReplace]
+        public void ctor(EntityData data, Vector2 offset, Directions dir) {
+            ctor(data.Position + offset, GetSize(data, dir), dir, data.Float("delayTime", DelayTime));
+        }
+
+        [MonoModConstructor]
+        [MonoModReplace]
+        public void ctor(Vector2 position, int size, Directions direction, float delayTime) {
+            ctor(position, size, direction);
+            customDelayTime = delayTime;
+        }
+
+        // inject the custom delay time in the spike info, instead of the hardcoded 0.4 time.
+
+        private struct SpikeInfo {
+            [MonoModIgnore]
+            [PatchTriggerSpikesDelayTime]
+            public extern bool OnPlayer(Player player, Vector2 outwards);
+        }
+    }
+}


### PR DESCRIPTION
Requested on Discord. This just adds a "delayTime" attribute to trigger spikes, to customize the delay before trigger spikes get triggered after being walked on.