### PR TITLE
Only call TranslateKeys on FNA branch when resetting key config or creating settings file from scratch

### DIFF
--- a/Celeste.Mod.mm/Patches/Settings.cs
+++ b/Celeste.Mod.mm/Patches/Settings.cs
@@ -1,0 +1,9 @@
+﻿using MonoMod;
+
+namespace Celeste {
+    class patch_Settings : Settings {
+        [MonoModIgnore]
+        [PatchSettingsDoNotTranslateKeys]
+        public extern new void SetDefaultKeyboardControls(bool reset);
+    }
+}


### PR DESCRIPTION
`Settings.TranslateKeys` is a method that only exists on the FNA branch and for example changes a key mapped to A to be mapped to Q instead on an AZERTY keyboard (A is where Q is on QWERTY).

The issue is that it is run on all bindings each time `SetDefaultKeyboardControls` is called... which is every time settings are loaded. So, bindings tend to be messed up a lot when you don't have a QWERTY keyboard, this is a vanilla issue that was reported multiple times since early on the beta.

This PR doesn't delete calls to TranslateKeys, but enclose them in a `if (reset || !Existed)` block. This means it will only be run when the user resets their key binds, or if the settings file didn't exist (first startup or corrupt file). This is still useful to adapt default bindings to the keyboard layout (turning ZXC to WXC on AZERTY for example), but won't mess with bindings on each startup.