### PR TITLE
Add simple support for EverestModuleSettings SubMenus

### DIFF
--- a/Celeste.Mod.mm/Mod/Module/EverestModuleSettings.cs
+++ b/Celeste.Mod.mm/Mod/Module/EverestModuleSettings.cs
@@ -115,4 +115,10 @@ namespace Celeste.Mod {
         public SettingIgnoreAttribute() {
         }
     }
+
+    /// <summary>
+    /// When used as a <see cref="EverestModuleSettings"/> property type, create a submenu based on this type.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    public class SettingSubMenuAttribute : Attribute { }
 }


### PR DESCRIPTION
Adds a simple way of implementing SubMenus in the ModOptions menu, using a `SettingSubMenu` attribute:
```cs
public class TestModuleSettings : EverestModuleSettings {
    public TestSubMenu1 SubMenu1 {get;set;}
    public TestSubMenu2 SubMenu2 {get;set;}

    [SettingSubMenu]
    public class TestSubMenu2 {
        public bool Boolean {get;set;}

        public int OtherOption {get; set;}
        public void CreateOtherOptionEntry(TextMenuExt.SubMenu menu, bool inGame) {
            menu.Add(new TextMenu.Slider(
                "Slider thing", 
                val => (val * 10).ToString(), 
                2, 12)
                .Change(val => OtherOption = val)
            );
        }
    }
}

[SettingSubMenu]
public class TestSubMenu1 {
    public string String {get;set;} = "testString";
}
```