### PR TITLE
Add support for custom moon texture / model

### DIFF
--- a/Celeste.Mod.mm/Mod/Meta/MapMeta.cs
+++ b/Celeste.Mod.mm/Mod/Meta/MapMeta.cs
@@ -449,6 +449,8 @@ namespace Celeste.Mod.Meta {
     public class MapMetaMountain {
         public string MountainModelDirectory { get; set; } = null;
         public string MountainTextureDirectory { get; set; } = null;
+        public string StarFogColor { get; set; } = null;
+        public string[] StarStreamColors { get; set; } = null;
         public MapMetaMountainCamera Idle { get; set; } = null;
         public MapMetaMountainCamera Select { get; set; } = null;
         public MapMetaMountainCamera Zoom { get; set; } = null;
@@ -475,7 +477,7 @@ namespace Celeste.Mod.Meta {
         [YamlMember(Alias = "Offset")] public float[] OffsetArray { get; set; }
         public MapMetaCompleteScreenLayer[] Layers { get; set; }
     }
-    public class MapMetaCompleteScreenLayer { 
+    public class MapMetaCompleteScreenLayer {
         public string Type { get; set; }
         public string[] Images { get; set; }
         [YamlIgnore] public Vector2 Position => PositionArray.ToVector2() ?? Vector2.Zero;

--- a/Celeste.Mod.mm/Patches/MountainModel.cs
+++ b/Celeste.Mod.mm/Patches/MountainModel.cs
@@ -26,8 +26,26 @@ namespace Celeste {
         private Ring fog;
         private Ring fog2;
 
+        private Ring starsky;
+        private Ring starfog;
+        private Ring stardots0;
+        private Ring starstream0;
+        private Ring starstream1;
+        private Ring starstream2;
+
+        private Vector3 starCenter;
+        private float birdTimer;
+
         protected Ring customFog;
         protected Ring customFog2;
+
+        private Ring customStarsky;
+        private Ring customStarfog;
+        private Ring customStardots0;
+        private Ring customStarstream0;
+        private Ring customStarstream1;
+        private Ring customStarstream2;
+
         // Used to check when we transition from a different area
         protected string PreviousSID;
         // How opaque the bg is when transitioning between models
@@ -40,6 +58,13 @@ namespace Celeste {
             orig_ctor();
             customFog = fog;
             customFog2 = fog2;
+
+            customStarsky = starsky;
+            customStarfog = starfog;
+            customStardots0 = stardots0;
+            customStarstream0 = starstream0;
+            customStarstream1 = starstream1;
+            customStarstream2 = starstream2;
         }
 
         public extern void orig_Update();
@@ -54,6 +79,8 @@ namespace Celeste {
                     customFog.TopColor = (customFog.BotColor = Color.Lerp((resources.MountainStates?[currState] ?? mountainStates[currState]).FogColor, (resources.MountainStates?[nextState] ?? mountainStates[nextState]).FogColor, easeState));
                     customFog2.Rotate((0f - Engine.DeltaTime) * 0.01f);
                     customFog2.TopColor = (customFog2.BotColor = Color.White * 0.3f * NearFogAlpha);
+                    customStarstream1.Rotate(Engine.DeltaTime * 0.01f);
+                    customStarstream2.Rotate(Engine.DeltaTime * 0.02f);
                 }
             }
         }
@@ -123,46 +150,79 @@ namespace Celeste {
                     Forward = Vector3.Transform(Vector3.Forward, Camera.Rotation.Conjugated());
                     Engine.Graphics.GraphicsDevice.SetRenderTarget(buffer);
 
-                    Matrix matrix4 = Matrix.CreateTranslation(0f, 5f - Camera.Position.Y * 1.1f, 0f) * Matrix.CreateFromQuaternion(rotation) * matrix;
+                    if (StarEase < 1f) {
+                        Matrix matrix4 = Matrix.CreateTranslation(0f, 5f - Camera.Position.Y * 1.1f, 0f) * Matrix.CreateFromQuaternion(rotation) * matrix;
 
-                    if (currState == nextState) {
-                        (resources.MountainStates?[currState] ?? mountainStates[currState]).Skybox.Draw(matrix4, Color.White);
-                    } else {
-                        (resources.MountainStates?[currState] ?? mountainStates[currState]).Skybox.Draw(matrix4, Color.White);
-                        (resources.MountainStates?[currState] ?? mountainStates[currState]).Skybox.Draw(matrix4, Color.White * easeState);
+                        if (currState == nextState) {
+                            (resources.MountainStates?[currState] ?? mountainStates[currState]).Skybox.Draw(matrix4, Color.White);
+                        } else {
+                            (resources.MountainStates?[currState] ?? mountainStates[currState]).Skybox.Draw(matrix4, Color.White);
+                            (resources.MountainStates?[currState] ?? mountainStates[currState]).Skybox.Draw(matrix4, Color.White * easeState);
+                        }
+                        if (currState != nextState) {
+                            GFX.FxMountain.Parameters["ease"].SetValue(easeState);
+                            GFX.FxMountain.CurrentTechnique = GFX.FxMountain.Techniques["Easing"];
+                        } else {
+                            GFX.FxMountain.CurrentTechnique = GFX.FxMountain.Techniques["Single"];
+                        }
+                        Engine.Graphics.GraphicsDevice.DepthStencilState = DepthStencilState.Default;
+                        Engine.Graphics.GraphicsDevice.BlendState = BlendState.AlphaBlend;
+                        Engine.Graphics.GraphicsDevice.RasterizerState = MountainRasterizer;
+                        GFX.FxMountain.Parameters["WorldViewProj"].SetValue(matrix3);
+                        GFX.FxMountain.Parameters["fog"].SetValue(customFog.TopColor.ToVector3());
+                        Engine.Graphics.GraphicsDevice.Textures[0] = (resources.MountainStates?[currState] ?? mountainStates[currState]).TerrainTexture.Texture;
+                        Engine.Graphics.GraphicsDevice.SamplerStates[0] = SamplerState.LinearClamp;
+                        if (currState != nextState) {
+                            Engine.Graphics.GraphicsDevice.Textures[1] = (resources.MountainStates?[nextState] ?? mountainStates[nextState]).TerrainTexture.Texture;
+                            Engine.Graphics.GraphicsDevice.SamplerStates[1] = SamplerState.LinearClamp;
+                        }
+                        (resources.MountainTerrain ?? MTN.MountainTerrain).Draw(GFX.FxMountain);
+                        GFX.FxMountain.Parameters["WorldViewProj"].SetValue(Matrix.CreateTranslation(CoreWallPosition) * matrix3);
+                        (resources.MountainCoreWall ?? MTN.MountainCoreWall).Draw(GFX.FxMountain);
+                        GFX.FxMountain.Parameters["WorldViewProj"].SetValue(matrix3);
+                        Engine.Graphics.GraphicsDevice.Textures[0] = (resources.MountainStates?[currState] ?? mountainStates[currState]).BuildingsTexture.Texture;
+                        Engine.Graphics.GraphicsDevice.SamplerStates[0] = SamplerState.LinearClamp;
+                        if (currState != nextState) {
+                            Engine.Graphics.GraphicsDevice.Textures[1] = (resources.MountainStates?[nextState] ?? mountainStates[nextState]).BuildingsTexture.Texture;
+                            Engine.Graphics.GraphicsDevice.SamplerStates[1] = SamplerState.LinearClamp;
+                        }
+                        (resources.MountainBuildings ?? MTN.MountainBuildings).Draw(GFX.FxMountain);
+                        customFog.Draw(matrix3);
                     }
-                    if (currState != nextState) {
-                        GFX.FxMountain.Parameters["ease"].SetValue(easeState);
-                        GFX.FxMountain.CurrentTechnique = GFX.FxMountain.Techniques["Easing"];
-                    } else {
+
+                    if (StarEase > 0f) {
+                        Draw.SpriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.LinearClamp, null, null);
+                        Draw.Rect(0f, 0f, buffer.Width, buffer.Height, Color.Black * Ease.CubeInOut(Calc.ClampedMap(StarEase, 0f, 0.6f)));
+                        Draw.SpriteBatch.End();
+                        Matrix matrix5 = Matrix.CreateTranslation(starCenter - Camera.Position) * Matrix.CreateFromQuaternion(rotation) * matrix;
+                        float alpha = Calc.ClampedMap(StarEase, 0.8f, 1f);
+                        customStarsky.Draw(matrix5, CullCCRasterizer, alpha);
+                        customStarfog.Draw(matrix5, CullCCRasterizer, alpha);
+                        customStardots0.Draw(matrix5, CullCCRasterizer, alpha);
+                        customStarstream0.Draw(matrix5, CullCCRasterizer, alpha);
+                        customStarstream1.Draw(matrix5, CullCCRasterizer, alpha);
+                        customStarstream2.Draw(matrix5, CullCCRasterizer, alpha);
+                        Engine.Graphics.GraphicsDevice.DepthStencilState = DepthStencilState.Default;
+                        Engine.Graphics.GraphicsDevice.BlendState = BlendState.AlphaBlend;
+                        Engine.Graphics.GraphicsDevice.RasterizerState = CullCRasterizer;
+                        Engine.Graphics.GraphicsDevice.Textures[0] = (resources.MountainMoonTexture ?? MTN.MountainMoonTexture).Texture;
+                        Engine.Graphics.GraphicsDevice.SamplerStates[0] = SamplerState.LinearClamp;
                         GFX.FxMountain.CurrentTechnique = GFX.FxMountain.Techniques["Single"];
+                        GFX.FxMountain.Parameters["WorldViewProj"].SetValue(matrix3);
+                        GFX.FxMountain.Parameters["fog"].SetValue(fog.TopColor.ToVector3());
+                        (resources.MountainMoon ?? MTN.MountainMoon).Draw(GFX.FxMountain);
+                        float num = birdTimer * 0.2f;
+                        Matrix matrix6 = Matrix.CreateScale(0.25f) * Matrix.CreateRotationZ((float) Math.Cos(num * 2f) * 0.5f) * Matrix.CreateRotationX(0.4f + (float) Math.Sin(num) * 0.05f) * Matrix.CreateRotationY(0f - num - (float) Math.PI / 2f) * Matrix.CreateTranslation((float) Math.Cos(num) * 2.2f, 31f + (float) Math.Sin(num * 2f) * 0.8f, (float) Math.Sin(num) * 2.2f);
+                        GFX.FxMountain.Parameters["WorldViewProj"].SetValue(matrix6 * matrix3);
+                        GFX.FxMountain.Parameters["fog"].SetValue(fog.TopColor.ToVector3());
+                        (resources.MountainBird ?? MTN.MountainBird).Draw(GFX.FxMountain);
                     }
-                    Engine.Graphics.GraphicsDevice.DepthStencilState = DepthStencilState.Default;
-                    Engine.Graphics.GraphicsDevice.BlendState = BlendState.AlphaBlend;
-                    Engine.Graphics.GraphicsDevice.RasterizerState = MountainRasterizer;
-                    GFX.FxMountain.Parameters["WorldViewProj"].SetValue(matrix3);
-                    GFX.FxMountain.Parameters["fog"].SetValue(customFog.TopColor.ToVector3());
-                    Engine.Graphics.GraphicsDevice.Textures[0] = (resources.MountainStates?[currState] ?? mountainStates[currState]).TerrainTexture.Texture;
-                    Engine.Graphics.GraphicsDevice.SamplerStates[0] = SamplerState.LinearClamp;
-                    if (currState != nextState) {
-                        Engine.Graphics.GraphicsDevice.Textures[1] = (resources.MountainStates?[nextState] ?? mountainStates[nextState]).TerrainTexture.Texture;
-                        Engine.Graphics.GraphicsDevice.SamplerStates[1] = SamplerState.LinearClamp;
-                    }
-                    (resources.MountainTerrain ?? MTN.MountainTerrain).Draw(GFX.FxMountain);
-                    GFX.FxMountain.Parameters["WorldViewProj"].SetValue(Matrix.CreateTranslation(CoreWallPosition) * matrix3);
-                    (resources.MountainCoreWall ?? MTN.MountainCoreWall).Draw(GFX.FxMountain);
-                    GFX.FxMountain.Parameters["WorldViewProj"].SetValue(matrix3);
-                    Engine.Graphics.GraphicsDevice.Textures[0] = (resources.MountainStates?[currState] ?? mountainStates[currState]).BuildingsTexture.Texture;
-                    Engine.Graphics.GraphicsDevice.SamplerStates[0] = SamplerState.LinearClamp;
-                    if (currState != nextState) {
-                        Engine.Graphics.GraphicsDevice.Textures[1] = (resources.MountainStates?[nextState] ?? mountainStates[nextState]).BuildingsTexture.Texture;
-                        Engine.Graphics.GraphicsDevice.SamplerStates[1] = SamplerState.LinearClamp;
-                    }
-                    (resources.MountainBuildings ?? MTN.MountainBuildings).Draw(GFX.FxMountain);
-                    customFog.Draw(matrix3);
 
                     DrawBillboards(matrix3, scene.Tracker.GetComponents<Billboard>());
-                    customFog2.Draw(matrix3, CullCRasterizer);
+
+                    if (StarEase < 1f) {
+                        customFog2.Draw(matrix3, CullCRasterizer);
+                    }
 
                     if (DrawDebugPoints && DebugPoints.Count > 0) {
                         GFX.FxDebug.World = Matrix.Identity;
@@ -183,9 +243,15 @@ namespace Celeste {
                     Draw.SpriteBatch.End();
 
                     // Initialize new custom fog when we switch between maps
-                    if (!(SIDToUse).Equals(PreviousSID) && resources.MountainFogTexture != null) {
+                    if (!(SIDToUse).Equals(PreviousSID)) {
                         customFog = new Ring(6f, -1f, 20f, 0f, 24, Color.White, resources.MountainFogTexture ?? MTN.MountainFogTexture);
                         customFog2 = new Ring(6f, -4f, 10f, 0f, 24, Color.White, resources.MountainFogTexture ?? MTN.MountainFogTexture);
+                        customStarsky = new Ring(18f, -18f, 20f, 0f, 24, Color.White, Color.Transparent, resources.MountainSpaceTexture ?? MTN.MountainStarSky);
+                        customStarfog = new Ring(10f, -18f, 19.5f, 0f, 24, resources.StarFogColor ?? Calc.HexToColor("020915"), Color.Transparent, resources.MountainFogTexture ?? MTN.MountainFogTexture);
+                        customStardots0 = new Ring(16f, -18f, 19f, 0f, 24, Color.White, Color.Transparent, resources.MountainSpaceStarsTexture ?? MTN.MountainStars, 4f);
+                        customStarstream0 = new Ring(5f, -8f, 18.5f, 0.2f, 80, resources.StarStreamColors?[0] ?? Color.Black, resources.MountainStarStreamTexture ?? MTN.MountainStarStream);
+                        customStarstream1 = new Ring(4f, -6f, 18f, 1f, 80, resources.StarStreamColors?[1] ?? Calc.HexToColor("9228e2") * 0.5f, resources.MountainStarStreamTexture ?? MTN.MountainStarStream);
+                        customStarstream2 = new Ring(3f, -4f, 17.9f, 1.4f, 80, resources.StarStreamColors?[2] ?? Calc.HexToColor("30ffff") * 0.5f, resources.MountainStarStreamTexture ?? MTN.MountainStarStream);
                     }
                     PreviousSID = SIDToUse;
                     return;


### PR DESCRIPTION
This completes the "custom mountain" feature to add support for the moon as well.

The YAML definition can look like that:
```yaml
Mountain:
  MountainModelDirectory: mycustommodels
  MountainTextureDirectory: mycustomtextures
  StarFogColor: 0F0804
  StarStreamColors:
    - 000000
    - 705C4B
    - CCC1B6
```

(there is some decompiler variable naming in this code, in particular the "matrix" variables, but that was the case with the existing code, and to be honest I'm not sure how those matrix transformations work, so I don't know how to name those variables better.)