### PR TITLE
Append XNA or FNA after Celeste version in log files

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -60,7 +60,7 @@ namespace Celeste.Mod {
         /// <summary>
         /// The currently present Celeste version combined with the currently installed Everest build.
         /// </summary>
-        public static string VersionCelesteString => $"{Celeste.Instance.Version} [Everest: {BuildString}]";
+        public static string VersionCelesteString => $"{Celeste.Instance.Version}-{(typeof(Game).Assembly.FullName.Contains("FNA") ? "fna" : "xna")} [Everest: {BuildString}]";
 
         /// <summary>
         /// The command line arguments passed when launching the game.


### PR DESCRIPTION
When someone posts a log file, it's unable to tell whether they are using XNA or FNA without asking them, so I think making it shown in the log files is better.

The error log will be like this:

<pre>
Celeste Error Log
==========================================

Ver 1.4.0.0<b>-fna</b> [Everest: 0-dev]
05/28/2021 02:11:00
System.NullReferenceException: Object reference not set to an instance of an object.
   at Monocle.Calc.NextFloat(Random random, Single max)
</pre>

And the log file will be like this:

<pre>
CELESTE : 1.4.0.0
(05/28/2021 02:01:23) [Everest] [Info] [core] Booting Everest
(05/28/2021 02:01:23) [Everest] [Info] [core] AppDomain: Celeste.exe+Everest
(05/28/2021 02:01:23) [Everest] [Info] [core] VersionCelesteString: 1.4.0.0<b>-fna</b> [Everest: 0-dev]
</pre>