### PR TITLE
Make spinners shake properly with the solid they are attached to

### DIFF
--- a/Celeste.Mod.mm/Patches/CrystalStaticSpinner.cs
+++ b/Celeste.Mod.mm/Patches/CrystalStaticSpinner.cs
@@ -8,7 +8,10 @@ namespace Celeste {
     class patch_CrystalStaticSpinner : CrystalStaticSpinner {
 
         private CrystalColor color;
+
+#pragma warning disable CS0649 // this attribute is from vanilla, so it's defined in there
         private Entity filler;
+#pragma warning restore CS0649
 
         private int ID;
 

--- a/Celeste.Mod.mm/Patches/CrystalStaticSpinner.cs
+++ b/Celeste.Mod.mm/Patches/CrystalStaticSpinner.cs
@@ -8,6 +8,7 @@ namespace Celeste {
     class patch_CrystalStaticSpinner : CrystalStaticSpinner {
 
         private CrystalColor color;
+        private Entity filler;
 
         private int ID;
 
@@ -36,6 +37,25 @@ namespace Celeste {
             }
 
             orig_Awake(scene);
+        }
+
+        [MonoModReplace]
+        private void OnShake(Vector2 amount) {
+            foreach (Component component in Components) {
+                if (component is Image image) {
+                    // change from vanilla: instead of setting the position, add to it.
+                    image.Position += amount;
+                }
+            }
+
+            // addition from vanilla: also shake spinner connectors.
+            if (filler != null) {
+                foreach (Component component in filler.Components) {
+                    if (component is Image image) {
+                        image.Position += amount;
+                    }
+                }
+            }
         }
 
         [MonoModIgnore] // do not change anything in the method...

--- a/Celeste.Mod.mm/Patches/DustStaticSpinner.cs
+++ b/Celeste.Mod.mm/Patches/DustStaticSpinner.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.Xna.Framework;
+using MonoMod;
+
+namespace Celeste {
+    class patch_DustStaticSpinner : DustStaticSpinner {
+
+        public patch_DustStaticSpinner(Vector2 position, bool attachToSolid, bool ignoreSolids = false)
+            : base(position, attachToSolid, ignoreSolids) {
+            // no-op. MonoMod ignores this - we only need this to make the compiler shut up.
+        }
+
+        [MonoModReplace]
+        private void OnShake(Vector2 amount) {
+            // fix from vanilla: add to the position instead of replacing it (that's what expected from OnShake in static movers).
+            Sprite.Position += amount;
+        }
+    }
+}


### PR DESCRIPTION
The spinners' OnShake method move the spinners visually _to_ the position they're given, instead of _by_ the position they're given, like entities are expected to do (for example, spikes do that). This PR aims to fix that. The shake is purely visual, the hitbox does not move when the spinners shake.

Before:


https://user-images.githubusercontent.com/52103563/124366612-561af100-dc51-11eb-9083-4cf1f76952a6.mp4



After:

https://user-images.githubusercontent.com/52103563/124366556-f4f31d80-dc50-11eb-8569-58f3a2503633.mp4

