### PR TITLE
Custom star belt color on the overworld through metadata

### DIFF
--- a/Celeste.Mod.mm/Mod/Meta/MapMeta.cs
+++ b/Celeste.Mod.mm/Mod/Meta/MapMeta.cs
@@ -452,6 +452,8 @@ namespace Celeste.Mod.Meta {
         public string BackgroundMusic { get; set; } = null;
         public string StarFogColor { get; set; } = null;
         public string[] StarStreamColors { get; set; } = null;
+        public string[] StarBeltColors1 { get; set; } = null;
+        public string[] StarBeltColors2 { get; set; } = null;
         public MapMetaMountainCamera Idle { get; set; } = null;
         public MapMetaMountainCamera Select { get; set; } = null;
         public MapMetaMountainCamera Zoom { get; set; } = null;

--- a/Celeste.Mod.mm/Patches/MTN.cs
+++ b/Celeste.Mod.mm/Patches/MTN.cs
@@ -62,6 +62,9 @@ namespace Celeste {
 
         public Color? StarFogColor;
         public Color[] StarStreamColors;
+
+        public Color[] StarBeltColors1;
+        public Color[] StarBeltColors2;
     }
 
     public static class MTNExt {
@@ -170,10 +173,13 @@ namespace Celeste {
                                 resources.StarFogColor = Calc.HexToColor(meta.Mountain.StarFogColor);
                             }
                             if (meta.Mountain.StarStreamColors != null) {
-                                resources.StarStreamColors = new Color[meta.Mountain.StarStreamColors.Length];
-                                for (int i = 0; i < meta.Mountain.StarStreamColors.Length; i++) {
-                                    resources.StarStreamColors[i] = Calc.HexToColor(meta.Mountain.StarStreamColors[i]);
-                                }
+                                resources.StarStreamColors = parseColorArray(meta.Mountain.StarStreamColors);
+                            }
+                            if (meta.Mountain.StarBeltColors1 != null) {
+                                resources.StarBeltColors1 = parseColorArray(meta.Mountain.StarBeltColors1);
+                            }
+                            if (meta.Mountain.StarBeltColors2 != null) {
+                                resources.StarBeltColors2 = parseColorArray(meta.Mountain.StarBeltColors2);
                             }
 
                             // Use the default textures if no custom ones were loaded
@@ -187,6 +193,14 @@ namespace Celeste {
                 Console.WriteLine(" - MODDED MTN LOAD: " + stopwatch.ElapsedMilliseconds + "ms");
             }
             ModsLoaded = true;
+        }
+
+        private static Color[] parseColorArray(string[] array) {
+            Color[] result = new Color[array.Length];
+            for (int i = 0; i < array.Length; i++) {
+                result[i] = Calc.HexToColor(array[i]);
+            }
+            return result;
         }
     }
 }

