### PR TITLE
Fix the game crashes after entering the command with the error argument in the console

### DIFF
--- a/Celeste.Mod.mm/Patches/Monocle/Commands.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Commands.cs
@@ -5,14 +5,12 @@
 using Celeste;
 using Celeste.Mod;
 using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 using MonoMod;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Reflection;
 
 namespace Monocle {
     class patch_Commands : Commands {
@@ -222,6 +220,31 @@ namespace Monocle {
             if (!string.IsNullOrWhiteSpace(currentText.Replace(",", ""))) {
                 orig_EnterCommand();
             }
+        }
+
+        [MonoModIgnore]
+        private extern void LogStackTrace(string stackTrace);
+
+        // If exception message contains characters can't be displayed tell user check log.txt for full exception message.
+        [MonoModReplace]
+        private void InvokeMethod(MethodInfo method, object[] param = null) {
+            try {
+                method.Invoke(null, param);
+            } catch (Exception ex) {
+                Exception innerException = ex.InnerException;
+
+                Engine.Commands.Log(innerException.Message, Color.Yellow);
+                LogStackTrace(innerException.StackTrace);
+
+                if (ContainCantDrawChar(innerException.Message + innerException.StackTrace)) {
+                    Engine.Commands.Log("Please check log.txt for full exception log, because it contains characters can't be displayed.", Color.Yellow);
+                    Logger.Log("Commands", innerException.ToString());
+                }
+            }
+        }
+
+        private bool ContainCantDrawChar(string text) {
+            return text.ToCharArray().Any(c => !Draw.DefaultFont.Characters.Contains(c));
         }
 
         // Only required to be defined so that we can access it.

--- a/Celeste.Mod.mm/Patches/Monocle/Draw.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Draw.cs
@@ -1,0 +1,20 @@
+﻿#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
+
+using Microsoft.Xna.Framework.Graphics;
+
+namespace Monocle {
+    class patch_Draw {
+        public static SpriteFont DefaultFont { get; private set; }
+
+        internal extern static void orig_Initialize(GraphicsDevice graphicsDevice);
+
+        internal static void Initialize(GraphicsDevice graphicsDevice) {
+            orig_Initialize(graphicsDevice);
+
+            // Fix the issue that the game crashes when the exception information printed on the console contains non-existent characters
+            // If DefaultCharacter is null ArgumentException will be thrown.
+            // The default character will be substituted if you draw or measure text that contains characters which were not included in the font
+            DefaultFont.DefaultCharacter = '*';
+        }
+    }
+}


### PR DESCRIPTION
After entering a command with error arguments in the console, the console will print exception messages, then `ArgumentException` will be thrown when the exception message contains characters that do not exist in `Draw.DefaultFont`.

This PR replaces non-existent characters in the exception message with asterisk marks and prompts the user to log.txt to check the full exception message.

Here is the `ArgumentException` log after entering `check_language whatever` in the console.
[error_log.txt](https://github.com/EverestAPI/Everest/files/5735171/error_log.txt)
