### PR TITLE
Improve performance when entering large menus

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Emoji.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Emoji.cs
@@ -163,8 +163,7 @@ namespace Celeste.Mod {
                                 now head and tail are pointing to colons so we need to check if the text inside colons is an emoji name
                             */
                             string name = text.Substring(head + 1, (tail - 1) - (head + 1) + 1);
-                            bool exist = _IDs.TryGetValue(name, out int value);
-                            if (exist) {
+                            if (_IDs.TryGetValue(name, out int value)) {
                                 // if it is, we need to first append the text before emoji
                                 resultBuilder.Append(text, appendStartIndex, (head - 1) - appendStartIndex + 1);
                                 // then append the emoji itself
@@ -193,7 +192,7 @@ namespace Celeste.Mod {
                 /*
                         aaaa:1111:2222:bbbb
                     (6)               H^S  ^T
-                    there are still text left since last append, so we need to append them 
+                    there are still text left since last append, so we need to append them
                 */
                 if (appendStartIndex < text.Length) {
                     resultBuilder.Append(text, appendStartIndex, (text.Length - 1) - appendStartIndex + 1);

--- a/Celeste.Mod.mm/Mod/Everest/Emoji.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Emoji.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Text;
 using System.Xml;
 
 namespace Celeste.Mod {
@@ -143,14 +144,62 @@ namespace Celeste.Mod {
         /// <param name="text"></param>
         /// <returns></returns>
         public static string Apply(string text) {
-            if (text == null || text.Count(c => c == ':') < 2)
+            if (text == null)
                 return text;
             // TODO: This trashes the GC and doesn't allow escaping!
             lock (_IDs) {
-                foreach (KeyValuePair<string, int> kvp in _IDs)
-                    text = text.Replace(":" + kvp.Key + ":", ((char) (Start + kvp.Value)).ToString());
+                StringBuilder resultBuilder = new StringBuilder();
+                int appendStartIndex = 0;
+                int head = -1, tail = 0;
+                // suppose text is "aaaa:1111:2222:bbbb", and only ":2222:" is emoji name
+                // H = head, T = tail, S = appendStartIndex
+                while (tail < text.Length) {
+                    if (text[tail] == ':') {
+                        if (head >= 0 && text[head] == ':') {
+                            /*
+                                    aaaa:1111:2222:bbbb
+                                (2) ^S  ^H   ^T   ^
+                                (4) ^S       ^H   ^T
+                                now head and tail are pointing to colons so we need to check if the text inside colons is an emoji name
+                            */
+                            string name = text.Substring(head + 1, (tail - 1) - (head + 1) + 1);
+                            bool exist = _IDs.TryGetValue(name, out int value);
+                            if (exist) {
+                                // if it is, we need to first append the text before emoji
+                                resultBuilder.Append(text, appendStartIndex, (head - 1) - appendStartIndex + 1);
+                                // then append the emoji itself
+                                resultBuilder.Append((char) (Start + value));
+                                // the emoji name has been replaced, we need to advance tail pointer once
+                                // because the colon is used and can't belong to next emoji
+                                tail++;
+                                appendStartIndex = tail;
+                                /*
+                                        aaaa:1111:2222:bbbb
+                                    (5)          ^H   S^T
+                                */
+                            }
+                        }
+                        head = tail;
+                        /*
+                                aaaa:1111:2222:bbbb
+                            (1) ^S H^T   ^
+                            (3) ^S      H^T
+                            when tail is pointing to a colon, we need to let head also points to it
+                            so when tail moves to next colon, text[head..tail] can be an emoji name and we can check then replace it
+                        */
+                    }
+                    tail++;
+                }
+                /*
+                        aaaa:1111:2222:bbbb
+                    (6)               H^S  ^T
+                    there are still text left since last append, so we need to append them 
+                */
+                if (appendStartIndex < text.Length) {
+                    resultBuilder.Append(text, appendStartIndex, (text.Length - 1) - appendStartIndex + 1);
+                }
+                return resultBuilder.ToString();
             }
-            return text;
         }
 
     }

--- a/Celeste.Mod.mm/Mod/Everest/Emoji.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Emoji.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Xml;
 
 namespace Celeste.Mod {
@@ -142,7 +143,7 @@ namespace Celeste.Mod {
         /// <param name="text"></param>
         /// <returns></returns>
         public static string Apply(string text) {
-            if (text == null)
+            if (text == null || text.Count(c => c == ':') < 2)
                 return text;
             // TODO: This trashes the GC and doesn't allow escaping!
             lock (_IDs) {

--- a/Celeste.Mod.mm/Mod/UI/OuiMapList.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiMapList.cs
@@ -78,6 +78,8 @@ namespace Celeste.Mod.UI {
         }
 
         private void ReloadItems() {
+            ((patch_TextMenu) menu).BatchMode = true;
+
             foreach (TextMenu.Item item in items)
                 menu.Remove(item);
             items.Clear();
@@ -148,6 +150,8 @@ namespace Celeste.Mod.UI {
                 items.Add(button);
             }
 
+            ((patch_TextMenu) menu).BatchMode = false;
+            
             // compute a delay so that options don't take more than a second to show up if many mods are installed.
             float delayBetweenOptions = 0.03f;
             if (items.Count > 0)

--- a/Celeste.Mod.mm/Mod/UI/OuiMapSearch.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiMapSearch.cs
@@ -238,6 +238,8 @@ namespace Celeste.Mod.UI {
             itemCount = 0;
             matchCount = 0;
 
+            ((patch_TextMenu) menu.rightMenu).BatchMode = true;
+
             foreach (TextMenu.Item item in items)
                 menu.rightMenu.Remove(item);
             items.Clear();
@@ -362,6 +364,8 @@ namespace Celeste.Mod.UI {
             if (resultHeader != null) {
                 resultHeader.Title = string.Format(itemCount == 1 ? Dialog.Get("maplist_results_singular") : Dialog.Get("maplist_results_plural"), itemCount);
             }
+
+            ((patch_TextMenu) menu.rightMenu).BatchMode = false;
 
             // compute a delay so that options don't take more than a second to show up if many mods are installed.
             float delayBetweenOptions = 0.03f;

--- a/Celeste.Mod.mm/Mod/UI/OuiModOptions.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiModOptions.cs
@@ -33,6 +33,7 @@ namespace Celeste.Mod.UI {
 
         public static TextMenu CreateMenu(bool inGame, EventInstance snapshot) {
             TextMenu menu = new TextMenu();
+            ((patch_TextMenu) menu).BatchMode = true;
 
             menu.Add(new TextMenuExt.HeaderImage("menu/everest") {
                 ImageColor = Color.White,
@@ -130,6 +131,7 @@ namespace Celeste.Mod.UI {
                 menu.Position.Y = menu.ScrollTargetY;
             }
 
+            ((patch_TextMenu) menu).BatchMode = false;
             return menu;
         }
 

--- a/Celeste.Mod.mm/Patches/TextMenu.cs
+++ b/Celeste.Mod.mm/Patches/TextMenu.cs
@@ -56,7 +56,9 @@ namespace Celeste {
             if (Selection == -1)
                 FirstSelection();
 
-            RecalculateSize();
+            if (!BatchMode) {
+                RecalculateSize();
+            }
             item.Added();
             return this;
         }
@@ -77,11 +79,13 @@ namespace Celeste {
             Remove(item.ValueWiggler);
             Remove(item.SelectWiggler);
 
-            RecalculateSize();
+            if (!BatchMode) {
+                RecalculateSize();
+            }
             return this;
         }
 
-        /// <inheritdoc cref="TextMenu.GetYOffsetOf(Item)"/>
+        /// <inheritdoc cref="TextMenu.GetYOffsetOf(TextMenu.Item)"/>
         [MonoModReplace]
         public new float GetYOffsetOf(Item targetItem) {
             // this is a small fix of the vanilla method to better support invisible menu items.
@@ -167,15 +171,23 @@ namespace Celeste {
             return skippedItems;
         }
 
-#pragma warning disable CS0626 // extern method with no attribute
-        public extern void orig_RecalculateSize();
-#pragma warning restore CS0626 // extern method with no attribute
-
-        public new void RecalculateSize() {
-            if (BatchMode) {
-                return;
+        /// <inheritdoc cref="TextMenu.Add(TextMenu.Item)"/>
+        [MonoModReplace]
+        public new TextMenu Add(Item item)
+        {
+            items.Add(item);
+            item.Container = this;
+            Add(item.ValueWiggler = Wiggler.Create(0.25f, 3f));
+            Add(item.SelectWiggler = Wiggler.Create(0.25f, 3f));
+            item.ValueWiggler.UseRawDeltaTime = item.SelectWiggler.UseRawDeltaTime = true;
+            if (Selection == -1) {
+                FirstSelection();
             }
-            orig_RecalculateSize();
+            if (!BatchMode) {
+                RecalculateSize();
+            }
+            item.Added();
+            return this;
         }
 
         public class patch_LanguageButton : LanguageButton {

--- a/Celeste.Mod.mm/Patches/TextMenu.cs
+++ b/Celeste.Mod.mm/Patches/TextMenu.cs
@@ -16,12 +16,16 @@ namespace Celeste {
         private List<Item> items;
 
         private bool batchMode;
+        private float width;
+        private float leftColumnWidth;
+        private float rightColumnWidth;
+        private float height;
+        private bool recalculatingSizeInBatchMode;
 
         /// <summary>
         /// The items contained in this menu.
         /// </summary>
         public List<Item> Items => items;
-
 
         /// <summary>
         /// When a menu is in batch mode, adding / removing items will not recalculate its size to improve performance.
@@ -35,6 +39,58 @@ namespace Celeste {
                     RecalculateSize();
                 }
             }
+        }
+
+        /// <inheritdoc cref="TextMenu.Width"/>
+        public new float Width {
+            [MonoModReplace]
+            get {
+                if (batchMode && !recalculatingSizeInBatchMode) {
+                    RecalculateSize();
+                }
+                return width;
+            }
+            [MonoModReplace]
+            private set => width = value;
+        }
+
+        /// <inheritdoc cref="TextMenu.Height"/>
+        public new float Height {
+            [MonoModReplace]
+            get {
+                if (batchMode && !recalculatingSizeInBatchMode) {
+                    RecalculateSize();
+                }
+                return height;
+            }
+            [MonoModReplace]
+            private set => height = value;
+        }
+
+        /// <inheritdoc cref="TextMenu.LeftColumnWidth"/>
+        public new float LeftColumnWidth {
+            [MonoModReplace]
+            get {
+                if (batchMode && !recalculatingSizeInBatchMode) {
+                    RecalculateSize();
+                }
+                return leftColumnWidth;
+            }
+            [MonoModReplace]
+            private set => leftColumnWidth = value;
+        }
+
+        /// <inheritdoc cref="TextMenu.RightColumnWidth"/>
+        public new float RightColumnWidth {
+            [MonoModReplace]
+            get {
+                if (batchMode && !recalculatingSizeInBatchMode) {
+                    RecalculateSize();
+                }
+                return rightColumnWidth;
+            }
+            [MonoModReplace]
+            private set => rightColumnWidth = value;
         }
 
         // Basically the same as Add(), but with an index parameter.
@@ -188,6 +244,20 @@ namespace Celeste {
             }
             item.Added();
             return this;
+        }
+
+#pragma warning disable CS0626 // extern method with no attribute
+        public extern void orig_RecalculateSize();
+#pragma warning restore CS0626 // extern method with no attribute
+
+        public new void RecalculateSize() {
+            if (BatchMode) {
+                recalculatingSizeInBatchMode = true;
+            }
+            orig_RecalculateSize();
+            if (BatchMode) {
+                recalculatingSizeInBatchMode = false;
+            }
         }
 
         public class patch_LanguageButton : LanguageButton {

--- a/Celeste.Mod.mm/Patches/TextMenu.cs
+++ b/Celeste.Mod.mm/Patches/TextMenu.cs
@@ -15,10 +15,27 @@ namespace Celeste {
         // We're effectively in TextMenu, but still need to "expose" private fields to our mod.
         private List<Item> items;
 
+        private bool batchMode;
+
         /// <summary>
         /// The items contained in this menu.
         /// </summary>
         public List<Item> Items => items;
+
+
+        /// <summary>
+        /// When a menu is in batch mode, adding / removing items will not recalculate its size to improve performance.
+        /// Size is recalculated immediately after batch mode is disabled.
+        /// </summary>
+        public bool BatchMode {
+            get => batchMode;
+            set {
+                batchMode = value;
+                if (!batchMode) {
+                    RecalculateSize();
+                }
+            }
+        }
 
         // Basically the same as Add(), but with an index parameter.
         /// <summary>
@@ -148,6 +165,17 @@ namespace Celeste {
             }
 
             return skippedItems;
+        }
+
+#pragma warning disable CS0626 // extern method with no attribute
+        public extern void orig_RecalculateSize();
+#pragma warning restore CS0626 // extern method with no attribute
+
+        public new void RecalculateSize() {
+            if (BatchMode) {
+                return;
+            }
+            orig_RecalculateSize();
         }
 
         public class patch_LanguageButton : LanguageButton {


### PR DESCRIPTION
### Issue

If players install a lot of mods, the game may freeze for a short time when they enter a menu with a lot of items (e.g. mod options, map search, map list).

### Reason

The game calls `TextMenu.RecalculateSize()` and calculates all items' width and height every time an item is added or removed. It is unnecessary because this happened in one frame and the calculation is only needed after all operations are done.

### Solution

This patch adds a batch mode to the text menu. When it is enabled, recalculating menu size is skipped when adding and removing menu items, which can significantly increase performance when players enter a large menu.

If `Width` / `Height` / `LeftColumnWidth` / `RightColumnWidth` is accessed in batch mode, `TextMenu.RecalculateSize()` will be called to make sure the result is correct. If `TextMenu.RecalculateSize()` is called in batch mode, `recalculatingSizeInBatchMode` will be set to `true` to prevent infinite recursive calls.

The patch also optimizes `Emoji.Apply(string)` by using two pointers to iterate the string only once and replace the emojis, to also improve performance in large menus, since `TextMenu.RecalculateSize()` is called every time the menu renders. Although there aren't many mods that register emojis, CelesteNet used emojis to display avatars, so if someone has been online for hours, about 50 avatars can be registered as emojis, causing lags on menus.

### Result

Suppose that we have a text menu with `n` items, `a` is an array of length `n`, containing each item's text length, and there are `m` emojis registered. The time complexity before and after the patch is:

|        | Best                | Average             | Worst                 |
| ------ | ------------------- | ------------------- | --------------------- |
| Before | `O(n * m * sum(a))` | `O(n * m * sum(a))` | `O(n^2 * m * max(a))` |
| After  | `O(sum(a))`         | `O(sum(a))`         | `O(sum(a))`           |

Call count and time comparison when entering map list with 20 level sets and 400 maps installed, all maps' name is 20 characters long without emojis, and there are 30 emojis registered: (Note that call time is much longer than in real game due to the profiler)

Before:

![before](https://user-images.githubusercontent.com/7558201/121803887-1fffd800-cc76-11eb-8327-8260e2838a77.png)

After:

![after](https://user-images.githubusercontent.com/7558201/121803891-23935f00-cc76-11eb-8b0f-b5c7d79b4d2a.png)

`Emoji.Apply()` benchmark result before and after optimizing ([code](https://www.pastery.net/mgajdh/)):

```text
BenchmarkDotNet=v0.10.3.0, OS=Microsoft Windows NT 6.2.9200.0
Processor=Intel(R) Core(TM) i7-7700HQ CPU 2.80GHz, ProcessorCount=8
Frequency=2742190 Hz, Resolution=364.6720 ns, Timer=TSC
  [Host]     : Clr 4.0.30319.42000, 64bit RyuJIT-v4.8.4010.0
  DefaultJob : Clr 4.0.30319.42000, 64bit RyuJIT-v4.8.4010.0
```

| Method | Emoji Count | Emoji in Text |               Mean |          StdErr |          StdDev | Scaled |
| ------ | ----------: | ------------: | -----------------: | --------------: | --------------: | -----: |
| Before |          10 |            10 |      3,095.7799 ns |      24.8549 ns |      96.2625 ns |   1.00 |
| After  |          10 |            10 |        912.1202 ns |       9.0746 ns |      48.0184 ns |   0.29 |
| Before |          10 |           100 |     27,512.6470 ns |     225.4702 ns |     873.2423 ns |   1.00 |
| After  |          10 |           100 |      9,595.4766 ns |      88.8038 ns |     486.3986 ns |   0.35 |
| Before |          10 |          1000 |    261,457.5667 ns |   2,535.8593 ns |  11,340.7077 ns |   1.00 |
| After  |          10 |          1000 |     95,803.9844 ns |     772.2700 ns |   2,990.9888 ns |   0.37 |
| Before |         100 |            10 |     12,256.1060 ns |      87.8604 ns |     340.2819 ns |   1.00 |
| After  |         100 |            10 |        865.7724 ns |       8.3928 ns |      41.1159 ns |   0.07 |
| Before |         100 |           100 |    190,369.1403 ns |   1,087.8736 ns |   4,213.3164 ns |   1.00 |
| After  |         100 |           100 |      8,615.6526 ns |      82.9249 ns |     388.9523 ns |   0.05 |
| Before |         100 |          1000 |  2,671,179.0389 ns |  31,067.6264 ns | 194,017.2648 ns |   1.00 |
| After  |         100 |          1000 |     97,382.9423 ns |     808.6068 ns |   3,025.5296 ns |   0.04 |
| Before |        1000 |            10 |    105,540.6256 ns |   1,045.1672 ns |   5,628.3978 ns |   1.00 |
| After  |        1000 |            10 |        943.0521 ns |       9.2539 ns |      47.1859 ns |   0.01 |
| Before |        1000 |           100 |    534,928.4297 ns |   4,262.8933 ns |  16,510.1148 ns |   1.00 |
| After  |        1000 |           100 |      9,600.3199 ns |      64.1450 ns |     248.4326 ns |   0.02 |
| Before |        1000 |          1000 | 16,723,940.9119 ns | 161,419.3316 ns | 665,548.9541 ns |   1.00 |
| After  |        1000 |          1000 |     84,667.3785 ns |     827.3982 ns |   3,309.5929 ns |   0.01 |
