### PR TITLE
Reload mod save and mod session on dll reload

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
@@ -559,6 +559,18 @@ namespace Celeste.Mod {
                         }
 
                         ((FileSystemWatcher) source).Dispose();
+
+                        // be sure to save this module's save data and session before reloading it, so that they are not lost.
+                        if (SaveData.Instance != null) {
+                            Logger.Log("core", $"Saving save data slot {SaveData.Instance.FileSlot} for {module.Metadata} before reloading");
+                            module.SaveSaveData(SaveData.Instance.FileSlot);
+
+                            if (SaveData.Instance.CurrentSession?.InArea ?? false) {
+                                Logger.Log("core", $"Saving session slot {SaveData.Instance.FileSlot} for {module.Metadata} before reloading");
+                                module.SaveSession(SaveData.Instance.FileSlot);
+                            }
+                        }
+
                         Unregister(module);
                         LoadModAssembly(module.Metadata, asm);
                     });

--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -644,6 +644,18 @@ namespace Celeste.Mod {
                 module.Initialize();
                 Input.Initialize();
 
+                if (SaveData.Instance != null) {
+                    // we are in a save. we are expecting the save data to already be loaded at this point
+                    Logger.Log("core", $"Loading save data slot {SaveData.Instance.FileSlot} for {module.Metadata}");
+                    module.LoadSaveData(SaveData.Instance.FileSlot);
+
+                    if (SaveData.Instance.CurrentSession?.InArea ?? false) {
+                        // we are in a level. we are expecting the session to already be loaded at this point
+                        Logger.Log("core", $"Loading session slot {SaveData.Instance.FileSlot} for {module.Metadata}");
+                        module.LoadSession(SaveData.Instance.FileSlot, false);
+                    }
+                }
+
                 // Check if the module defines a PrepareMapDataProcessors method. If this is the case, we want to reload maps so that they are applied.
                 // We should also run the map data processors again if new berry types are registered, so that CoreMapDataProcessor assigns them checkpoint IDs and orders.
                 if (newStrawberriesRegistered || module.GetType().GetMethod("PrepareMapDataProcessors", new Type[] { typeof(MapDataFixup) })?.DeclaringType == module.GetType()) {


### PR DESCRIPTION
When reloading a mod dll, this patch will save the mod save/mod session before reloading, and load it afterwards. This prevents NullReferenceExceptions that can happen when mods try to access their save/session afterwards when reloaded within a level.