### PR TITLE
Fix game crash when restarting into vanilla in fullscreen in XNA

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/ContentExtensions.cs
+++ b/Celeste.Mod.mm/Mod/Everest/ContentExtensions.cs
@@ -26,7 +26,7 @@ namespace Celeste.Mod {
             ?.GetMethod("FNA3D_Image_Free")
             ?.CreateDelegate<d_FNA3D_Image_Free>();
 
-        public static readonly bool TextureSetDataSupportsPtr = typeof(Game).Assembly.FullName.Contains("FNA");
+        public static readonly bool TextureSetDataSupportsPtr = Everest.Flags.IsFNA;
 
         /// <summary>
         /// Determine if the MTexture depicts a region of a larger VirtualTexture.

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Flags.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Flags.cs
@@ -4,6 +4,15 @@ using System;
 namespace Celeste.Mod {
     public static partial class Everest {
         public static class Flags {
+            /// <summary>
+            /// Is the game running on XNA?
+            /// </summary>
+            public static bool IsXNA { get; private set; }
+
+            /// <summary>
+            /// Is the game running on FNA?
+            /// </summary>
+            public static bool IsFNA { get; private set; }
 
             /// <summary>
             /// Is Everest running headlessly?
@@ -57,6 +66,9 @@ namespace Celeste.Mod {
             public static bool SupportUpdatingEverest { get; private set; }
 
             internal static void Initialize() {
+                IsFNA = typeof(Game).Assembly.FullName.Contains("FNA");
+                IsXNA = !IsFNA;
+
                 IsHeadless = Environment.GetEnvironmentVariable("EVEREST_HEADLESS") == "1";
 
                 IsMono = Type.GetType("Mono.Runtime") != null;
@@ -70,7 +82,7 @@ namespace Celeste.Mod {
                 PreferLazyLoading = IsMobile;
 
                 // The way how FNA3D's D3D11 implementation handles threaded GL is hated by a few drivers.
-                PreferThreadedGL = !typeof(Game).Assembly.FullName.Contains("FNA");
+                PreferThreadedGL = IsXNA;
 
                 SupportRuntimeMods = true;
                 SupportRelinkingMods = !IsMobile; // FIXME: Mono.Cecil can't find GAC when using Xamarin.*

--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -899,12 +899,12 @@ namespace Celeste.Mod {
                 return;
             }
 
-            Scene scene = new Scene();
-            scene.HelperEntity.Add(new Coroutine(_QuickFullRestart(Engine.Scene is Overworld)));
+            BlackScreen scene = new BlackScreen();
+            scene.HelperEntity.Add(new Coroutine(_QuickFullRestart(Engine.Scene is Overworld, scene)));
             Engine.Scene = scene;
         }
 
-        private static IEnumerator _QuickFullRestart(bool fromOverworld) {
+        private static IEnumerator _QuickFullRestart(bool fromOverworld, BlackScreen scene) {
             SaveData save = SaveData.Instance;
             if (save != null && save.FileSlot == patch_SaveData.LoadedModSaveDataIndex) {
                 if (!fromOverworld) {
@@ -919,7 +919,12 @@ namespace Celeste.Mod {
             }
 
             AppDomain.CurrentDomain.SetData("EverestRestart", true);
-            Engine.Instance.Exit();
+            scene.RunAfterRender = () => {
+                if (Engine.Graphics.IsFullScreen) {
+                    Engine.SetWindowed(320 * (Settings.Instance?.WindowScale ?? 1), 180 * (Settings.Instance?.WindowScale ?? 1));
+                }
+                Engine.Instance.Exit();
+            };
             yield break;
         }
 

--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -65,7 +65,7 @@ namespace Celeste.Mod {
         /// <summary>
         /// The currently present Celeste version combined with the currently installed Everest build.
         /// </summary>
-        public static string VersionCelesteString => $"{Celeste.Instance.Version}-{(typeof(Game).Assembly.FullName.Contains("FNA") ? "fna" : "xna")} [Everest: {BuildString}]";
+        public static string VersionCelesteString => $"{Celeste.Instance.Version}-{(Flags.IsFNA ? "fna" : "xna")} [Everest: {BuildString}]";
 
         /// <summary>
         /// UTF8 text encoding without a byte order mark, to be preferred over Encoding.UTF8
@@ -430,7 +430,7 @@ namespace Celeste.Mod {
             // Note: Everest fulfills some mod dependencies by itself.
             new NullModule(new EverestModuleMetadata() {
                 Name = "Celeste",
-                VersionString = $"{Celeste.Instance.Version.ToString()}-{(typeof(Game).Assembly.FullName.Contains("FNA") ? "fna" : "xna")}"
+                VersionString = $"{Celeste.Instance.Version.ToString()}-{(Flags.IsFNA ? "fna" : "xna")}"
             }).Register();
             new NullModule(new EverestModuleMetadata() {
                 Name = "DialogCutscene",

--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -920,7 +920,7 @@ namespace Celeste.Mod {
 
             AppDomain.CurrentDomain.SetData("EverestRestart", true);
             scene.RunAfterRender = () => {
-                if (Engine.Graphics.IsFullScreen) {
+                if (Flags.IsXNA && Engine.Graphics.IsFullScreen) {
                     Engine.SetWindowed(320 * (Settings.Instance?.WindowScale ?? 1), 180 * (Settings.Instance?.WindowScale ?? 1));
                 }
                 Engine.Instance.Exit();

--- a/Celeste.Mod.mm/Patches/Celeste.cs
+++ b/Celeste.Mod.mm/Patches/Celeste.cs
@@ -33,7 +33,7 @@ namespace Celeste {
                 File.Delete("BuildIsXNA.txt");
             if (File.Exists("BuildIsFNA.txt"))
                 File.Delete("BuildIsFNA.txt");
-            File.WriteAllText($"BuildIs{(typeof(Game).Assembly.FullName.Contains("FNA") ? "FNA" : "XNA")}.txt", "");
+            File.WriteAllText($"BuildIs{(Everest.Flags.IsFNA ? "FNA" : "XNA")}.txt", "");
 
             // macOS is FUN.
             if (PlatformHelper.Is(MonoMod.Utils.Platform.MacOS)) {

--- a/Celeste.Mod.mm/Patches/OuiTitleScreen.cs
+++ b/Celeste.Mod.mm/Patches/OuiTitleScreen.cs
@@ -122,6 +122,9 @@ namespace Celeste {
                     Everest.RestartVanilla = true;
                     new FadeWipe(Scene, false, () => {
                         Engine.Scene = new Scene();
+                        if (Engine.Graphics.IsFullScreen) {
+                            Engine.SetWindowed(320 * Settings.Instance.WindowScale, 180 * Settings.Instance.WindowScale);
+                        }
                         Engine.Instance.Exit();
                     });
                 }

--- a/Celeste.Mod.mm/Patches/OuiTitleScreen.cs
+++ b/Celeste.Mod.mm/Patches/OuiTitleScreen.cs
@@ -122,7 +122,7 @@ namespace Celeste {
                     Everest.RestartVanilla = true;
                     new FadeWipe(Scene, false, () => {
                         Engine.Scene = new Scene();
-                        if (Engine.Graphics.IsFullScreen) {
+                        if (Everest.Flags.IsXNA && Engine.Graphics.IsFullScreen) {
                             Engine.SetWindowed(320 * Settings.Instance.WindowScale, 180 * Settings.Instance.WindowScale);
                         }
                         Engine.Instance.Exit();


### PR DESCRIPTION
### Issue

- #323

### Solution

Just simply make the game go to windowed mode before restarting to vanilla. Since it directly calls `Engine.SetWindowed`, the "fullscreen mode" in settings is unchanged.

---

*Closes #323.*