### PR TITLE
Inject build number Name during prebuild pipeline

### DIFF
--- a/azure-pipelines-prebuild.ps1
+++ b/azure-pipelines-prebuild.ps1
@@ -7,7 +7,7 @@ $EverestPath = [io.path]::combine('Celeste.Mod.mm', 'Mod', 'Everest', 'Everest.c
 $HelperPath = [io.path]::combine('Celeste.Mod.mm', 'Mod', 'Helpers', 'EverestVersion.cs')
 echo @"
 namespace Celeste.Mod.Helpers {
-    private static class EverestBuild$BuildNumber {
+    internal static class EverestBuild$BuildNumber {
         public static string EverestBuild = "EverestBuild$BuildNumber";
     }
 }

--- a/azure-pipelines-prebuild.ps1
+++ b/azure-pipelines-prebuild.ps1
@@ -5,10 +5,10 @@ $EverestPath = [io.path]::combine('Celeste.Mod.mm', 'Mod', 'Everest', 'Everest.c
 
 # Currently unstable/in development
 $HelperPath = [io.path]::combine('Celeste.Mod.mm', 'Mod', 'Helpers', 'EverestVersion.cs')
-echo @'
+echo @"
 namespace Celeste.Mod.Helpers {
     private static class EverestBuild$BuildNumber {
         public static string EverestBuild = "EverestBuild$BuildNumber";
     }
 }
-'@ | Set-Content $HelperPath
+"@ | Set-Content $HelperPath

--- a/azure-pipelines-prebuild.ps1
+++ b/azure-pipelines-prebuild.ps1
@@ -2,3 +2,13 @@
 $BuildNumber = [string]([int]$env:Build_BuildId + [int]$env:Build_BuildIdOffset)
 $EverestPath = [io.path]::combine('Celeste.Mod.mm', 'Mod', 'Everest', 'Everest.cs')
 (Get-Content $EverestPath) -replace '(?<=public readonly static string VersionString = ")[^"]*', "1.$BuildNumber.0-azure-$(($env:BUILD_SOURCEVERSION).Substring(0, 5))" | Set-Content $EverestPath
+
+# Currently unstable/in development
+$HelperPath = [io.path]::combine('Celeste.Mod.mm', 'Mod', 'Everest', 'Helpers', 'EverestVersion.cs')
+echo @'
+namespace Celeste.Mod.Helpers {
+    private static class EverestBuild$BuildNumber {
+        public static string EverestBuild = "EverestBuild$BuildNumber";
+    }
+}
+'@ | Set-Content $HelperPath

--- a/azure-pipelines-prebuild.ps1
+++ b/azure-pipelines-prebuild.ps1
@@ -4,7 +4,7 @@ $EverestPath = [io.path]::combine('Celeste.Mod.mm', 'Mod', 'Everest', 'Everest.c
 (Get-Content $EverestPath) -replace '(?<=public readonly static string VersionString = ")[^"]*', "1.$BuildNumber.0-azure-$(($env:BUILD_SOURCEVERSION).Substring(0, 5))" | Set-Content $EverestPath
 
 # Currently unstable/in development
-$HelperPath = [io.path]::combine('Celeste.Mod.mm', 'Mod', 'Everest', 'Helpers', 'EverestVersion.cs')
+$HelperPath = [io.path]::combine('Celeste.Mod.mm', 'Mod', 'Helpers', 'EverestVersion.cs')
 echo @'
 namespace Celeste.Mod.Helpers {
     private static class EverestBuild$BuildNumber {


### PR DESCRIPTION
Format is currently unstable
Adds `EverestBuild${BuildNumber}` name to the `#Strings` and `#US` streams