### PR TITLE
Fix gameplay RNG in AscendManager in custom maps

### DIFF
--- a/Celeste.Mod.mm/Patches/AscendManager.cs
+++ b/Celeste.Mod.mm/Patches/AscendManager.cs
@@ -1,0 +1,19 @@
+﻿#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
+#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
+#pragma warning disable CS0169 // The field is never used
+
+using Monocle;
+using MonoMod;
+using System.Collections;
+
+namespace Celeste {
+    class patch_AscendManager {
+        [MonoModIgnore]
+        [PatchAscendManagerRoutine]
+        private extern IEnumerator Routine();
+
+        private bool ShouldRestorePlayerX() {
+            return (Engine.Scene as Level).Session.Area.GetLevelSet() != "Celeste";
+        }
+    }
+}


### PR DESCRIPTION
The RNG here is seeded based on the system clock, not room names (which is used only when the entity is constructed in `Level.LoadLevel()`, like spinner and pufferfish cycles, RNG reverts back to the clock based one after the level completes loading), so it will affect TASes.

If there is a `SummitBackgroundManager` in the room, when the player triggers it but the player's X pos is not aligned to horizontal tile (precisely, X pos mod 8 is 3 ~ 5), because player shake is using clock based RNG, player's X pos changes randomly when shaking, also affects which tile player will be rounded to when entering next room. This is caused by not tile-aligned badeline orbs in most cases.

So when doing TASes, the player could be in any of the two adjacent tiles randomly if the player was boosted by a not tile-aligned badeline orb in the previous room.

This patch fixes it by resetting the player's X pos to the one before the player shakes, so it's always consistent no matter what RNG is used when shaking.

```diff
*** Celeste/AscendManager.cs
@@ -85,10 +85,13 @@ private IEnumerator Routine()
         Vector2 from = player.Position;
         for (float p = 0f; p < 1f; p += Engine.DeltaTime / 1f) {
             player.Position = Vector2.Lerp(from, from + new Vector2(0f, 60f), Ease.CubeInOut(p)) +     Calc.Random.ShakeVector();
             Input.Rumble(RumbleSrength.Light, RumbleLength.Short);
             yield return null;
         }
         AscendManager.Fader fader = new AscendManager.Fader(this);
         base.Scene.Add(fader);
+        if (this.ShouldRestorePlayerX()) {
+            player.X = from.X;
+        }
         from = player.Position;
         Input.Rumble(RumbleStrength.Strong, RumbleLength.Medium);
@@ -207,0 +210,3 @@ public class AscendManager : Entity
+    private bool ShouldRestorePlayerX() {
+        return (Engine.Scene as Level).Session.Area.GetLevelSet() != "Celeste";
+    }
```