### PR TITLE
Attempt to fix InvalidOperationException when reloading maps

### DIFF
--- a/Celeste.Mod.mm/Patches/Monocle/VirtualContent.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/VirtualContent.cs
@@ -73,12 +73,14 @@ namespace Monocle {
         /// Unload all overworld-related content.
         /// </summary>
         public static void UnloadOverworld() {
-            foreach (VirtualAsset asset in assets) {
-                string path = asset.Name.Replace('\\', '/');
-                if (asset is VirtualTexture && path.StartsWith("Graphics/Atlases/")) {
-                    path = path.Substring(17);
-                    if (path.StartsWith("Opening") || path.StartsWith("Overworld") || path.StartsWith("Mountain") || path.StartsWith("Journal")) {
-                        asset.Unload();
+            lock (assets) {
+                foreach (VirtualAsset asset in assets) {
+                    string path = asset.Name.Replace('\\', '/');
+                    if (asset is VirtualTexture && path.StartsWith("Graphics/Atlases/")) {
+                        path = path.Substring(17);
+                        if (path.StartsWith("Opening") || path.StartsWith("Overworld") || path.StartsWith("Mountain") || path.StartsWith("Journal")) {
+                            asset.Unload();
+                        }
                     }
                 }
             }


### PR DESCRIPTION
- hopefully fixes #356 

I was unable to reproduce the crash so I just added a lock to `VirtualContent.assets` to hope that fixes it