### PR TITLE
Add support for custom endscreen music through map meta.yaml

### DIFF
--- a/Celeste.Mod.mm/Mod/Meta/MapMeta.cs
+++ b/Celeste.Mod.mm/Mod/Meta/MapMeta.cs
@@ -482,6 +482,8 @@ namespace Celeste.Mod.Meta {
         [YamlIgnore] public Vector2 Offset => OffsetArray.ToVector2() ?? Vector2.Zero;
         [YamlMember(Alias = "Offset")] public float[] OffsetArray { get; set; }
         public MapMetaCompleteScreenLayer[] Layers { get; set; }
+
+        public string[] MusicBySide { get; set; }
     }
     public class MapMetaCompleteScreenLayer {
         public string Type { get; set; }

--- a/Celeste.Mod.mm/Patches/LevelExit.cs
+++ b/Celeste.Mod.mm/Patches/LevelExit.cs
@@ -60,5 +60,18 @@ namespace Celeste {
         [PatchLevelExitRoutine] // ... except for slapping an additional parameter to / updating newobj AreaComplete
         private extern IEnumerator Routine();
 
+        [MonoModIgnore] // We don't want to change anything about the method...
+        [PatchAreaCompleteMusic] // ... except for manipulating the method via MonoModRules
+        private extern new void Begin();
+
+        // returns true if there is custom music, false otherwise.
+        private bool playCustomCompleteScreenMusic() {
+            string[] completeScreenMusic = AreaData.Get(session.Area)?.GetMeta()?.CompleteScreen?.MusicBySide;
+            if (completeScreenMusic != null && completeScreenMusic.Length > (int) session.Area.Mode) {
+                Audio.SetMusic(completeScreenMusic[(int) session.Area.Mode]);
+                return true;
+            }
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Usage:

```yaml
CompleteScreen:
  MusicBySide:
    - event:/music/menu/complete_area
    - event:/music/menu/complete_bside
    - event:/game/06_reflection/crushblock_move_loop
```

This will make the music on the endscreen be the default one on the A- and B-side, but will replace it with Kevin sounds on the C-side.

`LevelExit.Begin()` code before patching:
![image](https://user-images.githubusercontent.com/52103563/101285161-fe63f680-37e3-11eb-9e65-57cfc131dad8.png)

`LevelExit.Begin()` code after patching:
![image](https://user-images.githubusercontent.com/52103563/101285139-e7250900-37e3-11eb-968d-ddfff18bf4e4.png)
