### PR TITLE
In-game blacklist.txt editor (aka "Mod toggler")

### DIFF
--- a/Celeste.Mod.mm/Content/Dialog/English.txt
+++ b/Celeste.Mod.mm/Content/Dialog/English.txt
@@ -176,8 +176,9 @@
 
 # Mod Toggle Menu
 	MODOPTIONS_MODTOGGLE=				TOGGLE MODS
-	MODOPTIONS_MODTOGGLE_MESSAGE=		If you enable or disable mods, your blacklist.txt and whitelist.txt
-	MODOPTIONS_MODTOGGLE_MESSAGE2=		will be replaced, and Celeste will restart to apply changes.
+	MODOPTIONS_MODTOGGLE_MESSAGE_1=		If you enable or disable mods, your blacklist.txt will be replaced,
+	MODOPTIONS_MODTOGGLE_MESSAGE_2=		and Celeste will restart to apply changes.
+	MODOPTIONS_MODTOGGLE_WHITELISTWARN= Disable your whitelist for these settings to be applied properly.
 	MODOPTIONS_MODTOGGLE_ENABLEALL=		Enable All
 	MODOPTIONS_MODTOGGLE_DISABLEALL=	Disable All
 	MODOPTIONS_MODTOGGLE_CANCEL=		Cancel

--- a/Celeste.Mod.mm/Content/Dialog/English.txt
+++ b/Celeste.Mod.mm/Content/Dialog/English.txt
@@ -75,8 +75,8 @@
 	MODOPTIONS_COREMODULE_RECRAWL= 							~Reload Assets~
 
 	MODOPTIONS_COREMODULE_SOUNDTEST= 						Sound Test
-
 	MODOPTIONS_COREMODULE_OOBE= 							Redo Initial Setup
+	MODOPTIONS_COREMODULE_TOGGLEMODS=						Enable or Disable Mods
 
 	MODOPTIONS_COREMODULE_NOTLOADED_A= 						Some mods failed loading.
 	MODOPTIONS_COREMODULE_NOTLOADED_B= 						Please check your log.txt for more info.
@@ -173,3 +173,13 @@
 	OOBE_SETTINGS_SUBHEADER=	Here are some settings you might be interested in.
 	OOBE_SETTINGS_MORE=			You can change this and more in the Mod Options screen.
 	OOBE_SETTINGS_OK=			OK
+
+# Mod Toggle Menu
+	MODOPTIONS_MODTOGGLE=				TOGGLE MODS
+	MODOPTIONS_MODTOGGLE_MESSAGE=		If you enable or disable mods, your blacklist.txt and whitelist.txt
+	MODOPTIONS_MODTOGGLE_MESSAGE2=		will be replaced, and Celeste will restart to apply changes.
+	MODOPTIONS_MODTOGGLE_ENABLEALL=		Enable All
+	MODOPTIONS_MODTOGGLE_DISABLEALL=	Disable All
+	MODOPTIONS_MODTOGGLE_CANCEL=		Cancel
+	MODOPTIONS_MODTOGGLE_ZIPS=			Zip Files
+	MODOPTIONS_MODTOGGLE_DIRECTORIES=	Directories

--- a/Celeste.Mod.mm/Content/Dialog/French.txt
+++ b/Celeste.Mod.mm/Content/Dialog/French.txt
@@ -57,8 +57,8 @@
 	MODOPTIONS_COREMODULE_RECRAWL= 							~Recharger aspects~
 
 	MODOPTIONS_COREMODULE_SOUNDTEST= 						Test sons
-
 	MODOPTIONS_COREMODULE_OOBE= 							Ouvrir l'écran de premier démarrage
+	MODOPTIONS_COREMODULE_TOGGLEMODS= 						Activer ou désactiver des mods
 
 	MODOPTIONS_COREMODULE_NOTLOADED_A= 						Certains mods n'ont pas pu être chargés.
 	MODOPTIONS_COREMODULE_NOTLOADED_B= 						Vérifiez votre log.txt pour plus d'informations.
@@ -155,3 +155,13 @@
 	OOBE_SETTINGS_SUBHEADER=	Voici quelques réglages qui pourraient t'intéresser.
 	OOBE_SETTINGS_MORE=			Tu peux changer ces réglages et d'autres dans le menu "Options des mods".
 	OOBE_SETTINGS_OK=			OK
