### PR TITLE
Apply DecalRegistry tags to multiple Decals

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Content.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Content.cs
@@ -798,8 +798,8 @@ namespace Celeste.Mod {
                         using (StreamReader reader = new StreamReader(next.Stream)) {
                             fileContents = reader.ReadToEnd();
                         }
-                        // Directly apply new decal registry
-                        DecalRegistry.ReadDecalRegistryXml(fileContents, apply: true);
+                        // Reload decal registry entirely, from every mod, so that decal attributes apply in the same order than on startup consistenly
+                        DecalRegistry.LoadDecalRegistry();
                         AssetReloadHelper.ReloadLevel();
 
                     } else if (next.Type == typeof(AssetTypeDialog) || next.Type == typeof(AssetTypeDialogExport)) {

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Content.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Content.cs
@@ -798,7 +798,8 @@ namespace Celeste.Mod {
                         using (StreamReader reader = new StreamReader(next.Stream)) {
                             fileContents = reader.ReadToEnd();
                         }
-                        DecalRegistry.ReadDecalRegistryXml(fileContents);
+                        // Directly apply new decal registry
+                        DecalRegistry.ReadDecalRegistryXml(fileContents, apply: true);
                         AssetReloadHelper.ReloadLevel();
 
                     } else if (next.Type == typeof(AssetTypeDialog) || next.Type == typeof(AssetTypeDialogExport)) {

--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistry.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistry.cs
@@ -181,36 +181,34 @@ namespace Celeste.Mod {
                     }
 
                     if (decalPath.EndsWith("*") || decalPath.EndsWith("/")) {
+                        // Removing the '/' made the path wrong
                         decalPath = decalPath.TrimEnd('*');
                         int pathLength = decalPath.Length;
 
-                        foreach (string subDecalPath in 
+                        foreach (string subDecalPath in
                             GFX.Game.GetTextures().Keys
                             .Select(str => str.StartsWith("decals/") ? str.Remove(0, 7) : null)
                             .Where(str => str != null && str.StartsWith(decalPath))
                         ) {
                             // Decals in subfolders are considered as unmatched
-                            if (!subDecalPath.Remove(0, pathLength).Contains("/")) {
-                                if (RegisteredDecals.ContainsKey(subDecalPath)) {
-                                    Logger.Log("Decal Registry", $"Replaced decal {subDecalPath}");
-                                    RegisteredDecals[subDecalPath] = info;
-                                } else {
-                                    Logger.Log("Decal Registry", $"Registered decal {subDecalPath}");
-                                    RegisteredDecals.Add(subDecalPath, info);
-                                }
-                            }
+                            if (!subDecalPath.Remove(0, pathLength).Contains("/"))
+                                RegisterDecal(subDecalPath, info);
                         }
                     } else {
                         // Single decal registered
-                        if (RegisteredDecals.ContainsKey(decalPath)) {
-                            Logger.Log("Decal Registry", $"Replaced decal {decalPath}");
-                            RegisteredDecals[decalPath] = info;
-                        } else {
-                            Logger.Log("Decal Registry", $"Registered decal {decalPath}");
-                            RegisteredDecals.Add(decalPath, info);
-                        }
+                        RegisterDecal(decalPath, info);
                     }
                 }
+            }
+        }
+
+        public static void RegisterDecal(string decalPath, DecalInfo info) {
+            if (RegisteredDecals.ContainsKey(decalPath)) {
+                Logger.Log("Decal Registry", $"Replaced decal {decalPath}");
+                RegisteredDecals[decalPath] = info;
+            } else {
+                Logger.Log("Decal Registry", $"Registered decal {decalPath}");
+                RegisteredDecals.Add(decalPath, info);
             }
         }
 

