### PR TITLE
Add new NonGameplayLazyLoading hidden setting

### DIFF
--- a/Celeste.Mod.mm/Mod/Core/CoreModuleSettings.cs
+++ b/Celeste.Mod.mm/Mod/Core/CoreModuleSettings.cs
@@ -155,6 +155,9 @@ namespace Celeste.Mod.Core {
             set => LazyLoading_Yes_I_Know_This_Can_Cause_Bugs = value;
         }
 
+        [SettingIgnore]
+        public bool NonGameplayLazyLoading { get; set; } = true;
+
         [SettingNeedsRelaunch]
         [SettingInGame(false)]
         [SettingIgnore] // TODO: Show as advanced setting.

--- a/Celeste.Mod.mm/Patches/LevelLoader.cs
+++ b/Celeste.Mod.mm/Patches/LevelLoader.cs
@@ -37,6 +37,8 @@ namespace Celeste {
 
             if (CoreModule.Settings.LazyLoading) {
                 MainThreadHelper.Do(() => VirtualContentExt.UnloadOverworld());
+            } else if (CoreModule.Settings.NonGameplayLazyLoading) {
+                MainThreadHelper.Do(() => patch_VirtualContent.UnloadLazyLoadedNonGameplayElements());
             }
 
             // Vanilla TileToIndex mappings.

--- a/Celeste.Mod.mm/Patches/Monocle/VirtualContent.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/VirtualContent.cs
@@ -3,6 +3,7 @@
 #pragma warning disable CS0169 // The field is never used
 #pragma warning disable CS0414 // The field is assigned but its value is never used
 
+using Celeste;
 using Celeste.Mod;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
@@ -76,6 +77,20 @@ namespace Monocle {
                     path = path.Substring(17);
                     if (path.StartsWith("Opening") || path.StartsWith("Overworld") || path.StartsWith("Mountain") || path.StartsWith("Journal")) {
                         asset.Unload();
+                    }
+                }
+            }
+        }
+
+        public static void UnloadLazyLoadedNonGameplayElements() {
+            foreach (VirtualAsset asset in assets) {
+                if (asset is VirtualTexture tex) {
+                    // unload everything that should be lazily loaded, except map icons because that causes a slight freeze when going back to the overworld.
+                    if (!((patch_VirtualTexture) (object) tex).ShouldNotBeLazilyLoaded()
+                        && (!tex.Name.StartsWith("Graphics/Atlases/Gui/") || AreaData.Areas == null
+                        || !AreaData.Areas.Any(area => tex.Name.Substring(21).Equals(area.Icon, StringComparison.InvariantCultureIgnoreCase)))) {
+
+                        tex.Unload();
                     }
                 }
             }


### PR DESCRIPTION
Some try at a middle ground between "let's load everything" and "load stuff as it's needed, even if it causes stutter during gameplay".

Here is an option, enabled by default, that enables lazy loading for _some_ assets, everything excluding:
- everything from base game
- everything in the Gameplay, Misc and Mountain atlases
- all color grades

This aims at minimizing RAM usage by, for example, not loading all the maps' checkpoint images, while not introducing stutter in gameplay since gameplay assets are not lazy loaded. On my test install with 150 mods, this cut down RAM usage from ~3 to ~2 GB.

Main questions are:
- good idea or bad idea? 🤔 
- enabled or disabled by default?
- anything I overlooked?