### PR TITLE
Fix for #158 (center map editor on respawn point)

### DIFF
--- a/Celeste.Mod.mm/Patches/MapEditor.cs
+++ b/Celeste.Mod.mm/Patches/MapEditor.cs
@@ -67,7 +67,6 @@ namespace Celeste.Editor {
             }
 
             Camera.CenterOrigin();
-            Camera.Zoom = 6f;
             CenterViewOnCurrentRespawn();
         }
 


### PR DESCRIPTION
If the map loaded in the editor is the one currently being played:
- opening the map editor will center the view on the current respawn point.
- pressing F2 after moving in the editor will also re-center the view to the current respawn point.