### PR TITLE
Fix menu selection going up and down in XNA version of the game

### DIFF
--- a/Celeste.Mod.mm/Patches/Monocle/MInput.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/MInput.cs
@@ -1,0 +1,26 @@
+﻿#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
+#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
+#pragma warning disable CS0169 // The field is never used
+
+using Microsoft.Xna.Framework.Input;
+
+namespace Monocle {
+    class patch_MInput {
+        public class patch_KeyboardData {
+            public extern bool orig_Check(Keys key);
+
+            public bool Check(Keys key)
+                => key != Keys.None && orig_Check(key);
+
+            public extern bool orig_Pressed(Keys key);
+
+            public bool Pressed(Keys key)
+                => key != Keys.None && orig_Pressed(key);
+
+            public extern bool orig_Released(Keys key);
+
+            public bool Released(Keys key)
+                => key != Keys.None && orig_Released(key);
+        }
+    }
+}


### PR DESCRIPTION
Although it will be fixed in 1.3.2.0, earlier is better I think?

According to the devs [here](https://discord.com/channels/403698615446536203/615402712011636777/696210440816164924):

> So there's a bug in Celeste where if your Settings file is default, it accidentally adds Keys.None to the Menu inputs.
> In XNA (the engine we use on Windows), the Keys.None value is 0. Somehow, Groove Music is doing something internally to the keyboard state, and then when XNA checks against Key value 0, it returns true.
> So in theory checking against Keys.None should always return false but I guess XNA has some kind of weird bug internally (which is also why this doesn't happen in the OpenGL build which uses SDL2)

The bug is triggered by `MInput.Keyboard.CurrentState.IsKeyDown(Keys.None)` returning `true` after doing something in Groove Music, so it can be fixed by patching those related functions in `MInput.KeyboardData` and let them always return `false` if the game is querying states of `Keys.None`.

