### PR TITLE
Add Custom Debris Textures to Dashblocks

### DIFF
--- a/Celeste.Mod.mm/Patches/Autotiler.cs
+++ b/Celeste.Mod.mm/Patches/Autotiler.cs
@@ -1,18 +1,15 @@
 ﻿#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
+#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
 
 using Celeste.Mod;
-using Microsoft.Xna.Framework.Input;
 using Monocle;
-using MonoMod;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Xml;
 
 namespace Celeste {
     class patch_Autotiler : Autotiler {
+
+        private Dictionary<char, patch_TerrainType> lookup;
 
         public patch_Autotiler(string filename)
             : base(filename) {
@@ -25,11 +22,18 @@ namespace Celeste {
 
             if (xml.HasAttr("sound"))
                 SurfaceIndex.TileToIndex[xml.AttrChar("id")] = xml.AttrInt("sound");
+
+            if (xml.HasAttr("debris"))
+                data.Debris = xml.Attr("debris");
+        }
+
+        public bool TryGetCustomDebris(out string path, char tiletype) {
+            return !string.IsNullOrEmpty(path = lookup[tiletype].Debris);
         }
 
         // Required because TerrainType is private.
-        [MonoModIgnore]
         private class patch_TerrainType {
+            public string Debris;
         }
 
     }

--- a/Celeste.Mod.mm/Patches/Debris.cs
+++ b/Celeste.Mod.mm/Patches/Debris.cs
@@ -1,22 +1,26 @@
 ﻿#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
+#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
 
-using Celeste.Mod;
-using Microsoft.Xna.Framework.Input;
-using Monocle;
-using MonoMod;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Xml;
 using Microsoft.Xna.Framework;
+using Monocle;
 
 namespace Celeste {
     class patch_Debris : Debris {
 
+        private Image image;
+
         public Debris Init(Vector2 pos, char tileset) {
             return Init(pos, tileset, true);
+        }
+
+        public extern Debris orig_Init(Vector2 pos, char tileset, bool playSound = true);
+        public new Debris Init(Vector2 pos, char tileset, bool playSound) {
+            patch_Debris debris = (patch_Debris) orig_Init(pos, tileset, playSound);
+
+            if (((patch_Autotiler) GFX.FGAutotiler).TryGetCustomDebris(out string path, tileset))
+                debris.image.Texture = GFX.Game["debris/" + path];
+
+            return debris;
         }
 
     }


### PR DESCRIPTION
Texture can be added by setting the `debris` attribute in the ForegroundTiles.xml tileset definition.
Textures are retrieved from `Graphics/Atlases/Gameplay/debris`.