--- a/Celeste.Mod.mm/Patches/MoonParticle3D.cs
+++ b/Celeste.Mod.mm/Patches/MoonParticle3D.cs
@@ -28,17 +28,17 @@ namespace Celeste {
                 for (int i = 0; i < 20; i++) {
                     Add(new Particle(OVR.Atlas["star"], Calc.Random.Choose(starColors1), center, 1f, matrix));
                 }
-                for (int j = 0; j < 30; j++) {
+                for (int i = 0; i < 30; i++) {
                     Add(new Particle(OVR.Atlas["snow"], Calc.Random.Choose(starColors1), center, 0.3f, matrix));
                 }
             }
-            Matrix matrix2 = Matrix.CreateRotationZ(0.8f) * Matrix.CreateRotationX(0.4f);
+            matrix = Matrix.CreateRotationZ(0.8f) * Matrix.CreateRotationX(0.4f);
             if (starColors2.Length != 0) {
-                for (int k = 0; k < 20; k++) {
-                    Add(new Particle(OVR.Atlas["star"], Calc.Random.Choose(starColors2), center, 1f, matrix2));
+                for (int i = 0; i < 20; i++) {
+                    Add(new Particle(OVR.Atlas["star"], Calc.Random.Choose(starColors2), center, 1f, matrix));
                 }
-                for (int l = 0; l < 30; l++) {
-                    Add(new Particle(OVR.Atlas["snow"], Calc.Random.Choose(starColors2), center, 0.3f, matrix2));
+                for (int i = 0; i < 30; i++) {
+                    Add(new Particle(OVR.Atlas["snow"], Calc.Random.Choose(starColors2), center, 0.3f, matrix));
                 }
             }
         }

--- a/Celeste.Mod.mm/Patches/MoonParticle3D.cs
+++ b/Celeste.Mod.mm/Patches/MoonParticle3D.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.Xna.Framework;
+using Monocle;
+using MonoMod;
+using System.Collections.Generic;
+
+namespace Celeste {
+    class patch_MoonParticle3D : MoonParticle3D {
+        private MountainModel model;
+        private List<Particle> particles;
+
+        public patch_MoonParticle3D(MountainModel model, Vector3 center, Color[] starColors1, Color[] starColors2) : base(model, center) {
+            // dummy constructor
+        }
+
+        [MonoModLinkTo("Monocle.Entity", "System.Void .ctor()")]
+        [MonoModIgnore]
+        public extern void EntityCtor();
+
+        [MonoModConstructor]
+        public void ctor(MountainModel model, Vector3 center, Color[] starColors1, Color[] starColors2) {
+            particles = new List<Particle>();
+            EntityCtor();
+
+            this.model = model;
+            Visible = false;
+            Matrix matrix = Matrix.CreateRotationZ(0.4f);
+            if (starColors1.Length != 0) {
+                for (int i = 0; i < 20; i++) {
+                    Add(new Particle(OVR.Atlas["star"], Calc.Random.Choose(starColors1), center, 1f, matrix));
+                }
+                for (int j = 0; j < 30; j++) {
+                    Add(new Particle(OVR.Atlas["snow"], Calc.Random.Choose(starColors1), center, 0.3f, matrix));
+                }
+            }
+            Matrix matrix2 = Matrix.CreateRotationZ(0.8f) * Matrix.CreateRotationX(0.4f);
+            if (starColors2.Length != 0) {
+                for (int k = 0; k < 20; k++) {
+                    Add(new Particle(OVR.Atlas["star"], Calc.Random.Choose(starColors2), center, 1f, matrix2));
+                }
+                for (int l = 0; l < 30; l++) {
+                    Add(new Particle(OVR.Atlas["snow"], Calc.Random.Choose(starColors2), center, 0.3f, matrix2));
+                }
+            }
+        }
+    }
+}

--- a/Celeste.Mod.mm/Patches/MountainModel.cs
+++ b/Celeste.Mod.mm/Patches/MountainModel.cs
@@ -10,6 +10,7 @@ using MonoMod;
 using Celeste.Mod;
 using Celeste.Mod.Meta;
 using System.IO;
+using System.Linq;
 
 namespace Celeste {
     class patch_MountainModel : MountainModel {
@@ -46,6 +47,9 @@ namespace Celeste {
         private Ring customStarstream1;
         private Ring customStarstream2;
 
+        private MoonParticle3D vanillaMoonParticles;
+        private MoonParticle3D customMoonParticles;
+
         // Used to check when we transition from a different area
         protected string PreviousSID;
         // How opaque the bg is when transitioning between models
@@ -73,7 +77,7 @@ namespace Celeste {
             string path = Path.Combine("Maps", SaveData.Instance?.LastArea.GetSID() ?? "").Replace('\\', '/');
             if (SaveData.Instance != null && Everest.Content.TryGet(path, out ModAsset asset)) {
                 MapMeta meta;
-                if (asset != null && (meta = asset.GetMeta<MapMeta>()) != null && meta.Mountain != null && !(string.IsNullOrEmpty(meta.Mountain.MountainModelDirectory) && string.IsNullOrEmpty(meta.Mountain.MountainTextureDirectory))) {
+                if (asset != null && (meta = asset.GetMeta<MapMeta>()) != null && meta.Mountain != null && hasCustomSettings(meta)) {
                     MountainResources resources = MTNExt.MountainMappings[path];
                     customFog.Rotate((0f - Engine.DeltaTime) * 0.01f);
                     customFog.TopColor = (customFog.BotColor = Color.Lerp((resources.MountainStates?[currState] ?? mountainStates[currState]).FogColor, (resources.MountainStates?[nextState] ?? mountainStates[nextState]).FogColor, easeState));
@@ -90,30 +94,39 @@ namespace Celeste {
 
         public extern void orig_BeforeRender(Scene scene);
         public new void BeforeRender(Scene scene) {
+            if (vanillaMoonParticles == null) {
+                vanillaMoonParticles = (Engine.Scene as Overworld).Entities.OfType<MoonParticle3D>().First();
+            }
+
             string path = Path.Combine("Maps", SaveData.Instance?.LastArea.GetSID() ?? "").Replace('\\', '/');
             string SIDToUse = SaveData.Instance?.LastArea.GetSID() ?? "";
             bool fadingIn = true;
-            // Check if we're changing mountain models or textures
+            // Check if we're changing any mountain parameter
             // If so, we want to fade out and then back in
             if (!(SaveData.Instance?.LastArea.GetSID() ?? "").Equals(PreviousSID)) {
-                string oldModelDir = "", oldTextureDir = "", newModelDir = "", newTextureDir = "";
+                MapMetaMountain oldMountain = null;
+                MapMetaMountain newMountain = null;
                 if (SaveData.Instance != null && Everest.Content.TryGet(path, out ModAsset asset1)) {
                     MapMeta meta;
                     if (asset1 != null && (meta = asset1.GetMeta<MapMeta>()) != null && meta.Mountain != null) {
-                        newModelDir = meta.Mountain.MountainModelDirectory ?? "";
-                        newTextureDir = meta.Mountain.MountainTextureDirectory ?? "";
+                        newMountain = meta.Mountain;
                     }
                 }
                 string oldPath = Path.Combine("Maps", PreviousSID ?? "").Replace('\\', '/');
                 if (SaveData.Instance != null && Everest.Content.TryGet(oldPath, out asset1)) {
                     MapMeta meta;
                     if (asset1 != null && (meta = asset1.GetMeta<MapMeta>()) != null && meta.Mountain != null) {
-                        oldModelDir = meta.Mountain.MountainModelDirectory ?? "";
-                        oldTextureDir = meta.Mountain.MountainTextureDirectory ?? "";
+                        oldMountain = meta.Mountain;
                     }
                 }
 
-                if (!oldModelDir.Equals(newModelDir) || !oldTextureDir.Equals(newTextureDir)) {
+                if (oldMountain?.MountainModelDirectory != newMountain?.MountainModelDirectory
+                    || oldMountain?.MountainTextureDirectory != newMountain?.MountainTextureDirectory
+                    || oldMountain?.StarFogColor != newMountain?.StarFogColor
+                    || !arrayEqual(oldMountain?.StarStreamColors, newMountain?.StarStreamColors)
+                    || !arrayEqual(oldMountain?.StarBeltColors1, newMountain?.StarBeltColors1)
+                    || !arrayEqual(oldMountain?.StarBeltColors2, newMountain?.StarBeltColors2)) {
+
                     if (fade != 1f) {
                         SIDToUse = PreviousSID;
                         path = oldPath;
@@ -136,7 +149,7 @@ namespace Celeste {
 
             if (SaveData.Instance != null && Everest.Content.TryGet(path, out ModAsset asset)) {
                 MapMeta meta;
-                if (asset != null && (meta = asset.GetMeta<MapMeta>()) != null && meta.Mountain != null && !(string.IsNullOrEmpty(meta.Mountain.MountainModelDirectory) && string.IsNullOrEmpty(meta.Mountain.MountainTextureDirectory))) {
+                if (asset != null && (meta = asset.GetMeta<MapMeta>()) != null && meta.Mountain != null && hasCustomSettings(meta)) {
                     MountainResources resources = MTNExt.MountainMappings[path];
 
                     ResetRenderTargets();
@@ -242,7 +255,7 @@ namespace Celeste {
                     Draw.Rect(-10f, -10f, 1940f, 1100f, Color.Black * fade);
                     Draw.SpriteBatch.End();
 
-                    // Initialize new custom fog when we switch between maps
+                    // Initialize new custom fog and star belt when we switch between maps
                     if (!(SIDToUse).Equals(PreviousSID)) {
                         customFog = new Ring(6f, -1f, 20f, 0f, 24, Color.White, resources.MountainFogTexture ?? MTN.MountainFogTexture);
                         customFog2 = new Ring(6f, -4f, 10f, 0f, 24, Color.White, resources.MountainFogTexture ?? MTN.MountainFogTexture);
@@ -252,10 +265,30 @@ namespace Celeste {
                         customStarstream0 = new Ring(5f, -8f, 18.5f, 0.2f, 80, resources.StarStreamColors?[0] ?? Color.Black, resources.MountainStarStreamTexture ?? MTN.MountainStarStream);
                         customStarstream1 = new Ring(4f, -6f, 18f, 1f, 80, resources.StarStreamColors?[1] ?? Calc.HexToColor("9228e2") * 0.5f, resources.MountainStarStreamTexture ?? MTN.MountainStarStream);
                         customStarstream2 = new Ring(3f, -4f, 17.9f, 1.4f, 80, resources.StarStreamColors?[2] ?? Calc.HexToColor("30ffff") * 0.5f, resources.MountainStarStreamTexture ?? MTN.MountainStarStream);
+
+                        if (Engine.Scene is Overworld thisOverworld) {
+                            thisOverworld.Remove(customMoonParticles);
+                            if (resources.StarBeltColors1 != null && resources.StarBeltColors2 != null) {
+                                // there are custom moon particle colors. build the new particles and add them to the scene
+                                thisOverworld.Remove(vanillaMoonParticles);
+                                thisOverworld.Add(customMoonParticles = new patch_MoonParticle3D(this, new Vector3(0f, 31f, 0f), resources.StarBeltColors1, resources.StarBeltColors2));
+                            } else {
+                                // there are no more moon particle colors. restore the vanilla particles
+                                customMoonParticles = null;
+                                thisOverworld.Add(vanillaMoonParticles);
+                            }
+                        }
                     }
                     PreviousSID = SIDToUse;
                     return;
                 }
+            }
+
+            if (customMoonParticles != null && Engine.Scene is Overworld overworld) {
+                // revert back the moon particles to vanilla.
+                overworld.Remove(customMoonParticles);
+                customMoonParticles = null;
+                overworld.Add(vanillaMoonParticles);
             }
 
             orig_BeforeRender(scene);
@@ -267,5 +300,17 @@ namespace Celeste {
             PreviousSID = SIDToUse;
         }
 
+        private static bool hasCustomSettings(MapMeta meta) {
+            return !string.IsNullOrEmpty(meta.Mountain.MountainModelDirectory) || !string.IsNullOrEmpty(meta.Mountain.MountainTextureDirectory)
+                || !string.IsNullOrEmpty(meta.Mountain.StarFogColor) || meta.Mountain.StarStreamColors != null
+                || (meta.Mountain.StarBeltColors1 != null && meta.Mountain.StarBeltColors2 != null);
+        }
+
+        private bool arrayEqual(string[] array1, string[] array2) {
+            if (array1 == null || array2 == null) {
+                return array1 == array2;
+            }
+            return Enumerable.SequenceEqual(array1, array2);
+        }
     }
 }


### PR DESCRIPTION
This:
```yaml
Mountain:
  StarBeltColors1:
    - ff0000
  StarBeltColors2:
    - 00ff00
```
gives this:

![image](https://user-images.githubusercontent.com/52103563/87474751-e799e900-c623-11ea-9e8f-89b6fcd1bba2.png)

There also is the possibility to pass empty arrays to remove half of the star belt or to remove it entirely.

~~This is my last PR messing with the moon on the overworld I swear~~