### PR TITLE
Custom 'color' attribute for fake hearts

### DIFF
--- a/Celeste.Mod.mm/MonoModRules.cs
+++ b/Celeste.Mod.mm/MonoModRules.cs
@@ -265,6 +265,12 @@ namespace MonoMod {
     [MonoModCustomMethodAttribute("PatchTriggerSpikesDelayTime")]
     class PatchTriggerSpikesDelayTimeAttribute : Attribute { };
 
+    /// <summary>
+    /// Patch the fake heart color to make it customizable.
+    /// </summary>
+    [MonoModCustomMethodAttribute("PatchFakeHeartColor")]
+    class PatchFakeHeartColorAttribute : Attribute { };
+
 
     static class MonoModRules {
 
@@ -2016,6 +2022,23 @@ namespace MonoMod {
                     instr.OpCode = OpCodes.Ldarg_0;
                     instrs.Insert(instri + 1, il.Create(OpCodes.Ldfld, f_Parent));
                     instrs.Insert(instri + 2, il.Create(OpCodes.Ldfld, f_customDelayTime));
+                }
+            }
+        }
+
+        public static void PatchFakeHeartColor(MethodDefinition method, CustomAttribute attrib) {
+            MethodDefinition m_getCustomColor = method.DeclaringType.FindMethod("Celeste.AreaMode _getCustomColor(Celeste.AreaMode,Celeste.FakeHeart)");
+            if (m_getCustomColor == null)
+                return;
+
+            Mono.Collections.Generic.Collection<Instruction> instrs = method.Body.Instructions;
+            ILProcessor il = method.Body.GetILProcessor();
+            for (int instri = 0; instri < instrs.Count; instri++) {
+                Instruction instr = instrs[instri];
+
+                if (instr.OpCode == OpCodes.Call && ((MethodReference) instr.Operand).Name == "Choose") {
+                    instrs.Insert(instri + 1, il.Create(OpCodes.Ldarg_0));
+                    instrs.Insert(instri + 2, il.Create(OpCodes.Call, m_getCustomColor));
                 }
             }
         }

--- a/Celeste.Mod.mm/Patches/FakeHeart.cs
+++ b/Celeste.Mod.mm/Patches/FakeHeart.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.Xna.Framework;
+using Monocle;
+using MonoMod;
+
+namespace Celeste {
+    public class patch_FakeHeart : FakeHeart {
+        public patch_FakeHeart(Vector2 position)
+            : base(position) {
+            // dummy constructor
+        }
+
+        // null is the vanilla (random) color.
+        private AreaMode? color;
+
+        [MonoModConstructor]
+        [MonoModIgnore]
+        public extern void ctor(Vector2 position);
+
+        [MonoModConstructor]
+        [MonoModReplace]
+        public void ctor(EntityData data, Vector2 offset) {
+            ctor(data.Position + offset);
+
+            if (data.Has("color") && data.Attr("color") != "Random") {
+                color = data.Enum<AreaMode>("color");
+            } else {
+                color = null;
+            }
+        }
+
+        [MonoModIgnore]
+        [PatchFakeHeartColor] // adds a call to _getCustomColor to override the random color
+        public extern override void Awake(Scene scene);
+
+        private static AreaMode _getCustomColor(AreaMode vanillaColor, patch_FakeHeart self) {
+            return self.color ?? vanillaColor;
+        }
+    }
+}

--- a/Celeste.Mod.mm/Patches/FakeHeart.cs
+++ b/Celeste.Mod.mm/Patches/FakeHeart.cs
@@ -9,8 +9,8 @@ namespace Celeste {
             // dummy constructor
         }
 
-        // null is the vanilla (random) color.
-        private AreaMode? color;
+        // -1 is the vanilla (random) color.
+        private AreaMode color;
 
         [MonoModConstructor]
         [MonoModIgnore]
@@ -21,11 +21,7 @@ namespace Celeste {
         public void ctor(EntityData data, Vector2 offset) {
             ctor(data.Position + offset);
 
-            if (data.Has("color") && data.Attr("color") != "Random") {
-                color = data.Enum<AreaMode>("color");
-            } else {
-                color = null;
-            }
+            color = data.Enum<AreaMode>("color", (AreaMode) (-1));
         }
 
         [MonoModIgnore]
@@ -33,7 +29,7 @@ namespace Celeste {
         public extern override void Awake(Scene scene);
 
         private static AreaMode _getCustomColor(AreaMode vanillaColor, patch_FakeHeart self) {
-            return self.color ?? vanillaColor;
+            return self.color != (AreaMode) (-1) ? self.color : vanillaColor;
         }
     }
 }


### PR DESCRIPTION
Closes #135.

Having no "color" attribute or setting it to "Random" will leave the vanilla (pseudo) random value. Setting it to an area mode (Normal, BSide or CSide) will determine the heart color. In this case, the random value will still get generated, so that calls to the RNG that follow don't get impacted by it (1 random value is "consumed" by the heart, no matter if the heart color is customized or not).