### PR TITLE
Add OnlyX attribute to lookouts

### DIFF
--- a/Celeste.Mod.mm/Patches/Lookout.cs
+++ b/Celeste.Mod.mm/Patches/Lookout.cs
@@ -1,16 +1,31 @@
-﻿#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
+﻿#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
+#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
 
+using Celeste.Mod;
 using Microsoft.Xna.Framework;
 using Monocle;
+using MonoMod;
+using System.Collections;
 
 namespace Celeste {
-    class patch_Lookout : Lookout {
+    public class patch_Lookout : Lookout {
 
+        // We're effectively in Lookout, but still need to "expose" private fields to our mod.
         private bool interacting;
+
+        private bool onlyX;
 
         public patch_Lookout(EntityData data, Vector2 offset)
             : base(data, offset) {
             // no-op. MonoMod ignores this - we only need this to make the compiler shut up.
+        }
+
+        public extern void orig_ctor(EntityData data, Vector2 offset);
+        [MonoModConstructor]
+        public void ctor(EntityData data, Vector2 offset) {
+            orig_ctor(data, offset);
+
+            onlyX = data.Bool("onlyX");
         }
 
         public override void SceneEnd(Scene scene) {
@@ -23,5 +38,18 @@ namespace Celeste {
                 }
             }
         }
+
+        [MonoModIgnore] // don't change anything in the method...
+        [PatchLookoutRoutine] // except for patching it through MonoModRules
+        private extern IEnumerator LookRoutine(Player player);
+
+        public class patch_Hud : Entity{
+            public bool OnlyX;
+
+            [MonoModIgnore] // don't change anything in the method...
+            [PatchLookoutHudRender] // except for patching it through MonoModRules
+            public extern override void Render();
+        }
+
     }
 }


### PR DESCRIPTION
Allows lookouts to be locked to horizontal movement only.
Enabling both onlyX and onlyY attributes locks the lookout in place, if you want that for some reason.