### PR TITLE
Add Inherited option to TrackedAsAttribute

### DIFF
--- a/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
@@ -1,5 +1,6 @@
 ﻿using Celeste.Mod;
 using Celeste.Mod.Helpers;
+using MonoMod;
 using System;
 using System.Collections.Generic;
 
@@ -9,13 +10,24 @@ namespace Monocle {
     /// </summary>
     public class TrackedAsAttribute : Attribute {
         public Type TrackedAsType;
+        public bool Inherited;
 
         public TrackedAsAttribute(Type trackedAsType) {
             TrackedAsType = trackedAsType;
         }
+
+        /// <inheritdoc cref="TrackedAsAttribute(Type)"/>
+        /// <param name="inherited">Whether all child classes should also be tracked as <paramref name="trackedAsType"/>.</param>
+        public TrackedAsAttribute(Type trackedAsType, bool inherited = false) {
+            TrackedAsType = trackedAsType;
+            Inherited = inherited;
+        }
     }
 
     class patch_Tracker : Tracker {
+        [MonoModIgnore]
+        public static extern List<Type> GetSubclasses(Type type);
+
 #pragma warning disable CS0626 // method, operator or getter is tagged external and has no attribute
         public static extern void orig_Initialize();
 #pragma warning restore CS0626
@@ -28,7 +40,9 @@ namespace Monocle {
             foreach (Type type in types) {
                 object[] customAttributes = type.GetCustomAttributes(typeof(TrackedAsAttribute), inherit: false);
                 foreach (object customAttribute in customAttributes) {
-                    Type trackedAsType = (customAttribute as TrackedAsAttribute).TrackedAsType;
+                    TrackedAsAttribute trackedAs = customAttribute as TrackedAsAttribute;
+                    Type trackedAsType = trackedAs.TrackedAsType;
+                    bool inherited = trackedAs.Inherited;
                     if (typeof(Entity).IsAssignableFrom(type)) {
                         if (!type.IsAbstract) {
                             // this is an entity. copy the registered types for the target entity
@@ -37,6 +51,16 @@ namespace Monocle {
                             }
                             TrackedEntityTypes[type].AddRange(TrackedEntityTypes.TryGetValue(trackedAsType, out List<Type> list) ? list : new List<Type>());
                         }
+                        if (inherited) {
+                            // do the same for subclasses
+                            foreach (Type subclass in GetSubclasses(type)) {
+                                if (!subclass.IsAbstract) {
+                                    if (!TrackedEntityTypes.ContainsKey(subclass))
+                                        TrackedEntityTypes.Add(subclass, new List<Type>());
+                                    TrackedEntityTypes[subclass].AddRange(TrackedEntityTypes.TryGetValue(trackedAsType, out List<Type> list) ? list : new List<Type>());
+                                }
+                            }
+                        }
                     } else if (typeof(Component).IsAssignableFrom(type)) {
                         if (!type.IsAbstract) {
                             // this is an component. copy the registered types for the target component
@@ -44,6 +68,16 @@ namespace Monocle {
                                 TrackedComponentTypes.Add(type, new List<Type>());
                             }
                             TrackedComponentTypes[type].AddRange(TrackedComponentTypes.TryGetValue(trackedAsType, out List<Type> list) ? list : new List<Type>());
+                        }
+                        if (inherited) {
+                            // do the same for subclasses
+                            foreach (Type subclass in GetSubclasses(type)) {
+                                if (!subclass.IsAbstract) {
+                                    if (!TrackedComponentTypes.ContainsKey(subclass))
+                                        TrackedComponentTypes.Add(subclass, new List<Type>());
+                                    TrackedComponentTypes[subclass].AddRange(TrackedComponentTypes.TryGetValue(trackedAsType, out List<Type> list) ? list : new List<Type>());
+                                }
+                            }
                         }
                     } else {
                         // this is neither an entity nor a component. Help!

--- a/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
@@ -3,6 +3,7 @@ using Celeste.Mod.Helpers;
 using MonoMod;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Monocle {
     /// <summary>
@@ -50,6 +51,7 @@ namespace Monocle {
                                 TrackedEntityTypes.Add(type, new List<Type>());
                             }
                             TrackedEntityTypes[type].AddRange(TrackedEntityTypes.TryGetValue(trackedAsType, out List<Type> list) ? list : new List<Type>());
+                            TrackedEntityTypes[type] = TrackedEntityTypes[type].Distinct().ToList();
                         }
                         if (inherited) {
                             // do the same for subclasses
@@ -58,6 +60,7 @@ namespace Monocle {
                                     if (!TrackedEntityTypes.ContainsKey(subclass))
                                         TrackedEntityTypes.Add(subclass, new List<Type>());
                                     TrackedEntityTypes[subclass].AddRange(TrackedEntityTypes.TryGetValue(trackedAsType, out List<Type> list) ? list : new List<Type>());
+                                    TrackedEntityTypes[subclass] = TrackedEntityTypes[type].Distinct().ToList();
                                 }
                             }
                         }
@@ -68,6 +71,7 @@ namespace Monocle {
                                 TrackedComponentTypes.Add(type, new List<Type>());
                             }
                             TrackedComponentTypes[type].AddRange(TrackedComponentTypes.TryGetValue(trackedAsType, out List<Type> list) ? list : new List<Type>());
+                            TrackedComponentTypes[type] = TrackedComponentTypes[type].Distinct().ToList();
                         }
                         if (inherited) {
                             // do the same for subclasses
@@ -76,6 +80,7 @@ namespace Monocle {
                                     if (!TrackedComponentTypes.ContainsKey(subclass))
                                         TrackedComponentTypes.Add(subclass, new List<Type>());
                                     TrackedComponentTypes[subclass].AddRange(TrackedComponentTypes.TryGetValue(trackedAsType, out List<Type> list) ? list : new List<Type>());
+                                    TrackedComponentTypes[subclass] = TrackedComponentTypes[type].Distinct().ToList();
                                 }
                             }
                         }


### PR DESCRIPTION
Allows for a entity that is `TrackedAs` another to pass the tracked status to its subclasses.
Also cleans up duplicate types from `TrackedEntityTypes` and `TrackedComponentTypes` resulting from adding `TrackedAs` entities.