### PR TITLE
Fix C-Side button visible in chapter panel if B-Side doesn't have heart and the player got heart in A-Side

### DIFF
--- a/Celeste.Mod.mm/Patches/SaveData.cs
+++ b/Celeste.Mod.mm/Patches/SaveData.cs
@@ -700,7 +700,23 @@ namespace Celeste {
             get {
                 int offset = AreaOffset;
 
-                if (TotalHeartGems >= MaxHeartGemsExcludingCSides) {
+                bool completedAllBSides = true;
+                for (int i = 0; i <= MaxArea; i++) {
+                    AreaData areaData = AreaData.Areas[offset + i];
+                    if (!areaData.HasMode(AreaMode.BSide)) {
+                        continue;
+                    }
+                    AreaModeStats modeStats = AreasIncludingCeleste[i].Modes[(int) AreaMode.BSide];
+                    bool interlude = areaData.Interlude;
+                    bool mapHasHeartGem = areaData.Mode[(int) AreaMode.BSide].MapData.DetectedHeartGem;
+                    bool heartGemCollected = modeStats.HeartGem;
+                    bool completed = modeStats.Completed;
+                    if (!interlude && !(mapHasHeartGem ? heartGemCollected : completed)) {
+                        completedAllBSides = false;
+                    }
+                }
+
+                if (completedAllBSides) {
                     return 3;
                 }
 


### PR DESCRIPTION
Fixes #228.

Originally whether C-Side should be displayed is by checking `TotalHeartGems` and `MaxHeartGemsExcludingCSides`. In this case, if there is no heart in B-Side and the player collected the heart in A-Side, these two values are equal, so the button displayed on the chapter panel. But the game used selected index while entering a level, so actually B-Side is entered.

This patch changes the way on checking whether C-Side should unlock. A B-Side is counted as completed if it has heart and the player has collected it, or the player completed it without heart by triggering events if it hasn't. If all B-Sides are completed, then C-Sides should be unlocked.