### PR TITLE
Make dependency downloader open Everest updater if needed + translate Everest updater to French

### DIFF
--- a/Celeste.Mod.mm/Content/Dialog/English.txt
+++ b/Celeste.Mod.mm/Content/Dialog/English.txt
@@ -118,6 +118,25 @@
 	UPDATER_VERSIONS_ERR_FORMAT= 	Unknown format.
 	
 	UPDATER_SRC_BUILDBOT= 			Automatic builds
+	
+# Everest Updater
+	EVERESTUPDATER_NOTSUPPORTED=	Updating not supported on this platform - cancelling.
+	EVERESTUPDATER_NOUPDATE=		No update - cancelling.
+	EVERESTUPDATER_UPDATING=		Updating to {0} (branch: {1}) @ {2}
+	EVERESTUPDATER_DOWNLOADING=		Downloading
+	EVERESTUPDATER_DOWNLOADING_PROGRESS=		Downloading:
+	EVERESTUPDATER_DOWNLOADFAILED=	Download failed!
+	EVERESTUPDATER_DOWNLOADFINISHED=	Download finished.
+	EVERESTUPDATER_EXTRACTING=		Extracting update .zip
+	EVERESTUPDATER_ZIPENTRIES=		entries
+	EVERESTUPDATER_EXTRACTIONFAILED=	Extraction failed!
+	EVERESTUPDATER_EXTRACTIONFINISHED=	Extraction finished.
+	EVERESTUPDATER_RESTARTING=		Restarting
+	EVERESTUPDATER_RESTARTINGIN=	Restarting in {0}
+	EVERESTUPDATER_STARTINGFAILED=	Starting installer failed!
+	EVERESTUPDATER_ERRORHINT1=		Please create a new issue on GitHub @ https://github.com/EverestAPI/Everest
+	EVERESTUPDATER_ERRORHINT2=		or join the #modding_help channel on Discord (invite in the repo).
+	EVERESTUPDATER_ERRORHINT3=		Make sure to upload your log.txt
 
 # Mod Updater
 	MODUPDATECHECKER_MENU_TITLE=	MOD UPDATES
@@ -153,6 +172,7 @@
 	DEPENDENCYDOWNLOADER_DOWNLOADING_DATABASE=		Downloading mod database...
 	DEPENDENCYDOWNLOADER_DOWNLOAD_DATABASE_FAILED=	ERROR: Downloading the database failed. Please check your log.txt for more info.
 	DEPENDENCYDOWNLOADER_MUST_UPDATE_EVEREST=		WARNING: An updated Everest version is required for some mods to load. Install it from the Change Everest Version menu.
+	DEPENDENCYDOWNLOADER_EVEREST_UPDATE=			Everest will be updated to {0} to make some mods work. Press Confirm to continue.
 	DEPENDENCYDOWNLOADER_MOD_NOT_FOUND=				ERROR: {0} could not be found in the database. Please install this mod manually.
 	DEPENDENCYDOWNLOADER_MOD_NOT_AUTO_INSTALLABLE=	ERROR: {0} is available in multiple versions and cannot be installed automatically. Please install this mod manually.
 	DEPENDENCYDOWNLOADER_MOD_BLACKLISTED=			WARNING: {0}.zip is present in your blacklist. Please unblacklist it to be able to use it as a dependency.

--- a/Celeste.Mod.mm/Content/Dialog/French.txt
+++ b/Celeste.Mod.mm/Content/Dialog/French.txt
@@ -101,6 +101,25 @@
 	
 	UPDATER_SRC_BUILDBOT= 			Constructions automatiques
 	
+# Everest Updater
+	EVERESTUPDATER_NOTSUPPORTED=	La mise à jour n'est pas supportée sur cette plateforme - annulation.
+	EVERESTUPDATER_NOUPDATE=		Pas de mise à jour à installer - annulation.
+	EVERESTUPDATER_UPDATING=		Mise à jour vers la version {0} (branche : {1}) @ {2}
+	EVERESTUPDATER_DOWNLOADING=		Téléchargement
+	EVERESTUPDATER_DOWNLOADING_PROGRESS=		Téléchargement :
+	EVERESTUPDATER_DOWNLOADFAILED=	Le téléchargement a échoué.
+	EVERESTUPDATER_DOWNLOADFINISHED=	Téléchargement terminé.
+	EVERESTUPDATER_EXTRACTING=		Extraction du .zip de la mise à jour
+	EVERESTUPDATER_ZIPENTRIES=		fichiers
+	EVERESTUPDATER_EXTRACTIONFAILED=	L'extraction a échoué.
+	EVERESTUPDATER_EXTRACTIONFINISHED=	Extraction terminée.
+	EVERESTUPDATER_RESTARTING=		Redémarrage
+	EVERESTUPDATER_RESTARTINGIN=	Redémarrage dans {0}
+	EVERESTUPDATER_STARTINGFAILED=	Le lancement de l'installateur a échoué.
+	EVERESTUPDATER_ERRORHINT1=		Merci de créer une "issue" sur GitHub @ https://github.com/EverestAPI/Everest
+	EVERESTUPDATER_ERRORHINT2=		ou de rejoindre le salon #modding_help sur Discord (invitation sur le dépôt GitHub),
+	EVERESTUPDATER_ERRORHINT3=		et envoyez votre log.txt.
+
 # Mod Updater
 	MODUPDATECHECKER_MENU_TITLE=	MISE À JOUR DES MODS
 	MODUPDATECHECKER_NOUPDATE=		Aucune mise à jour disponible
