### PR TITLE
Customize log level through modsettings-Everest.celeste and code

### DIFF
--- a/Celeste.Mod.mm/Mod/Core/CoreModule.cs
+++ b/Celeste.Mod.mm/Mod/Core/CoreModule.cs
@@ -79,7 +79,7 @@ namespace Celeste.Mod.Core {
             }
 
             foreach (KeyValuePair<string, LogLevel> logLevel in Settings.LogLevels) {
-                Logger.SetLogLevelFromYaml(new Regex(logLevel.Key), logLevel.Value);
+                Logger.SetLogLevelFromYaml(logLevel.Key, logLevel.Value);
             }
         }
 

--- a/Celeste.Mod.mm/Mod/Core/CoreModule.cs
+++ b/Celeste.Mod.mm/Mod/Core/CoreModule.cs
@@ -17,6 +17,7 @@ using MonoMod.Utils;
 using Microsoft.Xna.Framework.Input;
 using System.Threading;
 using Stopwatch = System.Diagnostics.Stopwatch;
+using System.Text.RegularExpressions;
 
 namespace Celeste.Mod.Core {
     /// <summary>
@@ -75,6 +76,10 @@ namespace Celeste.Mod.Core {
             if (Everest.Flags.IsMobile) {
                 // It shouldn't look that bad on mobile screens...
                 Environment.SetEnvironmentVariable("FNA_OPENGL_BACKBUFFER_SCALE_NEAREST", "1");
+            }
+
+            foreach (KeyValuePair<string, LogLevel> logLevel in Settings.LogLevels) {
+                Logger.SetLogLevelFromYaml(new Regex(logLevel.Key), logLevel.Value);
             }
         }
 

--- a/Celeste.Mod.mm/Mod/Core/CoreModuleSettings.cs
+++ b/Celeste.Mod.mm/Mod/Core/CoreModuleSettings.cs
@@ -240,6 +240,9 @@ namespace Celeste.Mod.Core {
         [SettingIgnore]
         public string CurrentBranch { get; set; }
 
+        [SettingIgnore]
+        public Dictionary<string, LogLevel> LogLevels { get; set; } = new Dictionary<string, LogLevel>();
+
         /*
         [SettingRange(0, 10)]
         public int ExampleSlider { get; set; } = 5;

--- a/Celeste.Mod.mm/Mod/Everest/Logger.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Logger.cs
@@ -5,32 +5,31 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace Celeste.Mod {
     public static class Logger {
 
-        private static Dictionary<Regex, LogLevel> minimumLevels = new Dictionary<Regex, LogLevel>();
-        private static Dictionary<Regex, LogLevel> minimumLevelsFromEverestSettings = new Dictionary<Regex, LogLevel>();
+        private static Dictionary<string, LogLevel> minimumLevels = new Dictionary<string, LogLevel>();
+        private static Dictionary<string, LogLevel> minimumLevelsFromEverestSettings = new Dictionary<string, LogLevel>();
         private static Dictionary<string, LogLevel> minimumLevelsCache = new Dictionary<string, LogLevel>();
 
         /// <summary>
-        /// Sets the minimum log level to be written in the logs for lines matching the given tag.
-        /// When using this, make sure the tag regex is restrictive enough not to impact other mods
-        /// (for example, if all your tags follow the format MyMod/xxx, use "^MyMod/" as a regex).
+        /// Sets the minimum log level to be written in the logs for lines matching the given tag prefix.
+        /// When using this, make sure the tag prefix is restrictive enough not to impact other mods
+        /// (for example, if all your tags follow the format MyMod/xxx, use "MyMod/" as a prefix).
         /// </summary>
-        /// <param name="tagRegex">A regex matching the tags to affect with this log level</param>
+        /// <param name="tagPrefix">The prefix of the log tags to affect with this log level</param>
         /// <param name="minimumLevel">The minimum level of logs to print out in the logs</param>
         /// (useful to make levels set by code overridable through modsettings-Everest.celeste)</param>
-        public static void SetLogLevel(Regex tagRegex, LogLevel minimumLevel) {
-            minimumLevels[tagRegex] = minimumLevel;
+        public static void SetLogLevel(string tagPrefix, LogLevel minimumLevel) {
+            minimumLevels[tagPrefix] = minimumLevel;
             minimumLevelsCache.Clear();
         }
 
         // same as above, but for internal Everest use
-        internal static void SetLogLevelFromYaml(Regex tagRegex, LogLevel minimumLevel) {
-            minimumLevelsFromEverestSettings[tagRegex] = minimumLevel;
+        internal static void SetLogLevelFromYaml(string tagPrefix, LogLevel minimumLevel) {
+            minimumLevelsFromEverestSettings[tagPrefix] = minimumLevel;
             minimumLevelsCache.Clear();
         }
 
@@ -44,28 +43,31 @@ namespace Celeste.Mod {
                 return cachedLevel;
             }
 
-            LogLevel? wantedLogLevel = null;
-
-            // check log levels defined in mod settings.
-            foreach (Regex regex in minimumLevelsFromEverestSettings.Keys) {
-                if (regex.IsMatch(tag)) {
-                    wantedLogLevel = minimumLevelsFromEverestSettings[regex];
-                    break;
-                }
-            }
-
+            // look for the wanted log level in mod settings first, in rules set through code next.
+            LogLevel? wantedLogLevel = findMatchingLogLevel(minimumLevelsFromEverestSettings, tag);
             if (!wantedLogLevel.HasValue) {
-                // no log level defined in mod settings matches - check log levels defined through code.
-                foreach (Regex regex in minimumLevels.Keys) {
-                    if (regex.IsMatch(tag)) {
-                        wantedLogLevel = minimumLevels[regex];
-                        break;
-                    }
-                }
+                wantedLogLevel = findMatchingLogLevel(minimumLevels, tag);
             }
 
+            // cache and return it.
             minimumLevelsCache[tag] = wantedLogLevel ?? LogLevel.Verbose;
             return wantedLogLevel ?? LogLevel.Verbose;
+        }
+
+        private static LogLevel? findMatchingLogLevel(Dictionary<string, LogLevel> rules, string tag) {
+            // take the rules in reverse alphabetical order, so that the longest ones come first.
+            List<string> prefixes = rules.Keys.ToList();
+            prefixes.Sort((a, b) => b.CompareTo(a));
+
+            // try matching all rules.
+            foreach (string prefix in prefixes) {
+                if (tag.StartsWith(prefix)) {
+                    return rules[prefix];
+                }
+            }
+
+            // none matched
+            return null;
         }
 
         private static bool shouldLog(string tag, LogLevel level) {

--- a/Celeste.Mod.mm/Mod/Everest/Logger.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Logger.cs
@@ -16,12 +16,12 @@ namespace Celeste.Mod {
 
         /// <summary>
         /// Sets the minimum log level to be written in the logs for lines matching the given tag prefix.
+        /// <br />
         /// When using this, make sure the tag prefix is restrictive enough not to impact other mods
         /// (for example, if all your tags follow the format MyMod/xxx, use "MyMod/" as a prefix).
         /// </summary>
         /// <param name="tagPrefix">The prefix of the log tags to affect with this log level</param>
         /// <param name="minimumLevel">The minimum level of logs to print out in the logs</param>
-        /// (useful to make levels set by code overridable through modsettings-Everest.celeste)</param>
         public static void SetLogLevel(string tagPrefix, LogLevel minimumLevel) {
             minimumLevels[tagPrefix] = minimumLevel;
             minimumLevelsCache.Clear();

--- a/Celeste.Mod.mm/Mod/Everest/Logger.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Logger.cs
@@ -5,10 +5,72 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace Celeste.Mod {
     public static class Logger {
+
+        private static Dictionary<Regex, LogLevel> minimumLevels = new Dictionary<Regex, LogLevel>();
+        private static Dictionary<Regex, LogLevel> minimumLevelsFromEverestSettings = new Dictionary<Regex, LogLevel>();
+        private static Dictionary<string, LogLevel> minimumLevelsCache = new Dictionary<string, LogLevel>();
+
+        /// <summary>
+        /// Sets the minimum log level to be written in the logs for lines matching the given tag.
+        /// When using this, make sure the tag regex is restrictive enough not to impact other mods
+        /// (for example, if all your tags follow the format MyMod/xxx, use "^MyMod/" as a regex).
+        /// </summary>
+        /// <param name="tagRegex">A regex matching the tags to affect with this log level</param>
+        /// <param name="minimumLevel">The minimum level of logs to print out in the logs</param>
+        /// (useful to make levels set by code overridable through modsettings-Everest.celeste)</param>
+        public static void SetLogLevel(Regex tagRegex, LogLevel minimumLevel) {
+            minimumLevels[tagRegex] = minimumLevel;
+            minimumLevelsCache.Clear();
+        }
+
+        // same as above, but for internal Everest use
+        internal static void SetLogLevelFromYaml(Regex tagRegex, LogLevel minimumLevel) {
+            minimumLevelsFromEverestSettings[tagRegex] = minimumLevel;
+            minimumLevelsCache.Clear();
+        }
+
+        /// <summary>
+        /// Gets the minimum log level that will be written in log.txt for the given tag.
+        /// </summary>
+        /// <param name="tag">The tag to get the minimum log level for</param>
+        /// <returns>The minimum log level for this tag</returns>
+        public static LogLevel GetLogLevel(string tag) {
+            if (minimumLevelsCache.TryGetValue(tag, out LogLevel cachedLevel)) {
+                return cachedLevel;
+            }
+
+            LogLevel? wantedLogLevel = null;
+
+            // check log levels defined in mod settings.
+            foreach (Regex regex in minimumLevelsFromEverestSettings.Keys) {
+                if (regex.IsMatch(tag)) {
+                    wantedLogLevel = minimumLevelsFromEverestSettings[regex];
+                    break;
+                }
+            }
+
+            if (!wantedLogLevel.HasValue) {
+                // no log level defined in mod settings matches - check log levels defined through code.
+                foreach (Regex regex in minimumLevels.Keys) {
+                    if (regex.IsMatch(tag)) {
+                        wantedLogLevel = minimumLevels[regex];
+                        break;
+                    }
+                }
+            }
+
+            minimumLevelsCache[tag] = wantedLogLevel ?? LogLevel.Verbose;
+            return wantedLogLevel ?? LogLevel.Verbose;
+        }
+
+        private static bool shouldLog(string tag, LogLevel level) {
+            return GetLogLevel(tag) <= level;
+        }
 
         // TODO: Allow displaying mod log in future ImGui UI
 
@@ -26,14 +88,16 @@ namespace Celeste.Mod {
         /// <param name="tag">The tag, preferably short enough to identify your mod, but not too long to clutter the log.</param>
         /// <param name="str">The string / message to log.</param>
         public static void Log(LogLevel level, string tag, string str) {
-            Console.Write("(");
-            Console.Write(DateTime.Now);
-            Console.Write(") [Everest] [");
-            Console.Write(level.ToString());
-            Console.Write("] [");
-            Console.Write(tag);
-            Console.Write("] ");
-            Console.WriteLine(str);
+            if (shouldLog(tag, level)) {
+                Console.Write("(");
+                Console.Write(DateTime.Now);
+                Console.Write(") [Everest] [");
+                Console.Write(level.ToString());
+                Console.Write("] [");
+                Console.Write(tag);
+                Console.Write("] ");
+                Console.WriteLine(str);
+            }
         }
 
         /// <summary>
@@ -41,10 +105,9 @@ namespace Celeste.Mod {
         /// </summary>
         /// <param name="tag">The tag, preferably short enough to identify your mod, but not too long to clutter the log.</param>
         /// <param name="str">The string / message to log.</param>
-        public static void LogDetailed(string tag, string str) {
-            Log(LogLevel.Verbose, tag, str);
-            Console.WriteLine(new StackTrace(1, true).ToString());
-        }
+        public static void LogDetailed(string tag, string str)
+            => LogDetailed(LogLevel.Verbose, tag, str);
+
         /// <summary>
         /// Log a string to the console and to log.txt, including a call stack trace.
         /// </summary>
@@ -53,8 +116,10 @@ namespace Celeste.Mod {
         /// <param name="str">The string / message to log.</param>
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static void LogDetailed(LogLevel level, string tag, string str) {
-            Log(level, tag, str);
-            Console.WriteLine(new StackTrace(1, true).ToString());
+            if (shouldLog(tag, level)) {
+                Log(level, tag, str);
+                Console.WriteLine(new StackTrace(1, true).ToString());
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Allows customizing log levels through two ways:
- **in code**: a mod can call this in its Load method:
```cs
Logger.SetLogLevel(new Regex("^MyCoolMod/"), LogLevel.Info);
```
This will make only Info and higher logs appear in log.txt for tags starting with "MyCoolMod/" by default.
- **in modsettings-Everest.celeste**: by adding this to the file:
```yaml
LogLevels:
  ^ExtendedVariantMode/: Info
  ^DJMapHelper/: Info
```
someone can customize the log levels for each mod.

YAML log levels take priority over log levels set through code: the idea is that the developer of the mod can set the log level to Verbose while working on it, and have the default log level set to Info through code. This way, verbose logs only appear in the developer's log, and don't clutter other people's logs.

@rhelmot would this cover what you need? 😅 