### PR TITLE
Try to fix concurrent modification when loading sprite bank

### DIFF
--- a/Celeste.Mod.mm/Patches/Monocle/SpriteBank.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/SpriteBank.cs
@@ -58,13 +58,14 @@ namespace Monocle {
             string modAssetPath = filename.Substring(0, filename.Length - 4).Replace('\\', '/');
 
             // Find all mod files that match this one, EXCEPT for the "shadow structure" asset - the unique "Graphics/Sprites" asset.
-            IEnumerable<ModAsset> modAssets;
+            List<ModAsset> modAssets;
             lock (Everest.Content.Map)
                 modAssets = Everest.Content.Map
                     .Where((a) => a.Value.Type == typeof(AssetTypeSpriteBank) &&
                         a.Value.PathVirtual.Equals(modAssetPath) &&
                         !a.Value.PathVirtual.Equals(a.Key)) // Filter out the unique asset
-                    .Select(kvp => kvp.Value);
+                    .Select(kvp => kvp.Value)
+                    .ToList();
 
             foreach (ModAsset modAsset in modAssets) {
                 string modPath = modAsset.Source.Mod.PathDirectory;


### PR DESCRIPTION
From [this message](https://discord.com/channels/403698615446536203/514006912115802113/847018279323172874):

> ```
> --------------------------------
> Detailed exception log:
> --------------------------------
> System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
>    at System.ThrowHelper.ThrowInvalidOperationException(ExceptionResource resource)
>    at System.Collections.Generic.Dictionary`2.Enumerator.MoveNext()
>    at System.Linq.Enumerable.WhereSelectEnumerableIterator`2.MoveNext()
>    at Monocle.SpriteBank.LoadSpriteBank(String filename) in D:\a\1\s\Celeste.Mod.mm\Patches\Monocle\SpriteBank.cs:line 0
>    at Monocle.SpriteBank..ctor(Atlas atlas, String xmlPath) in D:\a\1\s\Celeste.Mod.mm\Patches\Monocle\SpriteBank.cs:line 36
>    at DMD<Celeste.LevelLoader::.ctor>(LevelLoader this, Session session, Nullable`1 startPosition)
> ```
> i get this error a lot when saving levels, doesn't crash the game but kicks me out of the level with the "send your log.txt to the mapper" message. dont see any mods in this stacktrace so i assume it's an everest thing

Don't know how to reproduce but it seems like `Everest.Content.Map` may be modified after the lock section, so `modAssets` needs to be a copy of it.