### PR TITLE
Flush to disk each time a file is saved to avoid save file corruption

### DIFF
--- a/Celeste.Mod.mm/Mod/Module/EverestModule.cs
+++ b/Celeste.Mod.mm/Mod/Module/EverestModule.cs
@@ -86,7 +86,7 @@ namespace Celeste.Mod {
             Directory.CreateDirectory(Path.GetDirectoryName(path));
 
             try {
-                using (Stream stream = File.OpenWrite(path)) {
+                using (FileStream stream = File.OpenWrite(path)) {
                     if (_Settings is EverestModuleBinarySettings) {
                         using (BinaryWriter writer = new BinaryWriter(stream))
                             ((EverestModuleBinarySettings) _Settings).Write(writer);
@@ -94,6 +94,7 @@ namespace Celeste.Mod {
                         using (StreamWriter writer = new StreamWriter(stream))
                             YamlHelper.Serializer.Serialize(writer, _Settings, SettingsType);
                     }
+                    stream.Flush(true);
                 }
             } catch (Exception e) {
                 Logger.Log(LogLevel.Warn, "EverestModule", $"Failed to save the settings of {Metadata.Name}!");
@@ -157,7 +158,7 @@ namespace Celeste.Mod {
             Directory.CreateDirectory(Path.GetDirectoryName(path));
 
             try {
-                using (Stream stream = File.OpenWrite(path)) {
+                using (FileStream stream = File.OpenWrite(path)) {
                     if (_SaveData is EverestModuleBinarySaveData) {
                         using (BinaryWriter writer = new BinaryWriter(stream))
                             ((EverestModuleBinarySaveData) _SaveData).Write(writer);
@@ -165,6 +166,7 @@ namespace Celeste.Mod {
                         using (StreamWriter writer = new StreamWriter(stream))
                             YamlHelper.Serializer.Serialize(writer, _SaveData, SaveDataType);
                     }
+                    stream.Flush(true);
                 }
             } catch (Exception e) {
                 Logger.Log(LogLevel.Warn, "EverestModule", $"Failed to save the save data of {Metadata.Name}!");
@@ -244,7 +246,7 @@ namespace Celeste.Mod {
             Directory.CreateDirectory(Path.GetDirectoryName(path));
 
             try {
-                using (Stream stream = File.OpenWrite(path)) {
+                using (FileStream stream = File.OpenWrite(path)) {
                     if (_Session is EverestModuleBinarySession) {
                         using (BinaryWriter writer = new BinaryWriter(stream))
                             ((EverestModuleBinarySession) _Session).Write(writer);
@@ -252,6 +254,7 @@ namespace Celeste.Mod {
                         using (StreamWriter writer = new StreamWriter(stream))
                             YamlHelper.Serializer.Serialize(writer, _Session, SessionType);
                     }
+                    stream.Flush(true);
                 }
             } catch (Exception e) {
                 Logger.Log(LogLevel.Warn, "EverestModule", $"Failed to save the session of {Metadata.Name}!");
@@ -706,12 +709,12 @@ namespace Celeste.Mod {
 
                 if (!typeof(ButtonBinding).IsAssignableFrom(prop.PropertyType))
                     continue;
-                
+
                 if (!headerCreated) {
                     CreateModMenuSectionHeader(menu, inGame, snapshot);
                     headerCreated = true;
                 }
-                
+
                 CreateModMenuSectionKeyBindings(menu, inGame, snapshot);
                 break;
             }

--- a/Celeste.Mod.mm/MonoModRules.cs
+++ b/Celeste.Mod.mm/MonoModRules.cs
@@ -383,7 +383,7 @@ namespace MonoMod {
     class PatchOuiFileSelectLoadThreadAttribute : Attribute { }
 
     /// <summary>
-    /// Patches OuiFileSelect.LoadThread to fix file slots missing bug.
+    /// Patches UserIO.Save to flush save data to disk after writing it.
     /// </summary>
     [MonoModCustomMethodAttribute("PatchSaveDataFlushSaves")]
     class PatchSaveDataFlushSavesAttribute : Attribute { }

--- a/Celeste.Mod.mm/MonoModRules.cs
+++ b/Celeste.Mod.mm/MonoModRules.cs
@@ -5,6 +5,7 @@ using MonoMod.InlineRT;
 using MonoMod.Utils;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 namespace MonoMod {
@@ -380,6 +381,12 @@ namespace MonoMod {
     /// </summary>
     [MonoModCustomMethodAttribute("PatchOuiFileSelectLoadThread")]
     class PatchOuiFileSelectLoadThreadAttribute : Attribute { }
+
+    /// <summary>
+    /// Patches OuiFileSelect.LoadThread to fix file slots missing bug.
+    /// </summary>
+    [MonoModCustomMethodAttribute("PatchSaveDataFlushSaves")]
+    class PatchSaveDataFlushSavesAttribute : Attribute { }
 
     static class MonoModRules {
 
@@ -3033,6 +3040,27 @@ namespace MonoMod {
                 c.Emit(OpCodes.Ldfld, il.Method.DeclaringType.FindField("Existed"));
                 c.Emit(OpCodes.Brtrue, jumpTarget);
             }
+        }
+
+        public static void PatchSaveDataFlushSaves(ILContext il, CustomAttribute attrib) {
+            ILCursor c = new ILCursor(il);
+
+            c.GotoNext(instr => instr.MatchCallvirt<Stream>("Write"));
+            c.Next.OpCode = OpCodes.Call;
+            c.Next.Operand = il.Method.DeclaringType.FindMethod("_saveAndFlush");
+
+            // File.Copy(from, to, overwrite: true) => _saveAndFlushToFile(data, to)
+            c.GotoNext(instr => instr.MatchCall(typeof(File), "Copy"));
+            c.Index -= 3;
+
+            // replace "from" with "data"
+            c.Next.OpCode = OpCodes.Ldarg_1;
+            // skip to "overwrite: true" and remove it
+            c.Index += 2;
+            c.Remove();
+            // replace Files.Copy with _saveAndFlushToFile
+            c.Next.OpCode = OpCodes.Call;
+            c.Next.Operand = il.Method.DeclaringType.FindMethod("_saveAndFlushToFile");
         }
 
         public static void PostProcessor(MonoModder modder) {

--- a/Celeste.Mod.mm/Patches/UserIO.cs
+++ b/Celeste.Mod.mm/Patches/UserIO.cs
@@ -69,6 +69,21 @@ namespace Celeste {
             return result;
         }
 
+        [MonoModIgnore]
+        [PatchSaveDataFlushSaves]
+        public static extern bool Save<T>(string path, byte[] data);
+
+        private static void _saveAndFlushToFile(byte[] data, string handle) {
+            using (FileStream fileStream = File.Open(handle, FileMode.Create, FileAccess.Write)) {
+                _saveAndFlush(fileStream, data, 0, data.Length);
+            }
+        }
+
+        private static void _saveAndFlush(FileStream stream, byte[] array, int offset, int count) {
+            stream.Write(array, offset, count);
+            stream.Flush(true);
+        }
+
         private static IEnumerator SaveNonHandler() {
             yield break;
         }


### PR DESCRIPTION
Tries to address the vanilla issue https://github.com/NoelFB/Celeste/issues/3

From https://stackoverflow.com/a/52751216:
> [In the scenario of a power loss] the file has 3 expected possible states when the machine comes back up:
> 1) The file doesn't exist at all or has its original length, as if the write never happened.
> 2) The file has the expected length as if the write happened, but the data is zeros.
> 3) The file has the expected length and the correct data that was written.
>
> State 2 [...] occurs because when you do the cached write, NTFS initially just extends the file size accordingly but leaves VDL (valid data length) untouched. Data beyond VDL always reads back as zeros. The data you were intending to write is sitting in memory in the file cache. It will eventually get written to disk, usually within a few seconds, and following that VDL will get advanced on disk to reflect the data written. If power loss occurs before the data is written or before VDL gets increased, you will end up in state 2.

To prevent file corruption, Celeste tries writing to the `Backups` folder, reading back from it, then copying to the `Saves` folder if the load succeeds... but this doesn't prevent from ending up with 2 files filled with zero bytes (probably because the data being loaded back for the check isn't coming from the disk, but from the file cache).

This PR adds `FileStream.Flush(true)` everywhere where save files are written, to force them to be actually written on disk.