+
+# Mod Toggle Menu
+	MODOPTIONS_MODTOGGLE=				(DÉS)ACTIVER DES MODS
+	MODOPTIONS_MODTOGGLE_MESSAGE=		Si vous activez ou désactivez des mods, votre blacklist.txt et whitelist.txt
+	MODOPTIONS_MODTOGGLE_MESSAGE2=		seront remplacés, et Celeste va redémarrer pour appliquer les changements.
+	MODOPTIONS_MODTOGGLE_ENABLEALL=		Tout activer
+	MODOPTIONS_MODTOGGLE_DISABLEALL=	Tout désactiver
+	MODOPTIONS_MODTOGGLE_CANCEL=		Annuler
+	MODOPTIONS_MODTOGGLE_ZIPS=			Fichiers ZIP
+	MODOPTIONS_MODTOGGLE_DIRECTORIES=	Dossiers

--- a/Celeste.Mod.mm/Content/Dialog/French.txt
+++ b/Celeste.Mod.mm/Content/Dialog/French.txt
@@ -158,8 +158,9 @@
 
 # Mod Toggle Menu
 	MODOPTIONS_MODTOGGLE=				(DÉS)ACTIVER DES MODS
-	MODOPTIONS_MODTOGGLE_MESSAGE=		Si vous activez ou désactivez des mods, votre blacklist.txt et whitelist.txt
-	MODOPTIONS_MODTOGGLE_MESSAGE2=		seront remplacés, et Celeste va redémarrer pour appliquer les changements.
+	MODOPTIONS_MODTOGGLE_MESSAGE_1=		Si vous activez ou désactivez des mods, votre blacklist.txt sera remplacé,
+	MODOPTIONS_MODTOGGLE_MESSAGE_2=		et Celeste va redémarrer pour appliquer les changements.
+	MODOPTIONS_MODTOGGLE_WHITELISTWARN= Désactivez votre whitelist pour que ces réglages soient appliqués correctement.
 	MODOPTIONS_MODTOGGLE_ENABLEALL=		Tout activer
 	MODOPTIONS_MODTOGGLE_DISABLEALL=	Tout désactiver
 	MODOPTIONS_MODTOGGLE_CANCEL=		Annuler

--- a/Celeste.Mod.mm/Mod/Core/CoreModule.cs
+++ b/Celeste.Mod.mm/Mod/Core/CoreModule.cs
@@ -273,6 +273,10 @@ namespace Celeste.Mod.Core {
                 menu.Add(new TextMenu.Button(Dialog.Clean("modoptions_coremodule_modupdates")).Pressed(() => {
                     OuiModOptions.Instance.Overworld.Goto<OuiModUpdateList>();
                 }));
+
+                menu.Add(new TextMenu.Button(Dialog.Clean("modoptions_coremodule_togglemods")).Pressed(() => {
+                    OuiModOptions.Instance.Overworld.Goto<OuiModToggler>();
+                }));
             }
         }
 

