### PR TITLE
Disable cassette block's static movers if it's not collidable when awake

### DIFF
--- a/Celeste.Mod.mm/Patches/CassetteBlock.cs
+++ b/Celeste.Mod.mm/Patches/CassetteBlock.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
+using Monocle;
 using MonoMod;
 
 namespace Celeste {
@@ -19,5 +20,8 @@ namespace Celeste {
             ctor(data, offset, new EntityID(data.Level.Name, data.ID));
         }
 
+        [MonoModIgnore]
+        [PatchCassetteBlockAwake]
+        public override extern void Awake(Scene scene);
     }
 }


### PR DESCRIPTION
### Issue

- #334

*Note: This is a vanilla issue.*

### Reason

`CassetteBlockManager` is used to activate/deactivate cassette blocks in a room. But when the cassette is collected, it will not be added to the level (checked in `Level.ShouldCreateCassetteManager`), so `Platform.DisableStaticMovers()` is not called (from `CassetteBlockManager.SilentUpdateBlocks()`), thus spikes and springs (and all static movers attached to it) will stay enabled.

### Solution

The patch adds a check in `CassetteBlock.Awake(Scene)` and if it's not collidable, `Platform.DisableStaticMovers()` is called to disable all attachments.

The effective code after patch is:

```diff
 public override void Awake(Scene scene) {
     ...
     for (float num5 = base.Left; num5 < base.Right; num5 += 8f) {
         ...
     }
+    if (!Collidable) {
+        DisableStaticMovers();
+    }
     UpdateVisualState();
     ...
 }
```

### Result

https://user-images.githubusercontent.com/7558201/124392300-4a99f980-dd27-11eb-8f3e-556894a1016a.mp4

Spinners and dust sprites still stay enabled due to some checks (I guess it's because they check the distance to the player and change the collidability), since some other magic bugs happen if they are attached to a cassette block, I think it's better to fix/reimplement it in a helper.

---

*Closes #334.*
