### PR TITLE
Delete titlescreen warning about save data loss + create mod save data on startup if Everest was just updated

### DIFF
--- a/Celeste.Mod.mm/Content/Dialog/English.txt
+++ b/Celeste.Mod.mm/Content/Dialog/English.txt
@@ -38,15 +38,7 @@
 
 # Title Screen
 	MENU_TITLESCREEN_RESTART_VANILLA= Restarting into orig/Celeste.exe
-	MENU_TITLESCREEN_WARNING=			Warning!
-	MENU_TITLESCREEN_WARNING_TEXT=
-		If you open a save in vanilla Celeste,
-		all your progress in custom maps will be lost in this save.
-	MENU_TITLESCREEN_WARNING_TEXT2=
-		If you need more save files, download "Infinite Saves" on GameBanana.
-	MENU_TITLESCREEN_OK=				Restart
-	MENU_TITLESCREEN_CANCEL=			Cancel
-	
+    
 # Extra Key Mapping
     KEY_CONFIG_ADDING= PRESS ADDITIONAL KEY FOR
     KEY_CONFIG_ADDITION_HINT= Press SHIFT + CONFIRM to add additional keys

--- a/Celeste.Mod.mm/Content/Dialog/French.txt
+++ b/Celeste.Mod.mm/Content/Dialog/French.txt
@@ -19,15 +19,7 @@
 	MENU_MODOPTIONS_MOD_UPDATES_AVAILABLE=		Mises à jour disponibles pour {0} mods
 	
 # Title Screen
-	MENU_TITLESCREEN_RESTART_VANILLA=	Lancement de orig/Celeste.exe
-	MENU_TITLESCREEN_WARNING=			Attention !
-	MENU_TITLESCREEN_WARNING_TEXT=
-		Si tu ouvres une sauvegarde dans le jeu de base,
-		ta progression dans les maps moddées sera supprimée sur cette sauvegarde.
-	MENU_TITLESCREEN_WARNING_TEXT2=
-		Si tu as besoin de plus de sauvegardes, télécharge "Infinite Saves" sur GameBanana.
-	MENU_TITLESCREEN_OK=				Redémarrer
-	MENU_TITLESCREEN_CANCEL=			Annuler
+	MENU_TITLESCREEN_RESTART_VANILLA= Lancement de orig/Celeste.exe
 
 # Extra Key Mapping
 	KEY_CONFIG_ADDING= APPUYEZ SUR LA TOUCHE SUPPLÉMENTAIRE POUR

--- a/Celeste.Mod.mm/Content/Dialog/Simplified Chinese.txt
+++ b/Celeste.Mod.mm/Content/Dialog/Simplified Chinese.txt
@@ -30,14 +30,6 @@
 
 # Title Screen
 	MENU_TITLESCREEN_RESTART_VANILLA=	重启打开原版 Celeste
-	MENU_TITLESCREEN_WARNING=			警告！
-	MENU_TITLESCREEN_WARNING_TEXT=
-		如果你在原版 Celeste 中打开存档，
-		这个存档中所有 Mod 图的进度将会丢失。
-	MENU_TITLESCREEN_WARNING_TEXT2=
-		如果你需要更多的存档，请到 GameBanana 上下载 "Infinite Saves"。
-	MENU_TITLESCREEN_OK=				重启
-	MENU_TITLESCREEN_CANCEL=			取消
 
 # Extra Key Mapping
 	KEY_CONFIG_ADDING=			按新建设置以下动作

