### PR TITLE
Ensure that Celeste is not modded before patching

### DIFF
--- a/Celeste.Mod.mm/MonoModRules.cs
+++ b/Celeste.Mod.mm/MonoModRules.cs
@@ -382,11 +382,18 @@ namespace MonoMod {
                 version = new Version(versionInts[0], versionInts[1], versionInts[2], versionInts[3]);
             }
 
+            // Check if Celeste version is supported
             Version versionMin = new Version(1, 3, 1, 2);
             if (version.Major == 0)
                 version = versionMin;
             if (version < versionMin)
-                throw new Exception($"Unsupported version of Celeste: {version}");
+                throw new Exception($"Unsupported version of Celeste: {version}. The minimum required version of Celeste is: {versionMin}.");
+
+            // Ensure that Celeste assembly is not already modded
+            // (https://github.com/MonoMod/MonoMod#how-can-i-check-if-my-assembly-has-been-modded)
+            if (MonoModRule.Modder.FindType("MonoMod.WasHere") != null)
+                throw new Exception("This version of Celeste is already modded. You need a clean install of Celeste to mod it.");
+
 
             // Set up flags.
 

--- a/Celeste.Mod.mm/MonoModRules.cs
+++ b/Celeste.Mod.mm/MonoModRules.cs
@@ -387,7 +387,7 @@ namespace MonoMod {
             if (version.Major == 0)
                 version = versionMin;
             if (version < versionMin)
-                throw new Exception($"Unsupported version of Celeste: {version}. The minimum required version of Celeste is: {versionMin}.");
+                throw new Exception($"Unsupported version of Celeste: {version}");
 
             // Ensure that Celeste assembly is not already modded
             // (https://github.com/MonoMod/MonoMod#how-can-i-check-if-my-assembly-has-been-modded)

--- a/MiniInstaller/Program.cs
+++ b/MiniInstaller/Program.cs
@@ -69,7 +69,9 @@ namespace MiniInstaller {
                     LogLine(e.ToString());
                     LogLine("");
                     LogLine("Installing Everest failed.");
-                    LogLine("Please create a new issue on GitHub @ https://github.com/EverestAPI/Everest");
+                    LogLine("Please review the error after the '--->' to see if you can fix it on your end.");
+                    LogLine("");
+                    LogLine("If you need help, please create a new issue on GitHub @ https://github.com/EverestAPI/Everest");
                     LogLine("or join the #modding_help channel on Discord (invite in the repo).");
                     LogLine("Make sure to upload your miniinstaller-log.txt");
                     return 1;


### PR DESCRIPTION
Check if the Celeste assembly has been patched before actually patching it.

(Slightly changed wording so users should be able to identify the root cause of the installation failure more easily)