@@ -135,6 +154,7 @@
 	DEPENDENCYDOWNLOADER_DOWNLOADING_DATABASE=		Téléchargement de la base de données de mods...
 	DEPENDENCYDOWNLOADER_DOWNLOAD_DATABASE_FAILED=	ERREUR: Le téléchargement de la base de données a échoué. Vérifiez votre log.txt pour plus d'informations.
 	DEPENDENCYDOWNLOADER_MUST_UPDATE_EVEREST=		ATTENTION: Certains de vos mods demandent une version plus récente d'Everest. Installez-la depuis le menu "Changer de version d'Everest".
+	DEPENDENCYDOWNLOADER_EVEREST_UPDATE=			Everest va être mis à jour vers la version {0} pour que certains mods puissent fonctionner. Appuyez sur Confirmer pour continuer.
 	DEPENDENCYDOWNLOADER_MOD_NOT_FOUND=				ERREUR: {0} n'a pas été trouvé dans la base de données. Merci de l'installer manuellement.
 	DEPENDENCYDOWNLOADER_MOD_NOT_AUTO_INSTALLABLE=	ERREUR: {0} possède plusieurs versions et ne peut pas être installé automatiquement. Merci de l'installer manuellement.
 	DEPENDENCYDOWNLOADER_MOD_BLACKLISTED=			ATTENTION: {0}.zip est dans votre blacklist. Retirez-le de la blacklist pour pouvoir l'utiliser comme une dépendance.

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Updater.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Updater.cs
@@ -260,7 +260,7 @@ namespace Celeste.Mod {
             public static void Update(OuiLoggedProgress progress, Entry version = null) {
                 if (!Flags.SupportUpdatingEverest) {
                     progress.Init<OuiModOptions>(Dialog.Clean("updater_title"), new Task(() => { }), 1).Progress = 1;
-                    progress.LogLine("Updating not supported on this platform - cancelling.");
+                    progress.LogLine(Dialog.Clean("EVERESTUPDATER_NOTSUPPORTED"));
                     return;
                 }
 
@@ -269,7 +269,7 @@ namespace Celeste.Mod {
                 if (version == null) {
                     // Exit immediately.
                     progress.Init<OuiModOptions>(Dialog.Clean("updater_title"), new Task(() => { }), 1).Progress = 1;
-                    progress.LogLine("No update - cancelling.");
+                    progress.LogLine(Dialog.Clean("EVERESTUPDATER_NOUPDATE"));
                     return;
                 }
 
@@ -277,46 +277,46 @@ namespace Celeste.Mod {
             }
             private static void _UpdateStart(OuiLoggedProgress progress, Entry version) {
                 // Last line printed on error.
-                const string errorHint = "\nPlease create a new issue on GitHub @ https://github.com/EverestAPI/Everest\nor join the #modding_help channel on Discord (invite in the repo).\nMake sure to upload your log.txt";
+                string errorHint = $"\n{Dialog.Clean("EVERESTUPDATER_ERRORHINT1")}\n{Dialog.Clean("EVERESTUPDATER_ERRORHINT2")}\n{Dialog.Clean("EVERESTUPDATER_ERRORHINT3")}";
 
                 string zipPath = Path.Combine(PathGame, "everest-update.zip");
                 string extractedPath = Path.Combine(PathGame, "everest-update");
 
-                progress.LogLine($"Updating to {version.Name} (branch: {version.Branch}) @ {version.URL}");
+                progress.LogLine(string.Format(Dialog.Get("EVERESTUPDATER_UPDATING"), version.Name, version.Branch, version.URL));
 
-                progress.LogLine($"Downloading");
+                progress.LogLine(Dialog.Clean("EVERESTUPDATER_DOWNLOADING"));
                 try {
                     DownloadFileWithProgress(version.URL, zipPath, (position, length, speed) => {
                         if (length > 0) {
                             progress.Lines[progress.Lines.Count - 1] =
-                                $"Downloading: {((int) Math.Floor(100D * (position / (double) length)))}% @ {speed} KiB/s";
+                                $"{Dialog.Clean("EVERESTUPDATER_DOWNLOADING_PROGRESS")} {((int) Math.Floor(100D * (position / (double) length)))}% @ {speed} KiB/s";
                             progress.Progress = position;
                         } else {
                             progress.Lines[progress.Lines.Count - 1] =
-                                $"Downloading: {((int) Math.Floor(position / 1000D))}KiB @ {speed} KiB/s";
+                                $"{Dialog.Clean("EVERESTUPDATER_DOWNLOADING_PROGRESS")} {((int) Math.Floor(position / 1000D))}KiB @ {speed} KiB/s";
                         }
 
                         progress.ProgressMax = (int) length;
                         return true; // continue downloading
                     });
                 } catch (Exception e) {
-                    progress.LogLine("Download failed!");
+                    progress.LogLine(Dialog.Clean("EVERESTUPDATER_DOWNLOADFAILED"));
                     e.LogDetailed();
                     progress.LogLine(errorHint);
                     progress.Progress = 0;
                     progress.ProgressMax = 1;
                     return;
                 }
-                progress.LogLine("Download finished.");
+                progress.LogLine(Dialog.Clean("EVERESTUPDATER_DOWNLOADFINISHED"));
 
-                progress.LogLine("Extracting update .zip");
+                progress.LogLine(Dialog.Clean("EVERESTUPDATER_EXTRACTING"));
                 try {
                     if (extractedPath != PathGame && Directory.Exists(extractedPath))
                         Directory.Delete(extractedPath, true);
 
                     // Don't use zip.ExtractAll because we want to keep track of the progress.
                     using (ZipFile zip = new ZipFile(zipPath)) {
-                        progress.LogLine($"{zip.Entries.Count} entries");
+                        progress.LogLine($"{zip.Entries.Count} {Dialog.Clean("EVERESTUPDATER_ZIPENTRIES")}");
                         progress.Progress = 0;
                         progress.ProgressMax = zip.Entries.Count;
 
@@ -342,24 +342,21 @@ namespace Celeste.Mod {
                         }
                     }
                 } catch (Exception e) {
-                    progress.LogLine("Extraction failed!");
+                    progress.LogLine(Dialog.Clean("EVERESTUPDATER_EXTRACTIONFAILED"));
                     e.LogDetailed();
                     progress.LogLine(errorHint);
                     progress.Progress = 0;
                     progress.ProgressMax = 1;
                     return;
                 }
-                progress.LogLine("Extraction finished.");
+                progress.LogLine(Dialog.Clean("EVERESTUPDATER_EXTRACTIONFINISHED"));
 
                 progress.Progress = 1;
                 progress.ProgressMax = 1;
-                String action = "Restarting";
-                if (Environment.OSVersion.Platform == PlatformID.Unix) {
-                    action = "Updating";
-                }
+                string action = Dialog.Clean("EVERESTUPDATER_RESTARTING");
                 progress.LogLine(action);
                 for (int i = 3; i > 0; --i) {
-                    progress.Lines[progress.Lines.Count - 1] = $"{action} in {i}";
+                    progress.Lines[progress.Lines.Count - 1] = string.Format(Dialog.Get("EVERESTUPDATER_RESTARTINGIN"), i);
                     Thread.Sleep(1000);
                 }
                 progress.Lines[progress.Lines.Count - 1] = action;
@@ -386,13 +383,11 @@ namespace Celeste.Mod {
                     if (Environment.OSVersion.Platform == PlatformID.Unix) {
                         installer.StartInfo.UseShellExecute = false;
                         installer.Start();
-                        progress.LogLine("Patching the game in-place");
-                        progress.LogLine("Restarting");
                     } else {
                         installer.Start();
                     }
                 } catch (Exception e) {
-                    progress.LogLine("Starting installer failed!");
+                    progress.LogLine(Dialog.Clean("EVERESTUPDATER_STARTINGFAILED"));
                     e.LogDetailed();
                     progress.LogLine(errorHint);
                     progress.Progress = 0;


### PR DESCRIPTION
When an Everest update is needed to satisfy a dependency, the dependency downloader will display a message and hitting Confirm will open the Everest updater. The selected version is latest stable if it is enough to satisfy the dependency, otherwise latest master.