### PR TITLE
Make watchtower can be placed behind Solid.

### DIFF
--- a/Celeste.Mod.mm/MonoModRules.cs
+++ b/Celeste.Mod.mm/MonoModRules.cs
@@ -2591,6 +2591,7 @@ namespace MonoMod {
             // this.talk = (TalkComponent) null;
 
             int indexTarget = -1;
+            MethodReference collideCheckMethodReference = null;
             for (int instri = 0; instri < instrs.Count - 5; instri++) {
                 if (instrs[instri].OpCode == OpCodes.Ldarg_0
                     && instrs[instri + 1].OpCode == OpCodes.Ldfld && (instrs[instri + 1].Operand as FieldReference)?.FullName == lookoutTalkFieldName
@@ -2600,6 +2601,7 @@ namespace MonoMod {
                     && (instrs[instri + 5].OpCode == OpCodes.Brfalse_S || instrs[instri + 5].OpCode == OpCodes.Br_S)
                 ) {
                     indexTarget = instri;
+                    collideCheckMethodReference = instrs[instri + 4].Operand as MethodReference;
                     break;
                 }
             }
@@ -2614,6 +2616,27 @@ namespace MonoMod {
             ILProcessor il = method.Body.GetILProcessor();
             instrs[indexTarget].OpCode = OpCodes.Nop;
             instrs[indexTarget + 1] = il.Create(OpCodes.Ldc_I4_0);
+
+            // insert at begin
+            // if (talk.UI != null) {
+            //     talk.UI.Visible = !CollideCheck<Solid>();
+            // }
+            int indexInsert = 0;
+            Instruction startIns = instrs[0];
+
+            instrs.Insert(indexInsert, il.Create(OpCodes.Ldarg_0));
+            instrs.Insert(++indexInsert, il.Create(OpCodes.Ldfld, method.DeclaringType.FindField("talk")));
+            instrs.Insert(++indexInsert, il.Create(OpCodes.Ldfld, method.Module.GetType("Celeste.TalkComponent").FindField("UI")));
+            instrs.Insert(++indexInsert, il.Create(OpCodes.Brfalse_S, startIns));
+
+            instrs.Insert(++indexInsert, il.Create(OpCodes.Ldarg_0));
+            instrs.Insert(++indexInsert, il.Create(OpCodes.Ldfld, method.DeclaringType.FindField("talk")));
+            instrs.Insert(++indexInsert, il.Create(OpCodes.Ldfld, method.Module.GetType("Celeste.TalkComponent").FindField("UI")));
+            instrs.Insert(++indexInsert, il.Create(OpCodes.Ldarg_0));
+            instrs.Insert(++indexInsert, il.Create(OpCodes.Call, collideCheckMethodReference));
+            instrs.Insert(++indexInsert, il.Create(OpCodes.Ldc_I4_0));
+            instrs.Insert(++indexInsert, il.Create(OpCodes.Ceq));
+            instrs.Insert(++indexInsert, il.Create(OpCodes.Stfld, method.Module.GetType("Monocle.Entity").FindField("Visible")));
         }
 
         public static void PostProcessor(MonoModder modder) {

--- a/Celeste.Mod.mm/Patches/Lookout.cs
+++ b/Celeste.Mod.mm/Patches/Lookout.cs
@@ -2,6 +2,7 @@
 
 using Microsoft.Xna.Framework;
 using Monocle;
+using MonoMod;
 
 namespace Celeste {
     class patch_Lookout : Lookout {
@@ -12,6 +13,10 @@ namespace Celeste {
             : base(data, offset) {
             // no-op. MonoMod ignores this - we only need this to make the compiler shut up.
         }
+
+        [MonoModIgnore]
+        [PatchLookoutUpdate]
+        public override extern void Update();
 
         public override void SceneEnd(Scene scene) {
             base.SceneEnd(scene);


### PR DESCRIPTION
In the vanilla, placing watchtower behind `Solid` would crash the game on `TalkComponentUI.awake()`.

	System.NullReferenceException: 未将对象引用设置到对象的实例。
	   在 Celeste.TalkComponent.TalkComponentUI.Awake(Scene scene)

```csharp
// Lookout
public override void Update() {
	...
	if (talk != null && CollideCheck<Solid>()) {
		Remove(talk);
		talk = null;
	}
    // after patch
	if (false && CollideCheck<Solid>()) {
		Remove(talk);
		talk = null;
	}
}
```

```csharp
// TalkComponentUI
public override void Awake(Scene scene) {
	base.Awake(scene);
	if (Scene.CollideCheck<FakeWall>(Handler.Entity.Position)) {  // <-- Handler.Entity == talk.Entity == null
		alpha = 0f;
	}
}
```