### PR TITLE
Fix adding mod assets filter check

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Content.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Content.cs
@@ -527,7 +527,7 @@ namespace Celeste.Mod {
             public static bool TryAdd(string path, ModAsset metadata) {
                 path = path.Replace('\\', '/');
 
-                if (path.StartsWith(".git/") || path.StartsWith("__MACOSX/") ||
+                if (path.Contains("/.git/") || path.Contains("/__MACOSX/") ||
                     Path.GetFileName(path).StartsWith("._"))
                     return false;
 


### PR DESCRIPTION
The original check didn't return false if a file has `.git` and `__MACOSX` in the middle of the path, like `Graphics/Atlases/Gameplay/bgs/MyMod/__MACOSX/some/folder/._a_png` and `Code/MyCodeMod/.git/index`