### PR TITLE
Fix custom starfog not rotating in custom mountain

### DIFF
--- a/Celeste.Mod.mm/Patches/MountainModel.cs
+++ b/Celeste.Mod.mm/Patches/MountainModel.cs
@@ -121,6 +121,7 @@ namespace Celeste {
                     customFog2.TopColor = (customFog2.BotColor = Color.White * 0.3f * NearFogAlpha);
                     customStarstream1.Rotate(Engine.DeltaTime * 0.01f);
                     customStarstream2.Rotate(Engine.DeltaTime * 0.02f);
+                    customStarfog.Rotate(-Engine.DeltaTime * 0.01f);
                 }
             }
 


### PR DESCRIPTION
In vanilla `Celeste.MountainModel.Update()`, there is a line `this.starfog.Rotate(-Engine.DeltaTime * 0.01f);` that makes the starfog rotates, but it's missing in the patched `Update()`, causing it not rotating when a custom mountain is used.