### PR TITLE
Delete existing mod first if mod is blacklisted when downloading dependencies

### DIFF
--- a/Celeste.Mod.mm/Mod/UI/OuiDependencyDownloader.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiDependencyDownloader.cs
@@ -421,6 +421,9 @@ namespace Celeste.Mod.UI {
                 } else {
                     string installDestination = Path.Combine(Everest.Loader.PathMods, $"{mod.Name}.zip");
                     LogLine(string.Format(Dialog.Get("DEPENDENCYDOWNLOADER_INSTALLING"), mod.Name, mod.Version, installDestination));
+                    if (File.Exists(installDestination)) {
+                        File.Delete(installDestination);
+                    }
                     File.Move(downloadDestination, installDestination);
                     Everest.Loader.LoadZip(installDestination);
                 }


### PR DESCRIPTION
If a mod is a dependency but blacklisted, an exception will be thrown by `File.Move` when downloading dependencies, because the file exists.

```
(05/30/2021 21:57:50) [Everest] [Verbose] [progress] Downloading AdventureHelper from https://celeste.weg.fan/download/521836.zip...
(05/30/2021 21:57:51) [Everest] [Verbose] [progress] Verifying checksum...
(05/30/2021 21:57:51) [Everest] [Verbose] [ModUpdaterHelper] Verifying checksum: actual hash is ead8194da92a8230, expected hash is ead8194da92a8230
(05/30/2021 21:57:51) [Everest] [Verbose] [progress] Installing mod AdventureHelper v.1.5.1 to E:\SteamLibrary\steamapps\common\Celeste\Mods\AdventureHelper.zip...
(05/30/2021 21:57:51) [Everest] [Verbose] [progress] ERROR: Installing AdventureHelper failed. Please check your log.txt for more info.
--------------------------------
Detailed exception log:
--------------------------------
System.IO.IOException: Cannot create a file when that file already exists.

   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.IO.__Error.WinIOError()
   at System.IO.File.InternalMove(String sourceFileName, String destFileName, Boolean checkHost)
   at Celeste.Mod.UI.OuiDependencyDownloader.downloadDependency(ModUpdateInfo mod, EverestModuleMetadata installedVersion) in D:\My Documents\Rider\Everest\Celeste.Mod.mm\Mod\UI\OuiDependencyDownloader.cs:line 379
(05/30/2021 21:57:51) [Everest] [Verbose] [OuiDependencyDownloader] Deleting temp file E:\SteamLibrary\steamapps\common\Celeste\dependency-download.zip
```