### PR TITLE
Fix check for vanilla behavior in the coroutine delay hackfix

### DIFF
--- a/Celeste.Mod.mm/Patches/Monocle/Coroutine.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Coroutine.cs
@@ -6,7 +6,6 @@ using Celeste.Mod;
 using Celeste.Mod.Core;
 using Celeste.Mod.Helpers;
 using MonoMod;
-using MonoMod.Utils;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -64,7 +63,7 @@ namespace Monocle {
             // - they are both from Celeste.exe
             // - they aren't from CoroutineDelayHackfixHelper.Wrap, because that would mean they are actually a wrapped hook from a mod
             return prev.GetType().Assembly == typeof(Engine).Assembly && prev.GetType() != typeof(CoroutineDelayHackfixHelper)
-                && next.GetType().Assembly == typeof(Engine).Assembly && prev.GetType() != typeof(CoroutineDelayHackfixHelper);
+                && next.GetType().Assembly == typeof(Engine).Assembly && next.GetType() != typeof(CoroutineDelayHackfixHelper);
         }
     }
     public static class CoroutineExt {


### PR DESCRIPTION
When `ForceDelayedSwap` is null (so in any case except in a coroutine from an old mod that is not a hook), the delay will apply if the old coroutine and the new coroutine are **both** from vanilla (same assembly as Celeste itself), and if they are **not** the wrap coroutine from `CoroutineDelayHackfixHelper` (because hook coroutines from mods pretty much get replaced by this one... and it is declared in Celeste.exe so it is ""vanilla"" 😓)

In order to check for the `Wrap` coroutine, I went for MonoModRule magic that replaces `typeof(CoroutineDelayHackfixHelper)` with `typeof(CoroutineDelayHackfixHelper.<Wrap>d__2)`.

The mod that caused issues hooked `Player.PickupCoroutine` and did `yield return orig(self)`. Before applying this patch, TAS would desync at c-00 (first room where a jelly appears) with this mod installed, and after applying this the TAS reaches the end of Farewell with no issues.