### PR TITLE
Don't catch OutOfMemoryException when loading maps

### DIFF
--- a/Celeste.Mod.mm/Patches/MapData.cs
+++ b/Celeste.Mod.mm/Patches/MapData.cs
@@ -96,6 +96,8 @@ namespace Celeste {
 
             } catch (Exception e) {
                 Mod.Logger.Log(LogLevel.Warn, "misc", $"Failed loading MapData {Area}");
+                if (e is OutOfMemoryException)
+                    throw e; // Unrecoverable
                 e.LogDetailed();
             }
         }

--- a/Celeste.Mod.mm/Patches/MapData.cs
+++ b/Celeste.Mod.mm/Patches/MapData.cs
@@ -94,10 +94,8 @@ namespace Celeste {
                     }
                 }
 
-            } catch (Exception e) {
+            } catch (Exception e) when (e is not OutOfMemoryException) { // OOM errors are currently unrecoverable
                 Mod.Logger.Log(LogLevel.Warn, "misc", $"Failed loading MapData {Area}");
-                if (e is OutOfMemoryException)
-                    throw e; // Unrecoverable
                 e.LogDetailed();
             }
         }


### PR DESCRIPTION
When loading maps all exceptions are caught, but if the game has run out of memory then it is in a presumably unrecoverable state. When this happens while loading maps it will continue to try/catch until all maps have been attempted as seen [here](https://cdn.discordapp.com/attachments/514006912115802113/854098111101141002/log.txt).
This patch throws any OOM exceptions encountered when loading maps.