### PR TITLE
Support scaling image layers through meta.yaml in ending screens

### DIFF
--- a/Celeste.Mod.mm/Mod/Meta/MapMeta.cs
+++ b/Celeste.Mod.mm/Mod/Meta/MapMeta.cs
@@ -497,6 +497,7 @@ namespace Celeste.Mod.Meta {
         public float Alpha { get; set; } = 1f;
         [YamlIgnore] public Vector2 Speed => SpeedArray.ToVector2() ?? Vector2.Zero;
         [YamlMember(Alias = "Speed")] public float[] SpeedArray { get; set; }
+        public float Scale { get; set; } = 1f;
     }
 
     public class MapMetaTextVignette {

--- a/Celeste.Mod.mm/MonoModRules.cs
+++ b/Celeste.Mod.mm/MonoModRules.cs
@@ -463,6 +463,7 @@ namespace MonoMod {
             MonoModRule.Flag.Set("OS:NotWindows", !isWindows);
 
             MonoModRule.Flag.Set("Has:BirdTutorialGuiButtonPromptEnum", MonoModRule.Modder.FindType("Celeste.BirdTutorialGui/ButtonPrompt")?.SafeResolve() != null);
+            MonoModRule.Flag.Set("Fill:CompleteRendererImageLayerScale", MonoModRule.Modder.FindType("Celeste.CompleteRenderer/ImageLayer").Resolve().FindField("Scale") == null);
 
             TypeDefinition t_Input = MonoModRule.Modder.FindType("Celeste.Input").Resolve();
             MethodDefinition m_GuiInputController = t_Input.FindMethod("GuiInputController");


### PR DESCRIPTION
Scaling is supported in vanilla after v1.3.3.0 in order to reduce high resolution asset sizes. This patch adds a `Scale` property in map meta.yaml files to support scaling in custom endscreens both for v1.3.1.x and v1.3.3.x. Code for back-compat should be removed after Celeste's minimum required version bumped to v1.3.3.x.

Usage:

```yaml
CompleteScreen:
  Atlas: 'OldSite'
  Start: [0.0, 1050.0]
  Center: [0.0, 250.0]
  Offset: [-108.0, 0.0]
  Layers:
  - Type: 'layer'
    Images: ['00']
    Position: [0.0, 0.0]
    Scroll: [0]
    Scale: 2.0
```