--- a/Celeste.Mod.mm/Mod/Core/CoreModuleSettings.cs
+++ b/Celeste.Mod.mm/Mod/Core/CoreModuleSettings.cs
@@ -249,9 +249,6 @@ namespace Celeste.Mod.Core {
         public bool ShowManualTextOnDebugMap { get; set; } = true;
 
         [SettingIgnore]
-        public bool RestartIntoVanillaWarningShown { get; set; } = false;
-
-        [SettingIgnore]
         public bool CodeReload_WIP { get; set; } = false;
 
         // TODO: Once CodeReload is no longer WIP, remove this and rename ^ to non-WIP.

--- a/Celeste.Mod.mm/Mod/UI/OuiOOBE.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiOOBE.cs
@@ -72,7 +72,7 @@ namespace Celeste.Mod.UI {
                         ).Change(
                             value => CoreModule.Settings.ShowEverestTitleScreen = value
                         ),
-                        
+
                         new OnOff(
                             Dialog.Clean("MODOPTIONS_COREMODULE_USEKEYBOARDFORTEXTINPUT"),
                             CoreModule.Settings.UseKeyboardForTextInput
@@ -123,7 +123,7 @@ namespace Celeste.Mod.UI {
                         ).Change(
                             value => CoreModule.Settings.ShowEverestTitleScreen = value
                         ),
-                        
+
                         new OnOff(
                             Dialog.Clean("MODOPTIONS_COREMODULE_USEKEYBOARDFORTEXTINPUT"),
                             CoreModule.Settings.UseKeyboardForTextInput
@@ -178,7 +178,7 @@ namespace Celeste.Mod.UI {
                             ).Change(
                                 value => CoreModule.Settings.ShowEverestTitleScreen = value
                             ),
-                        
+
                             new OnOff(
                                 Dialog.Clean("MODOPTIONS_COREMODULE_USEKEYBOARDFORTEXTINPUT"),
                                 CoreModule.Settings.UseKeyboardForTextInput
@@ -327,8 +327,12 @@ namespace Celeste.Mod.UI {
         }
 
         public override bool IsStart(Overworld overworld, Overworld.StartMode start) {
-            if (start != Overworld.StartMode.Titlescreen || CoreModule.Settings.CurrentVersion != null)
+            if (start != Overworld.StartMode.Titlescreen)
                 return false;
+            if (CoreModule.Settings.CurrentVersion != null) {
+                CoreModule.Instance.SaveSettings(); // be sure CurrentVersion is updated on startup.
+                return false;
+            }
             Add(new Coroutine(Enter(null)));
             return true;
         }

--- a/Celeste.Mod.mm/Patches/GameLoader.cs
+++ b/Celeste.Mod.mm/Patches/GameLoader.cs
@@ -164,7 +164,7 @@ namespace Celeste {
                 previousVersion = new Version(0, 0, 0);
             }
 
-            if (previousVersion < new Version(1, 2104, 0)) {
+            if (previousVersion < new Version(1, 2109, 0)) {
                 // user just upgraded: create mod save data backups.
                 // (this is very similar to OverworldLoader.CheckVariantsPostcardAtLaunch)
                 Logger.Log("core", $"User just upgraded from version {previousVersion}: creating mod save data backups.");
@@ -174,8 +174,8 @@ namespace Celeste {
                         continue;
                     }
                     SaveData saveData = UserIO.Load<SaveData>(SaveData.GetFilename(i), backup: false);
-                    saveData.AfterInitialize();
                     if (saveData != null) {
+                        saveData.AfterInitialize();
                         UserIO.Save<ModSaveData>(SaveData.GetFilename(saveData.FileSlot) + "-modsavedata", UserIO.Serialize(new ModSaveData(saveData as patch_SaveData)));
                     }
                 }

--- a/Celeste.Mod.mm/Patches/GameLoader.cs
+++ b/Celeste.Mod.mm/Patches/GameLoader.cs
@@ -126,6 +126,8 @@ namespace Celeste {
         public extern new IEnumerator IntroRoutine();
 
         private static Scene _GetNextScene(Overworld.StartMode startMode, HiresSnow snow) {
+            checkModSaveDataBackups();
+
             bool transitionToModUpdater = false;
 
             if (CoreModule.Settings.AutoUpdateModsOnStartup) {
@@ -147,6 +149,38 @@ namespace Celeste {
                 return new AutoModUpdater(snow);
             } else {
                 return new OverworldLoader(startMode, snow);
+            }
+        }
+
+        /// <summary>
+        /// Initializes mod save data backups if required (if Everest was just updated past 2104).
+        /// </summary>
+        private static void checkModSaveDataBackups() {
+            Version previousVersion;
+            try {
+                previousVersion = new Version(CoreModule.Settings.CurrentVersion);
+            } catch {
+                // oops, version is null or can't be parsed for any reason.
+                previousVersion = new Version(0, 0, 0);
+            }
+
+            if (previousVersion < new Version(1, 2104, 0)) {
+                // user just upgraded: create mod save data backups.
+                // (this is very similar to OverworldLoader.CheckVariantsPostcardAtLaunch)
+                Logger.Log("core", $"User just upgraded from version {previousVersion}: creating mod save data backups.");
+
+                for (int i = 0; i < 3; i++) { // only the first 3 saves really matter.
+                    if (!UserIO.Exists(SaveData.GetFilename(i))) {
+                        continue;
+                    }
+                    SaveData saveData = UserIO.Load<SaveData>(SaveData.GetFilename(i), backup: false);
+                    saveData.AfterInitialize();
+                    if (saveData != null) {
+                        UserIO.Save<ModSaveData>(SaveData.GetFilename(saveData.FileSlot) + "-modsavedata", UserIO.Serialize(new ModSaveData(saveData as patch_SaveData)));
+                    }
+                }
+                UserIO.Close();
+                SaveData.Instance = null;
             }
         }
     }

--- a/Celeste.Mod.mm/Patches/OuiTitleScreen.cs
+++ b/Celeste.Mod.mm/Patches/OuiTitleScreen.cs
@@ -25,15 +25,11 @@ namespace Celeste {
         private Image logo;
         private MTexture title;
         private List<MTexture> reflections;
-#pragma warning disable CS0414 // "unused" field actually used in vanilla code
         private bool hideConfirmButton;
-#pragma warning restore CS0414
 
         private float switchingToVanilla;
         private float switchingToVanillaBack;
         private const float switchingToVanillaDuration = 2f;
-        private TextMenu warningMessageMenu;
-        private float warningEase;
 
         private MTexture updateTex;
         private float updateAlpha;
@@ -123,51 +119,16 @@ namespace Celeste {
                 Add(tween);
             }
 
-            if (alpha >= 1f && Selected && Input.MenuRight && arrowToVanilla != null && warningMessageMenu == null) {
+            if (alpha >= 1f && Selected && Input.MenuRight && arrowToVanilla != null) {
                 switchingToVanillaBack = Math.Max(0f, switchingToVanillaBack - Engine.DeltaTime * 8f);
                 switchingToVanilla += Engine.DeltaTime;
 
                 if (switchingToVanilla >= switchingToVanillaDuration && !Everest.RestartVanilla) {
-                    if (CoreModule.Settings.RestartIntoVanillaWarningShown) {
-                        restartIntoVanilla();
-                    } else {
-                        warningMessageMenu = new TextMenu();
-                        Action onCancel = () => {
-                            // remove the menu
-                            Scene.Remove(warningMessageMenu);
-                            warningMessageMenu.Visible = false;
-                            warningMessageMenu = null;
-                            hideConfirmButton = false;
-
-                            // revert the "switch to vanilla" animation
-                            switchingToVanilla = 0f;
-                            switchingToVanillaBack = 0f;
-
-                            // fade the vanilla title screen back in
-                            alpha = 0f;
-                            Tween tween = Tween.Create(Tween.TweenMode.Oneshot, Ease.CubeInOut, 0.6f, start: true);
-                            tween.OnUpdate = t => {
-                                alpha = t.Percent;
-                                textY = MathHelper.Lerp(1200f, 1000f, t.Eased);
-                            };
-                            Add(tween);
-                        };
-                        warningMessageMenu.OnESC = warningMessageMenu.OnCancel = () => {
-                            Audio.Play(SFX.ui_main_button_back);
-                            onCancel();
-                        };
-                        warningMessageMenu.Add(new TextMenu.Button(Dialog.Clean("MENU_TITLESCREEN_OK")).Pressed(() => {
-                            if (!CoreModule.Settings.RestartIntoVanillaWarningShown) {
-                                CoreModule.Settings.RestartIntoVanillaWarningShown = true;
-                                CoreModule.Instance.SaveSettings();
-                            }
-                            warningMessageMenu.Focused = false;
-                            restartIntoVanilla();
-                        }));
-                        warningMessageMenu.Add(new TextMenu.Button(Dialog.Clean("MENU_TITLESCREEN_CANCEL")).Pressed(onCancel));
-                        Scene.Add(warningMessageMenu);
-                        hideConfirmButton = true;
-                    }
+                    Everest.RestartVanilla = true;
+                    new FadeWipe(Scene, false, () => {
+                        Engine.Scene = new Scene();
+                        Engine.Instance.Exit();
+                    });
                 }
 
             } else if (switchingToVanilla < switchingToVanillaDuration) {
@@ -176,16 +137,6 @@ namespace Celeste {
                 switchingToVanillaBack = Math.Max(0f, switchingToVanillaBack - Engine.DeltaTime * 4f);
                 switchingToVanilla = 0f;
             }
-
-            warningEase = Calc.Approach(warningEase, warningMessageMenu != null ? 1f : 0f, Engine.DeltaTime);
-        }
-
-        private void restartIntoVanilla() {
-            Everest.RestartVanilla = true;
-            new FadeWipe(Scene, false, () => {
-                Engine.Scene = new Scene();
-                Engine.Instance.Exit();
-            });
         }
 
         public extern void orig_Render();
@@ -222,33 +173,12 @@ namespace Celeste {
             textY = textYPrev;
 
             if (switchAlpha > 0f) {
-                if (warningMessageMenu != null) {
-                    // the restarting message should ease out as the warning message eases in.
-                    switchAlpha -= Ease.CubeOut(warningEase);
-                }
-
                 Draw.Rect(0f, 0f, 1920f, 1080f, Color.Black * switchAlpha);
                 float offs = 40f * (1f - switchAlpha);
-
-                if (warningMessageMenu != null) {
-                    // the restarting message should leave the opposite way it came from.
-                    offs *= -1f;
-                }
-
                 ActiveFont.Draw(Dialog.Clean("MENU_TITLESCREEN_RESTART_VANILLA"), new Vector2(960f + offs, 540f - 4f), new Vector2(0.5f, 1f), Vector2.One, Color.White * switchAlpha);
                 Draw.Rect(960f - 200f + offs, 540f + 4f, 400f, 4f, Color.Black * switchAlpha * switchAlpha);
                 Draw.HollowRect(960f - 200f + offs, 540f + 4f, 400f, 4f, Color.DarkSlateGray * switchAlpha);
                 Draw.Rect(960f - 200f + offs, 540f + 4f, 400f * Calc.Clamp(Math.Max(switchingToVanilla, switchingToVanillaBack) / switchingToVanillaDuration, 0f, 1f), 4f, Color.White * switchAlpha);
-            }
-
-            if (warningMessageMenu != null) {
-                float warningAlpha = Ease.CubeOut(warningEase);
-                float offs = 40f * (1f - warningAlpha);
-                warningMessageMenu.Position = new Vector2(960f + offs, 735f);
-                warningMessageMenu.Alpha = warningAlpha;
-                ActiveFont.Draw(Dialog.Clean("MENU_TITLESCREEN_WARNING"), new Vector2(960f + offs, 285f), new Vector2(0.5f, 0f), Vector2.One * 1.2f, Color.OrangeRed * warningAlpha);
-                ActiveFont.Draw(Dialog.Clean("MENU_TITLESCREEN_WARNING_TEXT"), new Vector2(960f + offs, 385f), new Vector2(0.5f, 0f), Vector2.One * 0.8f, Color.White * warningAlpha);
-                ActiveFont.Draw(Dialog.Clean("MENU_TITLESCREEN_WARNING_TEXT2"), new Vector2(960f + offs, 510f), new Vector2(0.5f, 0f), Vector2.One * 0.8f, Color.White * warningAlpha);
             }
         }
 


### PR DESCRIPTION
The first commit is just a revert of #242 to delete the mod save data loss warning when you restart into vanilla.

The second commit makes sure the mod save data backups are created after you update Everest: if you restart into vanilla and play a save you didn't open since when you upgraded Everest, you'll still lose your mod save data. So, we want to back up mod save data from existing files on first startup to make sure it exists if the user directly restarts into vanilla.