### PR TITLE
Make console key's repeat timer independent with time rate

### DIFF
--- a/Celeste.Mod.mm/MonoModRules.cs
+++ b/Celeste.Mod.mm/MonoModRules.cs
@@ -349,6 +349,12 @@ namespace MonoMod {
     class PatchAscendManagerRoutineAttribute : Attribute { }
 
     /// <summary>
+    /// Patches Commands.UpdateOpen to make key's repeat timer independent with time rate.
+    /// </summary>
+    [MonoModCustomMethodAttribute("PatchCommandsUpdateOpen")]
+    class PatchCommandsUpdateOpenAttribute : Attribute { }
+
+    /// <summary>
     /// Forcibly changes a given member's name.
     /// </summary>
     [MonoModCustomAttribute("ForceName")]
@@ -2867,6 +2873,17 @@ namespace MonoMod {
             cursor.Emit(OpCodes.Ldflda, f_from);
             cursor.Emit(OpCodes.Ldfld, f_Vector2_X);
             cursor.Emit(OpCodes.Callvirt, m_Entity_set_X);
+        }
+
+        public static void PatchCommandsUpdateOpen(ILContext il, CustomAttribute attrib) {
+            ILCursor cursor = new ILCursor(il);
+
+            TypeDefinition t_Engine = MonoModRule.Modder.FindType("Monocle.Engine").Resolve();
+            MethodReference m_get_RawDeltaTime = t_Engine.FindMethod("System.Single get_RawDeltaTime()");
+
+            while (cursor.TryGotoNext(MoveType.Before, instr => instr.MatchCall("Monocle.Engine", "get_DeltaTime"))) {
+                cursor.Next.Operand = m_get_RawDeltaTime;
+            }
         }
 
         public static void ForceName(ICustomAttributeProvider cap, CustomAttribute attrib) {

--- a/Celeste.Mod.mm/Patches/Monocle/Commands.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Commands.cs
@@ -374,6 +374,10 @@ namespace Monocle {
             return text.ToCharArray().Any(c => !Draw.DefaultFont.Characters.Contains(c) && !char.IsControl(c));
         }
 
+        [MonoModIgnore]
+        [PatchCommandsUpdateOpen]
+        internal extern void UpdateOpen();
+
         // Only required to be defined so that we can access it.
         [MonoModIgnore]
         private struct patch_Line {


### PR DESCRIPTION
In vanilla, if the player speeds up the game by the `time` command in the console, the repeat time for keys also shortens, so players can be impossible to revert the time rate without restarting the game, since they need to press and release the key for a very short amount of time to input only one character. #282 actually fixed this by using `TextInput`, but the control keys aren't fixed.