### PR TITLE
Take backups of mod save data in a separate file and restore it when necessary

### DIFF
--- a/Celeste.Mod.mm/Mod/Core/CoreModuleSaveData.cs
+++ b/Celeste.Mod.mm/Mod/Core/CoreModuleSaveData.cs
@@ -1,45 +1,19 @@
 ﻿using FMOD.Studio;
 using Microsoft.Xna.Framework;
+using Monocle;
+using Celeste;
+using System;
+using System.Collections;
 using System.Collections.Generic;
-using System.IO;
-using System.Xml.Serialization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using YamlDotNet.Serialization;
 
 namespace Celeste.Mod.Core {
-    public class CoreModuleSaveData : EverestModuleBinarySaveData {
-        public List<LevelSetStats> LevelSets = new List<LevelSetStats>();
-        public List<LevelSetStats> LevelSetRecycleBin = new List<LevelSetStats>();
-        public AreaKey LastArea_Safe;
-        public Session CurrentSession_Safe;
-        public bool Modded = false;
+    public class CoreModuleSaveData : EverestModuleSaveData {
 
-        public void CopyFromCelesteSaveData(patch_SaveData data) {
-            LevelSets = data.LevelSets;
-            LevelSetRecycleBin = data.LevelSetRecycleBin;
-            LastArea_Safe = data.LastArea_Safe;
-            CurrentSession_Safe = data.CurrentSession_Safe;
-            Modded = data.Modded;
-        }
+        public int WhateverCount { get; set; } = 1337;
 
-        public void CopyToCelesteSaveData(patch_SaveData data) {
-            data.LevelSets = LevelSets;
-            data.LevelSetRecycleBin = LevelSetRecycleBin;
-            data.LastArea_Safe = LastArea_Safe;
-            data.CurrentSession_Safe = CurrentSession_Safe;
-            data.Modded = Modded;
-        }
-
-        public override void Read(BinaryReader reader) {
-            CoreModuleSaveData fromSave = (CoreModuleSaveData) new XmlSerializer(typeof(CoreModuleSaveData)).Deserialize(reader.BaseStream);
-            LevelSets = fromSave.LevelSets;
-            LevelSetRecycleBin = fromSave.LevelSetRecycleBin;
-            LastArea_Safe = fromSave.LastArea_Safe;
-            CurrentSession_Safe = fromSave.CurrentSession_Safe;
-            Modded = fromSave.Modded;
-        }
-
-        public override void Write(BinaryWriter writer) {
-            byte[] contents = UserIO.Serialize(this);
-            writer.Write(contents, 0, contents.Length);
-        }
     }
 }

--- a/Celeste.Mod.mm/Mod/Core/CoreModuleSaveData.cs
+++ b/Celeste.Mod.mm/Mod/Core/CoreModuleSaveData.cs
@@ -1,19 +1,45 @@
 ﻿using FMOD.Studio;
 using Microsoft.Xna.Framework;
-using Monocle;
-using Celeste;
-using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using YamlDotNet.Serialization;
+using System.IO;
+using System.Xml.Serialization;
 
 namespace Celeste.Mod.Core {
-    public class CoreModuleSaveData : EverestModuleSaveData {
+    public class CoreModuleSaveData : EverestModuleBinarySaveData {
+        public List<LevelSetStats> LevelSets = new List<LevelSetStats>();
+        public List<LevelSetStats> LevelSetRecycleBin = new List<LevelSetStats>();
+        public AreaKey LastArea_Safe;
+        public Session CurrentSession_Safe;
+        public bool Modded = false;
 
-        public int WhateverCount { get; set; } = 1337;
+        public void CopyFromCelesteSaveData(patch_SaveData data) {
+            LevelSets = data.LevelSets;
+            LevelSetRecycleBin = data.LevelSetRecycleBin;
+            LastArea_Safe = data.LastArea_Safe;
+            CurrentSession_Safe = data.CurrentSession_Safe;
+            Modded = data.Modded;
+        }
 
+        public void CopyToCelesteSaveData(patch_SaveData data) {
+            data.LevelSets = LevelSets;
+            data.LevelSetRecycleBin = LevelSetRecycleBin;
+            data.LastArea_Safe = LastArea_Safe;
+            data.CurrentSession_Safe = CurrentSession_Safe;
+            data.Modded = Modded;
+        }
+
+        public override void Read(BinaryReader reader) {
+            CoreModuleSaveData fromSave = (CoreModuleSaveData) new XmlSerializer(typeof(CoreModuleSaveData)).Deserialize(reader.BaseStream);
+            LevelSets = fromSave.LevelSets;
+            LevelSetRecycleBin = fromSave.LevelSetRecycleBin;
+            LastArea_Safe = fromSave.LastArea_Safe;
+            CurrentSession_Safe = fromSave.CurrentSession_Safe;
+            Modded = fromSave.Modded;
+        }
+
+        public override void Write(BinaryWriter writer) {
+            byte[] contents = UserIO.Serialize(this);
+            writer.Write(contents, 0, contents.Length);
+        }
     }
 }

--- a/Celeste.Mod.mm/Mod/Everest/ModSaveData.cs
+++ b/Celeste.Mod.mm/Mod/Everest/ModSaveData.cs
@@ -1,0 +1,30 @@
+﻿using FMOD.Studio;
+using Microsoft.Xna.Framework;
+using System.Collections.Generic;
+using System.IO;
+using System.Xml.Serialization;
+
+namespace Celeste.Mod {
+    public class ModSaveData {
+        public List<LevelSetStats> LevelSets = new List<LevelSetStats>();
+        public List<LevelSetStats> LevelSetRecycleBin = new List<LevelSetStats>();
+        public AreaKey LastArea_Safe;
+        public Session CurrentSession_Safe;
+
+        public ModSaveData() { }
+
+        public ModSaveData(patch_SaveData data) {
+            LevelSets = data.LevelSets;
+            LevelSetRecycleBin = data.LevelSetRecycleBin;
+            LastArea_Safe = data.LastArea_Safe;
+            CurrentSession_Safe = data.CurrentSession_Safe;
+        }
+
+        public void CopyToCelesteSaveData(patch_SaveData data) {
+            data.LevelSets = LevelSets;
+            data.LevelSetRecycleBin = LevelSetRecycleBin;
+            data.LastArea_Safe = LastArea_Safe;
+            data.CurrentSession_Safe = CurrentSession_Safe;
+        }
+    }
+}

--- a/Celeste.Mod.mm/Patches/UserIO.cs
+++ b/Celeste.Mod.mm/Patches/UserIO.cs
@@ -61,6 +61,22 @@ namespace Celeste {
             return (T) new XmlSerializer(typeof(T)).Deserialize(stream);
         }
 
+        public static extern T orig_Load<T>(string path, bool backup = false);
+        public static T Load<T>(string path, bool backup = false) {
+            T result = orig_Load<T>(path, backup);
+
+            // if we are loading a SaveData, fill out the FileSlot right away.
+            if (typeof(T) == typeof(SaveData)) {
+                if (path == "debug") {
+                    (result as SaveData).FileSlot = -1;
+                } else if (int.TryParse(path, out int slot)) {
+                    (result as SaveData).FileSlot = slot;
+                }
+            }
+
+            return result;
+        }
+
         private static IEnumerator SaveNonHandler() {
             yield break;
         }


### PR DESCRIPTION
This is one way to deal with mod save data getting wiped when using a save file with modded save data in vanilla.

The strategy I'm using here is:
- before saving a file, save a duplicate of the `<LevelSets>`, `<LevelSetRecycleBin>`, `<CurrentSession_Safe>` and `<LastArea_Safe>` tags in a file named `filenumber-modsavedata.celeste`.
- when a file is loaded, if it doesn't have more than 1 level set (the vanilla one), restore this data from this backup file.

The tests I made:
- play a modded map, save and quit, switch to vanilla, play a bit of 1A, switch back to modded: the modded session and stats are intact, new progress in 1A (in my case more play time and deaths) was kept.
- play a vanilla map, save and quit, load the save in vanilla, progress a bit, save and quit, switch back to modded: the session saved in modded Celeste can be loaded from vanilla, but the session changes in vanilla are lost once loading back into modded.

The other strategies I considered:
- _when loading or saving SaveData, split or merge 2 files, a vanilla and a modded one_: while this would remove duplicate info, this can get messy if someone decides to switch to the dev branch, then back to stable, as they would "have lost all their mod saves" until they switch back (then which save data should take over?).
- _take modded save data info out of SaveData into its own thing (like `ModSaveData` in this PR), and save it separately_: would be the cleanest, but has the same issue as above, plus existing code mods that use `LevelSets` have to be taken into account. There would also be a need to write save data migration code for existing files, since a `<LevelSets>` tag in the vanilla save would be ignored.