### PR TITLE
Add support for custom chapter cards

### DIFF
--- a/Celeste.Mod.mm/MonoModRules.cs
+++ b/Celeste.Mod.mm/MonoModRules.cs
@@ -307,6 +307,12 @@ namespace MonoMod {
     [MonoModCustomMethodAttribute("PatchTextMenuOptionColor")]
     class PatchTextMenuOptionColorAttribute : Attribute { };
 
+    /// <summary>
+    /// Patches chapter panel rendering to allow for custom chapter cards.
+    /// </summary>
+    [MonoModCustomMethodAttribute("PatchOuiChapterPanelRender")]
+    class PatchOuiChapterPanelRenderAttribute : Attribute { };
+
     static class MonoModRules {
 
         static bool IsCeleste;
@@ -2498,6 +2504,32 @@ namespace MonoMod {
                     instrs.Insert(instri++, il.Create(OpCodes.Ldfld, f_this));
                     instr.OpCode = OpCodes.Ldfld;
                     instr.Operand = f_speed;
+                }
+            }
+        }
+
+        public static void PatchOuiChapterPanelRender(MethodDefinition method, CustomAttribute attrib) {
+            if (!method.HasBody)
+                return;
+
+            MethodDefinition m_ModCardTexture = method.DeclaringType.FindMethod("System.String _ModCardTexture(System.String,Celeste.OuiChapterPanel)");
+            if (m_ModCardTexture == null)
+                return;
+
+            Mono.Collections.Generic.Collection<Instruction> instrs = method.Body.Instructions;
+            ILProcessor il = method.Body.GetILProcessor();
+            for (int instri = 0; instri < instrs.Count; instri++) {
+                Instruction instr = instrs[instri];
+
+                if (instr.OpCode == OpCodes.Ldstr && ((string) instr.Operand).StartsWith("areaselect/card")) {
+                    // Move to after the string is loaded.
+                    instri++;
+                    // Push this.
+                    instrs.Insert(instri, il.Create(OpCodes.Ldarg_0));
+                    instri++;
+                    // Insert method call to modify the string.
+                    instrs.Insert(instri, il.Create(OpCodes.Call, m_ModCardTexture));
+                    instri++;
                 }
             }
         }

--- a/Celeste.Mod.mm/Patches/OuiChapterPanel.cs
+++ b/Celeste.Mod.mm/Patches/OuiChapterPanel.cs
@@ -199,5 +199,29 @@ namespace Celeste {
             LevelEnter.Go(new Session(Area, checkpoint), false);
         }
 
+        [MonoModIgnore] // We don't want to change anything about the method...
+        [PatchOuiChapterPanelRender] // ... except for manually manipulating the method via MonoModRules
+        public new extern void Render();
+
+        private static string _ModCardTexture(string textureName, patch_OuiChapterPanel self) {
+            // First, check for area (chapter) specific card textures.
+            string area = AreaData.Areas[self.Area.ID].Name;
+            string areaTextureName = textureName.Replace("areaselect/card", $"areaselect/{area}_card");
+            if (GFX.Gui.Has(areaTextureName)) {
+                textureName = areaTextureName;
+                return textureName;
+            }
+
+            // If none are found, fall back to levelset card textures.
+            string levelSet = SaveData.Instance?.GetLevelSet() ?? "Celeste";
+            string levelSetTextureName = textureName.Replace("areaselect/", $"areaselect/{levelSet}/");
+            if (GFX.Gui.Has(levelSetTextureName)) {
+                textureName = levelSetTextureName;
+                return textureName;
+            }
+
+            // If that doesn't exist either, return without changing anything.
+            return textureName;
+        }
     }
 }


### PR DESCRIPTION
This adds support for custom chapter select cards. Cards for a whole levelset can be added in `Gui/areaselect/campaignname/card`, while cards for individual chapters go in `Gui/areaselect/campaignname/mapname_card`, mirroring the format for custom scarf textures. There are four images in a full set of chapter card textures: `card`, `cardtop`, `card_golden`, and `cardtop_golden`. If any of these is missing, it will fall back to the corresponding vanilla texture.

The approach of modifying each string with a method call was suggested by @max4805 in order to avoid conflicting with existing code mods that modify chapter card textures by IL patching those strings. I've verified that this patch does not conflict with [Frozen Heights](https://gamebanana.com/maps/211420), which is the only mod I'm aware of that does this.