--- a/Celeste.Mod.mm/Mod/UI/OuiModToggler.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiModToggler.cs
@@ -1,0 +1,128 @@
+﻿using Microsoft.Xna.Framework;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Celeste.Mod.UI {
+    class OuiModToggler : OuiGenericMenu, OuiModOptions.ISubmenu {
+        public override string MenuName => Dialog.Clean("MODOPTIONS_MODTOGGLE");
+
+        private HashSet<string> blacklistedMods;
+        private HashSet<string> blacklistedModsOriginal;
+
+        private TextMenuExt.SubHeaderExt restartMessage;
+        private TextMenuExt.SubHeaderExt restartMessage2;
+
+        public OuiModToggler() {
+            backToParentMenu = onBackPressed;
+        }
+
+        protected override void addOptionsToMenu(TextMenu menu) {
+
+            menu.Add(restartMessage = new TextMenuExt.SubHeaderExt(Dialog.Clean("MODOPTIONS_MODTOGGLE_MESSAGE")));
+            menu.Add(restartMessage2 = new TextMenuExt.SubHeaderExt(Dialog.Clean("MODOPTIONS_MODTOGGLE_MESSAGE2")) { HeightExtra = 0f });
+
+            // "enable all" and "disable all" buttons
+            List<TextMenu.OnOff> allToggles = new List<TextMenu.OnOff>();
+            menu.Add(new TextMenu.Button(Dialog.Clean("MODOPTIONS_MODTOGGLE_ENABLEALL")).Pressed(() => {
+                foreach (TextMenu.OnOff toggle in allToggles) {
+                    if (toggle.Index != 1) {
+                        toggle.Index = 1;
+                        toggle.OnValueChange(true);
+                    }
+                }
+            }));
+            menu.Add(new TextMenu.Button(Dialog.Clean("MODOPTIONS_MODTOGGLE_DISABLEALL")).Pressed(() => {
+                foreach (TextMenu.OnOff toggle in allToggles) {
+                    if (toggle.Index != 0) {
+                        toggle.Index = 0;
+                        toggle.OnValueChange(false);
+                    }
+                }
+            }));
+
+            // "cancel" button to leave the screen without saving
+            menu.Add(new TextMenu.Button(Dialog.Clean("MODOPTIONS_MODTOGGLE_CANCEL")).Pressed(() => {
+                blacklistedMods = blacklistedModsOriginal;
+                onBackPressed(Overworld);
+            }));
+
+            // reset the mods list
+            blacklistedMods = new HashSet<string>();
+
+            // crawl zips
+            menu.Add(new TextMenu.SubHeader(Dialog.Clean("MODOPTIONS_MODTOGGLE_ZIPS")));
+            string[] files = Directory.GetFiles(Everest.Loader.PathMods);
+            for (int i = 0; i < files.Length; i++) {
+                string file = Path.GetFileName(files[i]);
+                if (file.EndsWith(".zip")) {
+                    allToggles.Add(addFileToMenu(menu, file));
+                }
+            }
+
+            // crawl directories
+            menu.Add(new TextMenu.SubHeader(Dialog.Clean("MODOPTIONS_MODTOGGLE_DIRECTORIES")));
+            files = Directory.GetDirectories(Everest.Loader.PathMods);
+            for (int i = 0; i < files.Length; i++) {
+                string file = Path.GetFileName(files[i]);
+                if (file != "Cache") {
+                    allToggles.Add(addFileToMenu(menu, file));
+                }
+            }
+
+            // clone the list to be able to check if the list changed when leaving the menu.
+            blacklistedModsOriginal = new HashSet<string>(blacklistedMods);
+        }
+
+        private TextMenu.OnOff addFileToMenu(TextMenu menu, string file) {
+            TextMenu.OnOff option;
+
+            bool enabled = !Everest.Loader._Blacklist.Contains(file) && (Everest.Loader._Whitelist == null || Everest.Loader._Whitelist.Contains(file));
+            menu.Add(option = (TextMenu.OnOff) new TextMenu.OnOff(file.Length > 40 ? file.Substring(0, 40) + "..." : file, enabled)
+                .Change(b => {
+                    if (b) {
+                        blacklistedMods.Remove(file);
+                    } else {
+                        blacklistedMods.Add(file);
+                    }
+
+                    if(blacklistedModsOriginal.SetEquals(blacklistedMods)) {
+                        restartMessage.TextColor = Color.Gray;
+                        restartMessage2.TextColor = Color.Gray;
+                    } else {
+                        restartMessage.TextColor = Color.OrangeRed;
+                        restartMessage2.TextColor = Color.OrangeRed;
+                    }
+                }));
+
+            if (!enabled) {
+                blacklistedMods.Add(file);
+            }
+
+            return option;
+        }
+
+        private void onBackPressed(Overworld overworld) {
+            if (blacklistedModsOriginal.SetEquals(blacklistedMods)) {
+                // nothing changed, go back to Mod Options
+                overworld.Goto<OuiModOptions>();
+            } else {
+                // save the blacklist
+                List<string> blacklistedList = blacklistedMods.ToList();
+                blacklistedList.Sort();
+                blacklistedList.Insert(0, "# This is the blacklist. Lines starting with # are ignored.");
+                blacklistedList.Insert(1, "# File generated through the \"Toggle Mods\" menu in Mod Options");
+                blacklistedList.Insert(2, "");
+                File.WriteAllLines(Everest.Loader.PathBlacklist, blacklistedList);
+
+                // delete the whitelist
+                if (File.Exists(Everest.Loader.PathWhitelist)) {
+                    File.Delete(Everest.Loader.PathWhitelist);
+                }
+
+                // restart the game
+                Everest.QuickFullRestart();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Good bad idea of the day: have a big list of all your mods in Mod Options and be able to turn some of them off / cherry pick which ones you want to turn on.

![image](https://user-images.githubusercontent.com/52103563/79441861-11695280-7fd8-11ea-87b4-f4f36c0c52a9.png)

**This is not a true mod toggler**, as in, it won't load/unload mods at runtime. When you exit the menu, it will write all disabled mods to blacklist.txt, delete whitelist.txt, and restart the game. And as such, I don't know if that's such a good idea or not. So, feel free to suggest stuff or to trash the idea entirely.