--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistry.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistry.cs
@@ -212,9 +212,13 @@ namespace Celeste.Mod {
 
                     foreach (string subDecalPath in
                         GFX.Game.GetTextures().Keys
-                        .Select(str => str.StartsWith("decals/") ? str.Remove(0, 7).TrimEnd('0','1','2','3','4','5','6','7','8','9') : null)
+                        .GroupBy(
+                            s => s.StartsWith("decals/") ? 
+                                s.Substring(7).TrimEnd('0','1','2','3','4','5','6','7','8','9') : 
+                                null, 
+                            (s, matches) => s
+                        ) 
                         .Where(str => str != null && str.StartsWith(decalPath) && str.Length > pathLength)
-                        .GroupBy(s => s, (s, matches) => s) // Group duplicates together
                     ) {
                         // Decals in subfolders are considered as unmatched
                         if (!subDecalPath.Remove(0, pathLength).Contains("/"))

--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistry.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistry.cs
@@ -188,7 +188,7 @@ namespace Celeste.Mod {
                         foreach (string subDecalPath in
                             GFX.Game.GetTextures().Keys
                             .Select(str => str.StartsWith("decals/") ? str.Remove(0, 7) : null)
-                            .Where(str => str != null && str.StartsWith(decalPath))
+                            .Where(str => str != null && str.StartsWith(decalPath) && str.Length > pathLength)
                         ) {
                             // Decals in subfolders are considered as unmatched
                             if (!subDecalPath.Remove(0, pathLength).Contains("/"))

--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistry.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistry.cs
@@ -180,14 +180,36 @@ namespace Celeste.Mod {
                         }
                     }
 
-                    if (RegisteredDecals.ContainsKey(decalPath)) {
-                        Logger.Log("Decal Registry", $"Replaced decal {decalPath}");
-                        RegisteredDecals[decalPath] = info;
-                    } else {
-                        Logger.Log("Decal Registry", $"Registered decal {decalPath}");
-                        RegisteredDecals.Add(decalPath, info);
-                    }
+                    if (decalPath.EndsWith("*") || decalPath.EndsWith("/")) {
+                        decalPath = decalPath.TrimEnd('*');
+                        int pathLength = decalPath.Length;
 
+                        foreach (string subDecalPath in 
+                            GFX.Game.GetTextures().Keys
+                            .Select(str => str.StartsWith("decals/") ? str.Remove(0, 7) : null)
+                            .Where(str => str != null && str.StartsWith(decalPath))
+                        ) {
+                            // Decals in subfolders are considered as unmatched
+                            if (!subDecalPath.Remove(0, pathLength).Contains("/")) {
+                                if (RegisteredDecals.ContainsKey(subDecalPath)) {
+                                    Logger.Log("Decal Registry", $"Replaced decal {subDecalPath}");
+                                    RegisteredDecals[subDecalPath] = info;
+                                } else {
+                                    Logger.Log("Decal Registry", $"Registered decal {subDecalPath}");
+                                    RegisteredDecals.Add(subDecalPath, info);
+                                }
+                            }
+                        }
+                    } else {
+                        // Single decal registered
+                        if (RegisteredDecals.ContainsKey(decalPath)) {
+                            Logger.Log("Decal Registry", $"Replaced decal {decalPath}");
+                            RegisteredDecals[decalPath] = info;
+                        } else {
+                            Logger.Log("Decal Registry", $"Registered decal {decalPath}");
+                            RegisteredDecals.Add(decalPath, info);
+                        }
+                    }
                 }
             }
         }

--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistry.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistry.cs
@@ -212,8 +212,9 @@ namespace Celeste.Mod {
 
                     foreach (string subDecalPath in
                         GFX.Game.GetTextures().Keys
-                        .Select(str => str.StartsWith("decals/") ? str.Remove(0, 7) : null)
+                        .Select(str => str.StartsWith("decals/") ? str.Remove(0, 7).TrimEnd('0','1','2','3','4','5','6','7','8','9') : null)
                         .Where(str => str != null && str.StartsWith(decalPath) && str.Length > pathLength)
+                        .GroupBy(s => s, (s, matches) => s) // Group duplicates together
                     ) {
                         // Decals in subfolders are considered as unmatched
                         if (!subDecalPath.Remove(0, pathLength).Contains("/"))

--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistry.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistry.cs
@@ -156,7 +156,7 @@ namespace Celeste.Mod {
         /// <summary>
         /// Reads a DecalRegistry.xml file's contents
         /// </summary>
-        public static List<KeyValuePair<string, DecalInfo>> ReadDecalRegistryXml(string fileContents, bool apply = false) {
+        public static List<KeyValuePair<string, DecalInfo>> ReadDecalRegistryXml(string fileContents) {
             // XmlElement file = Calc.LoadXML(path)["decals"];
             XmlDocument doc = new XmlDocument();
             doc.LoadXml(fileContents);
@@ -185,10 +185,6 @@ namespace Celeste.Mod {
                     elements.Add(new KeyValuePair<string, DecalInfo>(decalPath, info));
                 }
             }
-
-            // In-game reload only, we don't want to reload every decal registry each time a file is updated
-            if (apply)
-                ApplyDecalRegistry(elements);
 
             return elements;
         }


### PR DESCRIPTION
These changes make apply decal registry tags easier, specifically when more than one decal need the same tags. Could be really handy for people who use a lot of decals that need the same properties.

* Ending the path attribute with a `/` will cause it to be treated as a folder, and all decals in the folder will be affected.
* Ending the path attribute with a `*` will act as a wildcard, and match all decals that begin with that path.

Decals in subfolders, in both cases, are not affected.
This now makes `DecalRegistry.ReadDecalRegistryXml` only return a list of `KeyValuePair`s that contain the path to decals with the corresponding `DecalInfo` data. Those are all sorted so that the path attributes that concern a folder are applied first, then the ones acting as a wildcard, and then the single decal paths. And then they are all actually applied in `DecalRegistry.ApplyDecalRegistry`.

This also makes in-game mod updating reload every decal registry files, so that the decal tags are registered the same way that they are on startup consistently.

_Closes #315._ 