### PR TITLE
Add advanced option for AppDomain restart on Ctrl+F5

### DIFF
--- a/Celeste.Mod.mm/Mod/Core/CoreModuleSettings.cs
+++ b/Celeste.Mod.mm/Mod/Core/CoreModuleSettings.cs
@@ -183,7 +183,7 @@ namespace Celeste.Mod.Core {
         [SettingNeedsRelaunch]
         [SettingInGame(false)]
         [SettingIgnore] // TODO: Show as advanced setting.
-        public bool RestartAppDomain { get; set; } = true;
+        public bool RestartAppDomain_WIP { get; set; } = false;
 
         public string InputGui { get; set; } = "";
 

--- a/Celeste.Mod.mm/Mod/Core/CoreModuleSettings.cs
+++ b/Celeste.Mod.mm/Mod/Core/CoreModuleSettings.cs
@@ -180,6 +180,11 @@ namespace Celeste.Mod.Core {
         [SettingIgnore] // TODO: Show as advanced setting.
         public bool? MultithreadedGC { get; set; } = null;
 
+        [SettingNeedsRelaunch]
+        [SettingInGame(false)]
+        [SettingIgnore] // TODO: Show as advanced setting.
+        public bool RestartAppDomain { get; set; } = true;
+
         public string InputGui { get; set; } = "";
 
         private string _MainMenuMode = "";

--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -767,7 +767,7 @@ namespace Celeste.Mod {
         }
 
         public static void QuickFullRestart() {
-            if (AppDomain.CurrentDomain.IsDefaultAppDomain() || !CoreModule.Settings.RestartAppDomain) {
+            if (AppDomain.CurrentDomain.IsDefaultAppDomain() || !CoreModule.Settings.RestartAppDomain_WIP) {
                 SlowFullRestart();
                 return;
             }

--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -767,7 +767,7 @@ namespace Celeste.Mod {
         }
 
         public static void QuickFullRestart() {
-            if (AppDomain.CurrentDomain.IsDefaultAppDomain()) {
+            if (AppDomain.CurrentDomain.IsDefaultAppDomain() || !CoreModule.Settings.RestartAppDomain) {
                 SlowFullRestart();
                 return;
             }


### PR DESCRIPTION
Add a flag in mod settings to allow picking between AppDomain restart and process restart when hitting Ctrl+F5 and similar.

I don't really know what the default value for this should be... AppDomain restarting is slightly faster (1 or 2 seconds from my testing), but it is also leaking memory. If someone has many mods and updates their mods, the game will restart and use way more memory than it should (or run out of memory if they really have many and/or use ANGLE), so it might be a good idea to make AppDomain restarting opt-in instead of opt-out. Any thoughts about that? 

Of note that process restarting does not trigger the "preparing to launch Celeste" thing from Steam.