### PR TITLE
Fix selected item not in screen center in submenus

### DIFF
--- a/Celeste.Mod.mm/Mod/UI/TextMenuExt.cs
+++ b/Celeste.Mod.mm/Mod/UI/TextMenuExt.cs
@@ -718,7 +718,7 @@ namespace Celeste {
                         break;
                     }
                 }
-                return offset - item.Height() * 0.5f - ItemSpacing + Container.GetYOffsetOf(this);
+                return offset - item.Height() * 0.5f - ItemSpacing + Container.GetYOffsetOf(this) - Height() * 0.5f + TitleHeight;
             }
 
             public void Exit() {
@@ -1129,7 +1129,7 @@ namespace Celeste {
                         break;
                     }
                 }
-                return offset - item.Height() * 0.5f - ItemSpacing + Container.GetYOffsetOf(this);
+                return offset - item.Height() * 0.5f - ItemSpacing + Container.GetYOffsetOf(this) - Height() * 0.5f + TitleHeight;
             }
 
             #endregion

--- a/Celeste.Mod.mm/Patches/TextMenu.cs
+++ b/Celeste.Mod.mm/Patches/TextMenu.cs
@@ -77,7 +77,9 @@ namespace Celeste {
                 if (listItem == targetItem)
                     break;
             }
-
+            if (targetItem is TextMenuExt.OptionSubMenu optionSubMenuItem && !optionSubMenuItem.Focused) {
+                return num - targetItem.Height() - ItemSpacing + optionSubMenuItem.TitleHeight * 0.5f;
+            }
             return num - targetItem.Height() * 0.5f - ItemSpacing;
         }
 


### PR DESCRIPTION
Fixes selected item go offscreen if there are too many items in submenu.

Before & after preview:

`OptionSubMenu` title:

![option-submenu](https://user-images.githubusercontent.com/7558201/105349650-ff7ea500-5c24-11eb-8de9-ccb42149183d.jpg)

`OptionSubMenu` items:

![option-submenu-item](https://user-images.githubusercontent.com/7558201/105349644-fe4d7800-5c24-11eb-8ea0-02653bf78f3d.jpg)

`SubMenu` items:

![submenu-item](https://user-images.githubusercontent.com/7558201/105349653-00173b80-5c25-11eb-9bef-14ab293ad16e.jpg)
