### PR TITLE
Precompute LevelSetStats.MaxArea and AreaOffset instead of computing it on each usage

### DIFF
--- a/Celeste.Mod.mm/Patches/SaveData.cs
+++ b/Celeste.Mod.mm/Patches/SaveData.cs
@@ -7,6 +7,7 @@ using MonoMod;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Xml;
 using System.Xml.Serialization;
 
@@ -770,10 +771,18 @@ namespace Celeste {
         }
 
         [XmlIgnore]
-        public int AreaOffset { get; private set; }
+        public int AreaOffset {
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            get;
+            private set;
+        }
 
         [XmlIgnore]
-        public int MaxArea { get; private set; }
+        public int MaxArea {
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            get;
+            private set;
+        }
 
         internal void ComputeBounds() {
             AreaOffset = AreaData.Areas.FindIndex(area => area.GetLevelSet() == Name);

--- a/Celeste.Mod.mm/Patches/SaveData.cs
+++ b/Celeste.Mod.mm/Patches/SaveData.cs
@@ -373,6 +373,9 @@ namespace Celeste {
                 if (set.Name == "Celeste")
                     areas = Areas_Unsafe;
 
+                // compute the level set's AreaOffset and MaxArea.
+                set.ComputeBounds();
+
                 int offset = set.AreaOffset;
                 if (offset == -1) {
                     // LevelSet gone - let's move it to the recycle bin.
@@ -732,13 +735,6 @@ namespace Celeste {
         }
 
         [XmlIgnore]
-        public int AreaOffset {
-            get {
-                return AreaData.Areas.FindIndex(area => area.GetLevelSet() == Name);
-            }
-        }
-
-        [XmlIgnore]
         public int UnlockedModes {
             get {
                 int offset = AreaOffset;
@@ -774,13 +770,19 @@ namespace Celeste {
         }
 
         [XmlIgnore]
-        public int MaxArea {
-            get {
-                int count = AreaData.Areas.Count(area => area.GetLevelSet() == Name && string.IsNullOrEmpty(area.GetMeta()?.Parent)) - 1;
-                if (Celeste.PlayMode == Celeste.PlayModes.Event)
-                    return Math.Min(count, AreaOffset + 2);
-                return count;
-            }
+        public int AreaOffset { get; private set; }
+
+        [XmlIgnore]
+        public int MaxArea { get; private set; }
+
+        internal void ComputeBounds() {
+            AreaOffset = AreaData.Areas.FindIndex(area => area.GetLevelSet() == Name);
+
+            int count = AreaData.Areas.Count(area => area.GetLevelSet() == Name && string.IsNullOrEmpty(area.GetMeta()?.Parent)) - 1;
+            if (Celeste.PlayMode == Celeste.PlayModes.Event)
+                MaxArea = Math.Min(count, AreaOffset + 2);
+            else
+                MaxArea = count;
         }
 
         [XmlIgnore]


### PR DESCRIPTION
The goal of this change is to reduce the time it takes to the game to compute the total amount of cassettes the player has, which appeared to take a lot of time on each frame with a lot of mods installed (which I discovered while doing profiling sessions in a map for an unrelated issue). It is done on each frame due to the auto splitter info class.

I preferred doing that over caching cassette counts because this will help with other things, and the chapter list doesn't change (and when it does AfterInitialize is called anyway) contrary to cassette counts that can change if the player changes save files, activates cheat mode or ... collects a cassette.

**This affects AltSidesHelper** as it hooks get_MaxArea so make sure to let Luna know when it's merged.

------

Before this change:

![image](https://user-images.githubusercontent.com/52103563/124357198-8c894980-dc1a-11eb-9e04-f96e1a6483ba.png)

The game spent 30.3% of the time being idle, and 17.1% of the time computing cassette count

------

After this change:

![image](https://user-images.githubusercontent.com/52103563/124357250-d70ac600-dc1a-11eb-8bc8-ae5dcaf5c6c3.png)

The game spent 40.9% of the time being idle, and 3% of the time computing cassette count

