### PR TITLE
Skip applying custom Sprites.xml sprites that are identical to vanilla ones

### DIFF
--- a/Celeste.Mod.mm/Patches/LevelLoader.cs
+++ b/Celeste.Mod.mm/Patches/LevelLoader.cs
@@ -26,6 +26,8 @@ namespace Celeste {
         public extern void orig_ctor(Session session, Vector2? startPosition = default);
         [MonoModConstructor]
         public void ctor(Session session, Vector2? startPosition = default) {
+            Logger.Log(LogLevel.Info, "LevelLoader", "Loading level " + session?.Area.GetSID());
+
             if (LastLoadingThread != null &&
                 LastLoadingThread.TryGetTarget(out Thread lastThread) &&
                 (lastThread?.IsAlive ?? false)) {
@@ -98,7 +100,7 @@ namespace Celeste {
             path = meta?.Sprites;
             if (!string.IsNullOrEmpty(path)) {
                 SpriteBank bankOrig = GFX.SpriteBank;
-                SpriteBank bankMod = new SpriteBank(GFX.Game, path);
+                SpriteBank bankMod = new SpriteBank(GFX.Game, getModdedSpritesXml(path));
 
                 foreach (KeyValuePair<string, SpriteData> kvpBank in bankMod.SpriteData) {
                     string key = kvpBank.Key;
@@ -145,6 +147,12 @@ namespace Celeste {
             foreach (Queue<Entity> entities in ((patch_Pooler) Engine.Pooler).Pools.Values) {
                 entities.Clear();
             }
+        }
+
+        private XmlDocument getModdedSpritesXml(string path) {
+            XmlDocument vanillaSpritesXml = patch_Calc.orig_LoadContentXML(Path.Combine("Graphics", "Sprites.xml"));
+            XmlDocument modSpritesXml = Calc.LoadContentXML(path);
+            return patch_SpriteBank.GetSpriteBankExcludingVanillaCopyPastes(vanillaSpritesXml, modSpritesXml, path);
         }
 
         [MonoModIgnore] // We don't want to change anything about the method...

--- a/Celeste.Mod.mm/Patches/Monocle/Commands.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Commands.cs
@@ -236,7 +236,7 @@ namespace Monocle {
                 LogStackTrace(innerException.StackTrace);
 
                 if (ContainCantDrawChar(innerException.Message + innerException.StackTrace)) {
-                    Engine.Commands.Log("Please check log.txt for full exception log, because it contains characters can't be displayed.", Color.Yellow);
+                    Engine.Commands.Log("Please check log.txt for full exception log, because it contains characters that can't be displayed.", Color.Yellow);
                     Logger.Log("Commands", innerException.ToString());
                 }
             }


### PR DESCRIPTION
Proposed (partial) fix for #269: if a mod tries overriding a vanilla sprite with a copy-paste of itself (same XML code), just skip it by virtually deleting it from the XML before parsing it. The override would have no effect anyway, but would conflict with other mods and would undo their changes.

Copy-pasting and editing the vanilla Sprites.xml is a common practice both for skin mods and for maps, and this easily creates conflicts that this change could help mitigating. Remaining issues could be handled case by case through mod updates, so #269 could be closed.

This PR applies this to both Sprites.xml shipping with mods, and those applied to maps through metadata.