### PR TITLE
Delete mod saves before starting a new game

### DIFF
--- a/Celeste.Mod.mm/Patches/OuiFileSelectSlot.cs
+++ b/Celeste.Mod.mm/Patches/OuiFileSelectSlot.cs
@@ -166,6 +166,8 @@ namespace Celeste {
 
         public extern void orig_OnNewGameSelected();
         public void OnNewGameSelected() {
+            patch_SaveData.TryDeleteModSaveData(FileSlot);
+
             orig_OnNewGameSelected();
 
             string newGameLevelSet = newGameLevelSetPicker?.NewGameLevelSet;

--- a/Celeste.Mod.mm/Patches/SaveData.cs
+++ b/Celeste.Mod.mm/Patches/SaveData.cs
@@ -241,17 +241,18 @@ namespace Celeste {
         public static new bool TryDelete(int slot) {
             if (!orig_TryDelete(slot))
                 return false;
+            return TryDeleteModSaveData(slot);
+        }
 
+        public static bool TryDeleteModSaveData(int slot) {
             foreach (EverestModule mod in Everest._Modules) {
                 mod.DeleteSaveData(slot);
                 mod.DeleteSession(slot);
             }
 
-            UserIO.Delete(GetFilename(slot) + "-modsavedata");
-
             LoadedModSaveDataIndex = int.MinValue;
 
-            return true;
+            return UserIO.Delete(GetFilename(slot) + "-modsavedata");
         }
 
         public extern void orig_StartSession(Session session);


### PR DESCRIPTION
May fixes the bug that the game skips prologue when starting a new game, if the save file is deleted in vanilla.

If a file was deleted in vanilla, when beginning a new file in Everest, the game restores mod save backup in `SaveData.AfterInitialize()` and used restored `LastArea_Safe` to enter the first area in `OuiFileSelectSlot.EnterFirstAreaRoutine()`, so the game may enter other areas instead of the prologue.