### PR TITLE
Add Optional Dependencies support

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
@@ -58,6 +58,8 @@ namespace Celeste.Mod {
             internal static List<Tuple<EverestModuleMetadata, Action>> Delayed = new List<Tuple<EverestModuleMetadata, Action>>();
             internal static int DelayedLock;
 
+            private static bool enforceOptionalDependencies;
+
             internal static HashSet<string> FilesWithMetadataLoadFailures = new HashSet<string>();
 
             internal static readonly Version _VersionInvalid = new Version(int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue);
@@ -167,6 +169,8 @@ namespace Celeste.Mod {
 
                 Stopwatch watch = Stopwatch.StartNew();
 
+                enforceOptionalDependencies = true;
+
                 string[] files = Directory.GetFiles(PathMods);
                 for (int i = 0; i < files.Length; i++) {
                     string file = Path.GetFileName(files[i]);
@@ -186,6 +190,10 @@ namespace Celeste.Mod {
                         continue;
                     LoadDir(Path.Combine(PathMods, file));
                 }
+
+                enforceOptionalDependencies = false;
+                Logger.Log(LogLevel.Info, "loader", "Loading mods with unsatisfied optional dependencies (if any)");
+                Everest.CheckDependenciesOfDelayedMods();
 
                 watch.Stop();
                 Logger.Log(LogLevel.Verbose, "loader", $"ALL MODS LOADED IN {watch.ElapsedMilliseconds}ms");
@@ -443,6 +451,16 @@ namespace Celeste.Mod {
                         return;
                     }
 
+                foreach (EverestModuleMetadata dep in meta.OptionalDependencies) {
+                    if (!DependencyLoaded(dep) && (enforceOptionalDependencies || Everest.Modules.Any(module => module.Metadata?.Name == dep.Name))) {
+                        Logger.Log(LogLevel.Info, "loader", $"Optional dependency {dep} of mod {meta} not loaded! Delaying.");
+                        lock (Delayed) {
+                            Delayed.Add(Tuple.Create(meta, callback));
+                        }
+                        return;
+                    }
+                }
+
                 callback?.Invoke();
 
                 LoadMod(meta);
@@ -616,9 +634,18 @@ namespace Celeste.Mod {
                     return false;
                 }
 
+                // enforce dependencies.
                 foreach (EverestModuleMetadata dep in meta.Dependencies)
                     if (!DependencyLoaded(dep))
                         return false;
+
+                // enforce optional dependencies: an optional dependency is satisfied if either of these 2 applies:
+                // - it is loaded (obviously)
+                // - enforceOptionalDependencies = false and no version of the mod is loaded (if one is, it might be incompatible and cause issues)
+                foreach (EverestModuleMetadata dep in meta.OptionalDependencies)
+                    if (!DependencyLoaded(dep) && (enforceOptionalDependencies || Everest.Modules.Any(mod => mod.Metadata?.Name == dep.Name)))
+                        return false;
+
                 return true;
             }
 

--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -689,6 +689,10 @@ namespace Celeste.Mod {
 
             Logger.Log(LogLevel.Info, "core", $"Module {module.Metadata} registered.");
 
+            CheckDependenciesOfDelayedMods();
+        }
+
+        internal static void CheckDependenciesOfDelayedMods() {
             // Attempt to load mods after their dependencies have been loaded.
             // Only load and lock the delayed list if we're not already loading delayed mods.
             if (Interlocked.CompareExchange(ref Loader.DelayedLock, 1, 0) == 0) {

--- a/Celeste.Mod.mm/Mod/Module/EverestModuleMetadata.cs
+++ b/Celeste.Mod.mm/Mod/Module/EverestModuleMetadata.cs
@@ -69,6 +69,11 @@ namespace Celeste.Mod {
         public List<EverestModuleMetadata> Dependencies { get; set; } = new List<EverestModuleMetadata>();
 
         /// <summary>
+        /// The optional dependencies of the mod. This mod will load after the mods listed here if they are installed; if they aren't, the mod will load anyway.
+        /// </summary>
+        public List<EverestModuleMetadata> OptionalDependencies { get; set; } = new List<EverestModuleMetadata>();
+
+        /// <summary>
         /// The runtime mod hash. Might not be determined by all mod content.
         /// </summary>
         public byte[] Hash { get; set; }

--- a/Celeste.Mod.mm/Mod/UI/OuiModOptions.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiModOptions.cs
@@ -56,6 +56,12 @@ namespace Celeste.Mod.UI {
                                 // check for missing dependencies
                                 List<EverestModuleMetadata> missingDependenciesForMod = mod.Item1.Dependencies
                                     .FindAll(dep => !Everest.Loader.DependencyLoaded(dep));
+                                if (mod.Item1.OptionalDependencies != null) {
+                                    // find optional dependencies with mismatching versions
+                                    List<EverestModuleMetadata> optionalDependenciesWithVersionMismatches = mod.Item1.OptionalDependencies
+                                        .FindAll(dep => !Everest.Loader.DependencyLoaded(dep) && Everest.Modules.Any(module => module.Metadata?.Name == dep.Name));
+                                    missingDependenciesForMod.AddRange(optionalDependenciesWithVersionMismatches);
+                                }
                                 missingDependencies.AddRange(missingDependenciesForMod);
 
                                 if (missingDependenciesForMod.Count != 0) {


### PR DESCRIPTION
Mods would be able to define _optional dependencies_ like this:
```yaml
- Name: ReversedSilverBerry
  Version: 1.0.0
  OptionalDependencies:
    - Name: CollabUtils2
      Version: 1.3.2
```
- If CollabUtils2 is installed, ReversedSilverBerry will load after it on startup.
- If CollabUtils2 isn't installed, ReversedSilverBerry will load once all other mods are loaded
- If CollabUtils2 is installed in a version lower than 1.3.2, an error will appear in Mod Options, and the "Install dependencies" button will update CollabUtils2.

This targets 2 use cases:
- a skin that can apply to mods, for example a skin that would reskin berries including silver and rainbow berries. We want to make sure the skin loads after the collab utils, so that the skin overrides its textures, but we also want the skin to still load if the user doesn't have the collab utils installed.
- a mod that plugs into another, for example randomizer configs. If someone uses new randomizer features in the config that ships with a map, the map should still load if the user doesn't have the randomizer installed, but should be prompted to update their randomizer if it is out of date, because that could lead to crashes.