### PR TITLE
Greatly speed up texture loading for runtime mod loading

### DIFF
--- a/Celeste.Mod.mm/Mod/Helpers/MainThreadHelper.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/MainThreadHelper.cs
@@ -115,12 +115,19 @@ namespace Celeste.Mod {
         }
 
         public override void Update(GameTime gameTime) {
-            while (Queue.Count > 0) {
-                Action action;
-                lock (Queue) {
-                    action = Queue.Dequeue();
+            if (Queue.Count > 0) {
+                // run as many tasks as possible in 10 milliseconds (a frame is ~16ms).
+                Stopwatch stopwatch = new Stopwatch();
+                stopwatch.Start();
+                while (stopwatch.ElapsedMilliseconds < 10) {
+                    Action action = null;
+                    lock (Queue) {
+                        if (Queue.Count > 0) {
+                            action = Queue.Dequeue();
+                        }
+                    }
+                    action?.Invoke();
                 }
-                action?.Invoke();
             }
 
             if (gameTime == null)

--- a/Celeste.Mod.mm/Mod/Helpers/MainThreadHelper.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/MainThreadHelper.cs
@@ -117,8 +117,7 @@ namespace Celeste.Mod {
         public override void Update(GameTime gameTime) {
             if (Queue.Count > 0) {
                 // run as many tasks as possible in 10 milliseconds (a frame is ~16ms).
-                Stopwatch stopwatch = new Stopwatch();
-                stopwatch.Start();
+                Stopwatch stopwatch = Stopwatch.StartNew();
                 while (stopwatch.ElapsedMilliseconds < 10) {
                     Action action = null;
                     lock (Queue) {
@@ -128,6 +127,7 @@ namespace Celeste.Mod {
                     }
                     action?.Invoke();
                 }
+                stopwatch.Stop();
             }
 
             if (gameTime == null)


### PR DESCRIPTION
This is a track to speed up runtime mod loading.

To try that out, I started up the game with the collab and all its dependencies minus Extended Variants, then headed to Mod Options to install the missing dependency. Results:
- without this patch: about 1 minute and 5 seconds
- with this patch: about **15 seconds**

This code doesn't look good though... but it greatly speeds up things, because Everest isn't limited to loading 1 texture per frame. So, this is at least a track to explore! Please tell me what can be done to do this in a cleaner way.