### PR TITLE
Explicitly select Celeste.Mod.mm.dll when running MonoMod

### DIFF
--- a/MiniInstaller/MiniInstaller.csproj
+++ b/MiniInstaller/MiniInstaller.csproj
@@ -6,6 +6,7 @@
     <RootNamespace>MiniInstaller</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputType>Exe</OutputType>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MiniInstaller/Program.cs
+++ b/MiniInstaller/Program.cs
@@ -61,7 +61,7 @@ namespace MiniInstaller {
                     if (AsmMonoMod == null) {
                         LoadMonoMod();
                     }
-                    RunMonoMod(Path.Combine(PathOrig, "Celeste.exe"), PathEverestExe);
+                    RunMonoMod(Path.Combine(PathOrig, "Celeste.exe"), PathEverestExe, new string[] { Path.ChangeExtension(PathCelesteExe, ".Mod.mm.dll") });
                     RunHookGen(PathEverestExe, PathCelesteExe);
                     MakeLargeAddressAware(PathEverestExe);
                     CombineXMLDoc(Path.ChangeExtension(PathCelesteExe, ".Mod.mm.xml"), Path.ChangeExtension(PathCelesteExe, ".xml"));
@@ -224,13 +224,14 @@ namespace MiniInstaller {
             AsmHookGen = LazyLoadAssembly(Path.Combine(PathGame, "MonoMod.RuntimeDetour.HookGen.exe"));
         }
 
-        public static void RunMonoMod(string asmFrom, string asmTo = null) {
-            if (asmTo == null)
-                asmTo = asmFrom;
+        public static void RunMonoMod(string asmFrom, string asmTo = null, string[] dllPaths = null) {
+            asmTo ??= asmFrom;
+            dllPaths ??= new string[] { PathGame };
+
             LogLine($"Running MonoMod for {asmFrom}");
             // We're lazy.
             Environment.SetEnvironmentVariable("MONOMOD_DEPDIRS", PathGame);
-            Environment.SetEnvironmentVariable("MONOMOD_MODS", PathGame);
+            Environment.SetEnvironmentVariable("MONOMOD_MODS", string.Join(Path.PathSeparator.ToString(), dllPaths));
             Environment.SetEnvironmentVariable("MONOMOD_DEPENDENCY_MISSING_THROW", "0");
             AsmMonoMod.EntryPoint.Invoke(null, new object[] { new string[] { asmFrom, asmTo + ".tmp" } });
 


### PR DESCRIPTION
If someone doesn't have `Celeste.Mod.mm.dll` in the game folder for some reason and tries to run Mini Installer, the patching will succeed and outputs a file with `MonoMod.WasHere` in the assembly but without any patches. Since the modded game check is done in `Celeste.Mod.mm.dll`, running Mini Installer multiple times can cause the vanilla executable in `orig` folder being replaced and they need to re-download the game to install Everest properly.

![image](https://user-images.githubusercontent.com/7558201/124476940-031e7680-ddd6-11eb-8ce9-7f9ed75ce1ea.png)

This patch adds `Celeste.Mod.mm.dll` explicitly to `MONOMOD_MODS` environment variable so that MonoMod loads this file instead of scanning the whole directory, and an error will be thrown if the file doesn't exist.

`miniinstaller-log.txt` diff after patch:

```diff
 Running MonoMod for E:\SteamLibrary\steamapps\common\Celeste\orig\Celeste.exe
 MonoMod 21.4.29.1
 [MonoMod] Reading input file into module.
-[MonoMod] [ReadMod] Loading mod dir: E:\SteamLibrary\steamapps\common\Celeste
 [MonoMod] [ReadMod] Loading mod: E:\SteamLibrary\steamapps\common\Celeste\Celeste.Mod.mm.dll
 [MonoMod] [Main] Scanning for mods in directory.
 [MonoMod] [ReadMod] Loading mod dir: E:\SteamLibrary\steamapps\common\Celeste\orig
 [MonoMod] [Main] mm.AutoPatch();
 [MonoMod] [AutoPatch] Parsing rules in loaded mods
 [MonoMod] [RulesModder] [Write] Writing modded module into output stream.
 [MonoMod] [AutoPatch] PrePatch pass
 [MonoMod] [AutoPatch] Patch pass
 [MonoMod] [AutoPatch] PatchRefs pass
 [MonoMod] [PostProcessor] PostProcessor pass #1
 [MonoMod] [PostProcessor] PostProcessor pass #2
 [MonoMod] [Write] Writing modded module into output file.
 [MonoMod] [Main] Done.
```
