### PR TITLE
Support for removing specified additional key

### DIFF
--- a/Celeste.Mod.mm/Content/Dialog/English.txt
+++ b/Celeste.Mod.mm/Content/Dialog/English.txt
@@ -41,7 +41,7 @@
     
 # Extra Key Mapping
     KEY_CONFIG_ADDING= PRESS ADDITIONAL KEY FOR
-    KEY_CONFIG_ADDITION_HINT= Press SHIFT + CONFIRM to add additional keys
+    KEY_CONFIG_ADDITION_HINT= Press SHIFT + CONFIRM to add or remove additional keys
 
 # Mod Options
 	MODOPTIONS_TITLE= 										EVEREST

--- a/Celeste.Mod.mm/Content/Dialog/Simplified Chinese.txt
+++ b/Celeste.Mod.mm/Content/Dialog/Simplified Chinese.txt
@@ -32,8 +32,8 @@
 	MENU_TITLESCREEN_RESTART_VANILLA=	重启打开原版 Celeste
 
 # Extra Key Mapping
-	KEY_CONFIG_ADDING=			按新建设置以下动作
-	KEY_CONFIG_ADDITION_HINT=	按下 Shift + 确认设置额外的按键
+	KEY_CONFIG_ADDING=			额外的按建用于以下动作
+	KEY_CONFIG_ADDITION_HINT=	按下 Shift + 确认键添加或移除额外的按键
 
 # Mod Options
 	MODOPTIONS_TITLE= 										EVEREST

--- a/Celeste.Mod.mm/Patches/KeyboardConfigUI.cs
+++ b/Celeste.Mod.mm/Patches/KeyboardConfigUI.cs
@@ -178,8 +178,11 @@ namespace Celeste {
             if (keyList != null) {
                 if (!additiveRemap)
                     keyList.Clear();
-                if (!keyList.Contains(key))
+                if (!keyList.Contains(key)) {
                     keyList.Add(key);
+                } else if (keyList.Count >= 2) {
+                    keyList.Remove(key);
+                }
             }
             Input.Initialize();
             Reload(Selection);


### PR DESCRIPTION
When binding a duplicate key by shift+confirm, remove the key.