### PR TITLE
Message on the main menu if mod updates are available

### DIFF
--- a/Celeste.Mod.mm/Content/Dialog/English.txt
+++ b/Celeste.Mod.mm/Content/Dialog/English.txt
@@ -32,6 +32,8 @@
 	MENU_MODOPTIONS_ONE_MOD_FAILEDTOLOAD=		1 mod failed to load
 	MENU_MODOPTIONS_MULTIPLE_MODS_FAILEDTOLOAD=	{0} mods failed to load
 	MENU_MODOPTIONS_UPDATE_AVAILABLE=			An Everest update is available
+	MENU_MODOPTIONS_MOD_UPDATE_AVAILABLE=		An update is available for 1 mod
+	MENU_MODOPTIONS_MOD_UPDATES_AVAILABLE=		Updates are available for {0} mods
 
 # Title Screen
 	MENU_TITLESCREEN_RESTART_VANILLA= Restarting into orig/Celeste.exe

--- a/Celeste.Mod.mm/Content/Dialog/French.txt
+++ b/Celeste.Mod.mm/Content/Dialog/French.txt
@@ -14,6 +14,8 @@
 	MENU_MODOPTIONS_ONE_MOD_FAILEDTOLOAD=		1 mod n'a pas pu être chargé
 	MENU_MODOPTIONS_MULTIPLE_MODS_FAILEDTOLOAD=	{0} mods n'ont pas pu être chargés
 	MENU_MODOPTIONS_UPDATE_AVAILABLE=			Une mise à jour d'Everest est disponible
+	MENU_MODOPTIONS_MOD_UPDATE_AVAILABLE=		Mise à jour disponible pour 1 mod
+	MENU_MODOPTIONS_MOD_UPDATES_AVAILABLE=		Mises à jour disponibles pour {0} mods
 	
 # Title Screen
 	MENU_TITLESCREEN_RESTART_VANILLA= Lancement de orig/Celeste.exe

--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -424,10 +424,8 @@ namespace Celeste.Mod {
             // Start requesting the version list ASAP.
             Updater.RequestAll();
 
-            if (CoreModule.Settings.AutoUpdateModsOnStartup) {
-                // Request the mod update list as well.
-                ModUpdaterHelper.RunAsyncCheckForModUpdates();
-            }
+            // Request the mod update list as well.
+            ModUpdaterHelper.RunAsyncCheckForModUpdates();
         }
 
         internal static bool _Initialized;

--- a/Celeste.Mod.mm/Mod/UI/MainMenuModOptionsButton.cs
+++ b/Celeste.Mod.mm/Mod/UI/MainMenuModOptionsButton.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Xna.Framework;
+﻿using Celeste.Mod.Helpers;
+using Microsoft.Xna.Framework;
 using Monocle;
 using System;
 
@@ -19,12 +20,17 @@ namespace Celeste.Mod.UI {
             : base(labelName, iconName, oui, targetPosition, tweenFrom, onConfirm) {
 
             int delayedModCount = Everest.Loader.Delayed.Count;
+            int modUpdatesAvailable = ModUpdaterHelper.IsAsyncUpdateCheckingDone() ? ModUpdaterHelper.GetAsyncLoadedModUpdates().Count : 0;
             if (delayedModCount > 1) {
                 subText = string.Format(Dialog.Get("MENU_MODOPTIONS_MULTIPLE_MODS_FAILEDTOLOAD"), delayedModCount);
             } else if (delayedModCount == 1) {
                 subText = Dialog.Clean("MENU_MODOPTIONS_ONE_MOD_FAILEDTOLOAD");
             } else if (Everest.Updater.HasUpdate) {
                 subText = Dialog.Clean("MENU_MODOPTIONS_UPDATE_AVAILABLE");
+            } else if (modUpdatesAvailable > 1) {
+                subText = string.Format(Dialog.Get("MENU_MODOPTIONS_MOD_UPDATES_AVAILABLE"), modUpdatesAvailable);
+            } else if (modUpdatesAvailable == 1) {
+                subText = Dialog.Clean("MENU_MODOPTIONS_MOD_UPDATE_AVAILABLE");
             } else {
                 subText = null;
             }


### PR DESCRIPTION
Closes #175.

Some people want to keep their mods up-to-date, but have reasons not to enable auto-updating and picking which mods they want to update.

This PR checks for mod updates on startup even if auto-updating is disabled, and shows a message on the main menu if mod updates are available.