### PR TITLE
Make sure method.FixShortLongOps() is called for all methods after IL patching

### DIFF
--- a/Celeste.Mod.mm/MonoModRules.cs
+++ b/Celeste.Mod.mm/MonoModRules.cs
@@ -2765,6 +2765,7 @@ namespace MonoMod {
         private static void PostProcessType(MonoModder modder, TypeDefinition type) {
             foreach (MethodDefinition method in type.Methods) {
                 PostProcessMethod(modder, method);
+                method.FixShortLongOps();
             }
 
             foreach (TypeDefinition nested in type.NestedTypes)


### PR DESCRIPTION
In Everest, MonoMod's post processor is called in this order:

1. `MonoModder.DefaultPostProcessor()` in MonoMod, which includes fixing and optimizing any instructions which should use the long / short form opcodes.
2. `MonoModRules.PostProcessor()` from Everest, which includes patching some methods that can't be patched in auto patch.

So if a method only gets patched in step 2, its instructions will not be fixed after patching, and will cause game crash if too many instructions are added into a branch.

This patch calls `method.FixShortLongOps()` for all methods after all patches, so it can prevent that issue.