### PR TITLE
Fix rare missing file slots bug

### DIFF
--- a/Celeste.Mod.mm/Patches/OuiFileSelect.cs
+++ b/Celeste.Mod.mm/Patches/OuiFileSelect.cs
@@ -1,14 +1,17 @@
 ﻿using Celeste.Mod.Core;
+using Monocle;
 using MonoMod;
 using System;
 using System.Collections;
 using System.IO;
+using System.Linq;
 
 namespace Celeste {
     class patch_OuiFileSelect : OuiFileSelect {
         public float Scroll = 0f;
 
         [PatchOuiFileSelectSubmenuChecks] // we want to manipulate the orig method with MonoModRules
+        [PatchOuiFileSelectEnter]
         public extern IEnumerator orig_Enter(Oui from);
         public new IEnumerator Enter(Oui from) {
             if (!Loaded) {
@@ -91,6 +94,21 @@ namespace Celeste {
                     (slot as patch_OuiFileSelectSlot).ScrollTo(slot.IdlePosition.X, slot.IdlePosition.Y);
                 }
             }
+        }
+
+        [PatchOuiFileSelectLoadThread]
+        [MonoModIgnore]
+        private extern void LoadThread();
+
+        private void RemoveSlotsFromScene() {
+            Scene.Remove(Slots
+                .Where(slot => slot != null)
+                // do not remove this line or the game will crash
+                .Where(_ => true));
+        }
+
+        private void AddSlotsToScene() {
+            Scene.Add(Slots);
         }
     }
 }

--- a/Celeste.Mod.mm/Patches/OuiFileSelect.cs
+++ b/Celeste.Mod.mm/Patches/OuiFileSelect.cs
@@ -101,10 +101,7 @@ namespace Celeste {
         private extern void LoadThread();
 
         private void RemoveSlotsFromScene() {
-            Scene.Remove(Slots
-                .Where(slot => slot != null)
-                // do not remove this line or the game will crash
-                .Where(_ => true));
+            Scene.Remove(Slots.Where(slot => slot != null));
         }
 
         private void AddSlotsToScene() {


### PR DESCRIPTION
NoelFB/Celeste#4

When file slots are missing, the missing slots is not in the scene's entity list, so they are never get updated and rendered, which is why selecting them will cause a soft lock.

![image](https://user-images.githubusercontent.com/7558201/108750472-0417df80-757c-11eb-8cf9-156c13c54fd4.png)

After logging all `Monocle.Entity.Added()` and `Monocle.EntityList.Add(Monocle.Entity)` calls (log file [here](https://pastebin.com/iB47jjEG), changed to 100 saves for easier reproduce), I found that the missing slot (at line 148) was adding to the scene but didn't get added. It's because that after pressing "CLIMB", the game starts a thread to load the save files, but the thread is also removing and adding entities, so two threads can access to `Monocle.EntityList.entities` at the same time, which can cause issues. (The main thread updates the game every frame, which calls `Monocle.Engine.Update(GameTime)`, which calls `Monocle.Scene.BeforeUpdate()`, which calls `Monocle.EntityList.UpdateLists()`, which actually adds/removes entities that get added/removed during this frame and sorts the entities by depth, thus `Monocle.EntityList.entities` is changed)

The solution is simply moving code that adds and removes entities out of the loading thread, so only one thread is accessing the entity list at the same time. The patched code should be similar to this:

```diff
*** Celeste/OuiFileSelect.cs
@@ -12,12 +12,20 @@ public class OuiFileSelect : Oui
 public override IEnumerator Enter(Oui from) {
     this.SlotSelected = false;
     if (!OuiFileSelect.Loaded) {
+        for (int i = 0; i < this.Slots.Length; i++) {
+            if (this.Slots[i] != null) {
+                base.Scene.Remove(this.Slots[i]);
+            }
+        }
         RunThread.Start(new Action(this.LoadThread), "FILE_LOADING", false);
         float elapsed = 0f;
         while (!OuiFileSelect.Loaded || elapsed < 0.5f) {
             elapsed += Engine.DeltaTime;
             yield return null;
         }
+        for (int i = 0; i < this.Slots.Length; i++) {
+            base.Scene.Add(ouiFileSelectSlot);
+        }
         if (!this.loadedSuccess) {
             FileErrorOverlay error = new FileErrorOverlay(FileErrorOverlay.Error.Load);
             while (error.Open) {
@@ -65,9 +73,6 @@ public class OuiFileSelect : Oui
 private void LoadThread() {
     if (UserIO.Open(UserIO.Mode.Read)) {
         for (int i = 0; i < this.Slots.Length; i++) {
-            if (this.Slots[i] != null) {
-                base.Scene.Remove(this.Slots[i]);
-            }
             OuiFileSelectSlot ouiFileSelectSlot;
             if (!UserIO.Exists(SaveData.GetFilename(i))) {
                 ouiFileSelectSlot = new OuiFileSelectSlot(i, this, false);
@@ -81,7 +86,6 @@ private void LoadThread() {
                 }
             }
             this.Slots[i] = ouiFileSelectSlot;
-            base.Scene.Add(ouiFileSelectSlot);
         }
         UserIO.Close();
         this.loadedSuccess = true;
```
