### PR TITLE
Add support for custom overworld music through map metadata

### DIFF
--- a/Celeste.Mod.mm/Mod/Meta/MapMeta.cs
+++ b/Celeste.Mod.mm/Mod/Meta/MapMeta.cs
@@ -449,6 +449,7 @@ namespace Celeste.Mod.Meta {
     public class MapMetaMountain {
         public string MountainModelDirectory { get; set; } = null;
         public string MountainTextureDirectory { get; set; } = null;
+        public string BackgroundMusic { get; set; } = null;
         public string StarFogColor { get; set; } = null;
         public string[] StarStreamColors { get; set; } = null;
         public MapMetaMountainCamera Idle { get; set; } = null;

--- a/Celeste.Mod.mm/Patches/Overworld.cs
+++ b/Celeste.Mod.mm/Patches/Overworld.cs
@@ -34,6 +34,25 @@ namespace Celeste {
         public override void Update() {
             lock (AssetReloadHelper.AreaReloadLock) {
                 orig_Update();
+
+                if (string.IsNullOrEmpty(Audio.CurrentMusic)) {
+                    // don't change music if no music is currently playing
+                    return;
+                }
+
+                if (SaveData.Instance != null && (IsCurrent<OuiChapterSelect>() || IsCurrent<OuiChapterPanel>() || IsCurrent<OuiMapList>() || IsCurrent<OuiMapSearch>())) {
+                    string backgroundMusic = AreaData.Get(SaveData.Instance.LastArea)?.GetMeta()?.Mountain?.BackgroundMusic;
+                    if (backgroundMusic != null) {
+                        // current map has custom background music
+                        Audio.SetMusic(backgroundMusic);
+                    } else {
+                        // current map has no custom background music
+                        SetNormalMusic();
+                    }
+                } else {
+                    // no save is loaded or we are not in chapter select
+                    SetNormalMusic();
+                }
             }
         }
     }

--- a/Celeste.Mod.mm/Patches/Overworld.cs
+++ b/Celeste.Mod.mm/Patches/Overworld.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 
 namespace Celeste {
     class patch_Overworld : Overworld {
+        private bool customizedChapterSelectMusic = false;
 
         public patch_Overworld(OverworldLoader loader)
             : base(loader) {
@@ -45,14 +46,22 @@ namespace Celeste {
                     if (backgroundMusic != null) {
                         // current map has custom background music
                         Audio.SetMusic(backgroundMusic);
+                        customizedChapterSelectMusic = true;
                     } else {
                         // current map has no custom background music
-                        SetNormalMusic();
+                        restoreNormalMusicIfCustomized();
                     }
                 } else {
                     // no save is loaded or we are not in chapter select
-                    SetNormalMusic();
+                    restoreNormalMusicIfCustomized();
                 }
+            }
+        }
+
+        private void restoreNormalMusicIfCustomized() {
+            if (customizedChapterSelectMusic) {
+                SetNormalMusic();
+                customizedChapterSelectMusic = false;
             }
         }
     }


### PR DESCRIPTION
Can be used like this:
```cs
Mountain:
    BackgroundMusic: event:/max480/test_music
```

Calling Audio.SetMusic repeatedly is fine, since this method doesn't do anything if the music you're asking for is already playing.