### PR TITLE
Offer extra save file slots so that the last slot is always empty

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
@@ -102,6 +102,8 @@ namespace Celeste.Mod {
                 { "Elemental Chaos", new Version(1, 0, 0, 0) },
                 { "BGswitch", new Version(0, 1, 0, 0) },
 
+                // Infinite Saves 1.0.0 does not work well with the "extra save slots" feature of Everest
+                { "InfiniteSaves", new Version(1, 0, 1) }
             };
 
             /// <summary>

--- a/Celeste.Mod.mm/MonoModRules.cs
+++ b/Celeste.Mod.mm/MonoModRules.cs
@@ -1975,8 +1975,12 @@ namespace MonoMod {
                 return;
 
             // The routine is stored in a compiler-generated method.
+            string methodName = method.Name;
+            if (methodName.StartsWith("orig_")) {
+                methodName = methodName.Substring(5);
+            }
             foreach (TypeDefinition nest in method.DeclaringType.NestedTypes) {
-                if (!nest.Name.StartsWith("<" + method.Name + ">d__"))
+                if (!nest.Name.StartsWith("<" + methodName + ">d__"))
                     continue;
                 method = nest.FindMethod("System.Boolean MoveNext()") ?? method;
                 break;

--- a/Celeste.Mod.mm/Patches/OuiFileSelect.cs
+++ b/Celeste.Mod.mm/Patches/OuiFileSelect.cs
@@ -1,14 +1,80 @@
 ﻿using MonoMod;
+using System;
 using System.Collections;
+using System.IO;
 
 namespace Celeste {
     class patch_OuiFileSelect : OuiFileSelect {
-        [MonoModIgnore] // we don't want to change anything in the method...
-        [PatchOuiFileSelectSubmenuChecks] // ... except manipulating it manually with MonoModRules
-        public extern new IEnumerator Enter(Oui from);
+        public float Scroll = 0f;
 
-        [MonoModIgnore] // we don't want to change anything in the method...
-        [PatchOuiFileSelectSubmenuChecks] // ... except manipulating it manually with MonoModRules
-        public extern new IEnumerator Leave(Oui next);
+        [PatchOuiFileSelectSubmenuChecks] // we want to manipulate the orig method with MonoModRules
+        public extern IEnumerator orig_Enter(Oui from);
+        public new IEnumerator Enter(Oui from) {
+            if (!Loaded) {
+                // first load: we want to check how many slots there are by checking which files exist in the Saves folder.
+                int maxSaveFile = 1; // we're adding 2 later, so there will be at least 3 slots.
+                string saveFilePath = patch_UserIO.GetSaveFilePath();
+                if (Directory.Exists(saveFilePath)) {
+                    foreach (string filePath in Directory.GetFiles(saveFilePath)) {
+                        string fileName = Path.GetFileName(filePath);
+                        // is the file named [number].celeste?
+                        if (fileName.EndsWith(".celeste") && int.TryParse(fileName.Substring(0, fileName.Length - 8), out int fileIndex)) {
+                            maxSaveFile = Math.Max(maxSaveFile, fileIndex);
+                        }
+                    }
+                }
+
+                // if 2.celeste exists, slot 3 is the last slot filled, therefore we want 4 slots (2 + 2) to always have the latest one empty.
+                Slots = new OuiFileSelectSlot[maxSaveFile + 2];
+            }
+
+            int slotIndex = 0;
+            IEnumerator orig = orig_Enter(from);
+            while (orig.MoveNext()) {
+                if (orig.Current is float f && f == 0.02f) {
+                    // only apply the delay if the slot is on-screen (less than 2 slots away from the selected one).
+                    if (Math.Abs(SlotIndex - slotIndex) <= 2) {
+                        yield return orig.Current;
+                    }
+                    slotIndex++;
+                } else {
+                    yield return orig.Current;
+                }
+            }
+        }
+
+        [PatchOuiFileSelectSubmenuChecks] // we want to manipulate the orig method with MonoModRules
+        public extern IEnumerator orig_Leave(Oui next);
+        public new IEnumerator Leave(Oui from) {
+            int slotIndex = 0;
+            IEnumerator orig = orig_Leave(from);
+            while (orig.MoveNext()) {
+                if (orig.Current is float f && f == 0.02f) {
+                    // only apply the delay if the slot is on-screen (less than 2 slots away from the selected one).
+                    if (Math.Abs(SlotIndex - slotIndex) <= 2) {
+                        yield return orig.Current;
+                    }
+                    slotIndex++;
+                } else {
+                    yield return orig.Current;
+                }
+            }
+        }
+
+#pragma warning disable CS0626 // extern method with no attribute
+        public extern void orig_Update();
+#pragma warning restore CS0626
+        public override void Update() {
+            int initialFileIndex = SlotIndex;
+
+            orig_Update();
+
+            if (SlotIndex != initialFileIndex) {
+                // selection moved, so update the Y position of all file slots.
+                foreach (OuiFileSelectSlot slot in Slots) {
+                    (slot as patch_OuiFileSelectSlot).ScrollTo(slot.IdlePosition.X, slot.IdlePosition.Y);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Essentially Infinite Saves, except integrated in Everest and actually infinite.

This will show as many slots as you have save files + 1, so that you always have a spare save file.

- When entering file select, Everest goes through the Saves folder and gets the highest file slot. Then, it rebuilds the Slots array to give it as many slots as required + 1 before the game fills it, so the game instantiates the slots itself. (No need to refresh the number of slots, since it is rebuilt each time you come back to the overworld, and creating a new save _requires_ you to leave the overworld.)
- When going through the saves, scrolling has been set up if there are more than 3 slots.
- The file select enter and leave animations were patched so that the animations of off-screen slots don't cause delay.

Question: how do we deal with Infinite Saves if it is installed?