### PR TITLE
Add support for custom endscreen title through meta.yaml

### DIFF
--- a/Celeste.Mod.mm/Mod/Meta/MapMeta.cs
+++ b/Celeste.Mod.mm/Mod/Meta/MapMeta.cs
@@ -485,6 +485,8 @@ namespace Celeste.Mod.Meta {
         public MapMetaCompleteScreenLayer[] Layers { get; set; }
 
         public string[] MusicBySide { get; set; }
+
+        public MapMetaCompleteScreenTitle Title { get; set; }
     }
     public class MapMetaCompleteScreenLayer {
         public string Type { get; set; }
@@ -497,6 +499,13 @@ namespace Celeste.Mod.Meta {
         public float Alpha { get; set; } = 1f;
         [YamlIgnore] public Vector2 Speed => SpeedArray.ToVector2() ?? Vector2.Zero;
         [YamlMember(Alias = "Speed")] public float[] SpeedArray { get; set; }
+    }
+
+    public class MapMetaCompleteScreenTitle {
+        public string ASide { get; set; }
+        public string BSide { get; set; }
+        public string CSide { get; set; }
+        public string FullClear { get; set; }
     }
 
     public class MapMetaTextVignette {

--- a/Celeste.Mod.mm/Patches/AreaComplete.cs
+++ b/Celeste.Mod.mm/Patches/AreaComplete.cs
@@ -152,5 +152,33 @@ namespace Celeste {
             }
         }
 
+        private string GetCustomCompleteScreenTitle() {
+            MapMetaCompleteScreenTitle completeScreenTitle = AreaData.Get(Session.Area)?.GetMeta()?.CompleteScreen?.Title;
+            if (completeScreenTitle == null) {
+                return null;
+            }
+            string text = null;
+            switch (Session.Area.Mode) {
+                case AreaMode.Normal:
+                    if (Session.FullClear) {
+                        text = completeScreenTitle.FullClear;
+                    } else {
+                        text = completeScreenTitle.ASide;
+                    }
+                    break;
+                case AreaMode.BSide:
+                    text = completeScreenTitle.BSide;
+                    break;
+                case AreaMode.CSide:
+                    text = completeScreenTitle.CSide;
+                    break;
+                default:
+                    break;
+            }
+            if (text == null) {
+                return null;
+            }
+            return Dialog.Clean(text);
+        }
     }
 }


### PR DESCRIPTION
If map makers want to customize end screen title, they can simply edit meta.yaml files without having to messing with image editors.

Usage:

```yaml
CompleteScreen:
  Title:
    ASide: 'yournickname_campaignname_mapname_endscreen_a_side' # A-side complete
    BSide: 'yournickname_campaignname_mapname_endscreen_b_side' # B-side complete
    CSide: 'yournickname_campaignname_mapname_endscreen_c_side' # C-side complete
    FullClear: 'yournickname_campaignname_mapname_endscreen_full_clear' # A-side full clear
  Layers:
  - Type: 'ui'
```

If corresponding key is omitted, it will fallback to title in vanilla.

---

`AreaComplete` constructor before patching:
![Snipaste_2020-12-18_00-02-43](https://user-images.githubusercontent.com/7558201/102515245-7675ca80-40c8-11eb-9129-c931aef2dfcc.png)

after patching:
![Snipaste_2020-12-18_00-08-37](https://user-images.githubusercontent.com/7558201/102515262-7aa1e800-40c8-11eb-8d99-f0a86a6108f5.png)

---

Example use and preview - Chapter 2 endscreen with "D-Side Complete" title
![preview](https://user-images.githubusercontent.com/7558201/102515332-96a58980-40c8-11eb-86a0-6fa696d846c0.png)

```yaml
CompleteScreen:
  Atlas: 'OldSite'
  Start: [0.0, 1050.0]
  Center: [0.0, 250.0]
  Offset: [-108.0, 0.0]
  Title:
    ASide: 'WEGFan_WEGFanMappingPlayground_2_CompleteScreenTest_Endscreen_A_Side'
  Layers:
  - Type: 'layer'
    Images: ['00']
    Position: [0.0, 0.0]
    Scroll: [0]
  - Type: 'layer'
    Images: ['01']
    Position: [0.0, 0.0]
    Scroll: [0.02]
  - Type: 'layer'
    Images: ['02']
    Position: [0.0, 0.0]
    Scroll: [0.04]
  - Type: 'layer'
    Images: ['03']
    Position: [0.0, 0.0]
    Scroll: [0.06]
  - Type: 'layer'
    Images: ['04']
    Position: [0.0, 0.0]
    Scroll: [0.10]
  - Type: 'layer'
    Images: ['05']
    Position: [0.0, 0.0]
    Scroll: [0.10]
  - Type: 'layer'
    Images: ['06']
    Position: [0.0, -20.0]
    Scroll: [0.11]
  - Type: 'layer'
    Images: ['07']
    Position: [0.0, 0.0]
    Scroll: [0.12]
  - Type: 'ui'
  - Type: 'layer'
    Images: ['08']
    Position: [0.0, -680.0]
    Scroll: [0.13]
  - Type: 'layer'
    Images: ['09']
    Position: [0.0, 0.0]
    Scroll: [0.13]
  - Type: 'layer'
    Images: ['10']
    Position: [0.0, -680.0]
    Scroll: [0.15]
```