### PR TITLE
Keep a short history of old log.txt files (3 by default)

### DIFF
--- a/Celeste.Mod.mm/Mod/Core/CoreModule.cs
+++ b/Celeste.Mod.mm/Mod/Core/CoreModule.cs
@@ -81,6 +81,18 @@ namespace Celeste.Mod.Core {
             foreach (KeyValuePair<string, LogLevel> logLevel in Settings.LogLevels) {
                 Logger.SetLogLevelFromYaml(logLevel.Key, logLevel.Value);
             }
+
+            if (Directory.Exists("LogHistory")) {
+                int historyToKeep = Math.Max(Settings.LogHistoryCountToKeep, 0); // just in case someone tries to set the value to -42
+                while (Directory.GetFiles("LogHistory", "log_*.txt").Length > historyToKeep) {
+                    // we have to delete 1 more file: the first in alphabetical order, which should be the oldest.
+                    List<string> files = Directory.GetFiles("LogHistory", "log_*.txt").ToList();
+                    files.Sort();
+
+                    Logger.Log("core", $"log.txt history: keeping {historyToKeep} file(s) of history, deleting {files[0]}");
+                    File.Delete(files[0]);
+                }
+            }
         }
 
         public override void Initialize() {

--- a/Celeste.Mod.mm/Mod/Core/CoreModuleSettings.cs
+++ b/Celeste.Mod.mm/Mod/Core/CoreModuleSettings.cs
@@ -158,6 +158,9 @@ namespace Celeste.Mod.Core {
         [SettingIgnore]
         public string DefaultStartingLevelSet { get; set; } = "Celeste";
 
+        [SettingIgnore]
+        public int LogHistoryCountToKeep { get; set; } = 3;
+
         [SettingNeedsRelaunch]
         [SettingInGame(false)]
         [SettingIgnore] // TODO: Show as advanced setting.

--- a/Celeste.Mod.mm/Patches/Celeste.cs
+++ b/Celeste.Mod.mm/Patches/Celeste.cs
@@ -104,8 +104,21 @@ namespace Celeste {
                 return;
             }
 
-            if (File.Exists("log.txt"))
-                File.Delete("log.txt");
+            if (File.Exists("log.txt")) {
+                if (new FileInfo("log.txt").Length > 0) {
+                    // move the old log.txt to the LogHistory folder.
+                    // note that the cleanup will only be done when the core module is loaded: the settings aren't even loaded right now,
+                    // so we don't know how many files we should keep.
+                    if (!Directory.Exists("LogHistory")) {
+                        Directory.CreateDirectory("LogHistory");
+                    }
+                    File.Move("log.txt", Path.Combine("LogHistory", "log_" + File.GetLastAccessTime("log.txt").ToString("yyyyMMdd_HHmmss") + ".txt"));
+                } else {
+                    // log is empty! (this actually happens more often than you'd think, because of Steam re-opening Celeste)
+                    // just delete it.
+                    File.Delete("log.txt");
+                }
+            }
 
             using (Stream fileStream = new FileStream("log.txt", FileMode.OpenOrCreate, FileAccess.Write, FileShare.ReadWrite | FileShare.Delete))
             using (StreamWriter fileWriter = new StreamWriter(fileStream, Console.OutputEncoding))


### PR DESCRIPTION
On Celeste startup, if log.txt exists and is not empty, Everest will move it to a `LogHistory` folder, naming it after the file's last modified date. Then, if there are more files than the configured maximum count, Everest will delete some, beginning with the first ones in alphabetical order (since they're named with their date, this should be the oldest ones).

Moving log.txt happens on early startup (`Celeste.Main`) because this has to happen before Everest starts writing to it; deleting oldest log.txts happens on CoreModule loading (`CoreModule.Load`) because the mod settings have to be loaded to access the `LogHistoryCountToKeep` mod setting.