### PR TITLE
Optimize TileGrid.RenderAt()

### DIFF
--- a/Celeste.Mod.mm/Patches/Monocle/TileGrid.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/TileGrid.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.Xna.Framework;
+
+namespace Monocle {
+    class patch_TileGrid : TileGrid {
+
+        public patch_TileGrid() : base(0, 0, 0, 0) {
+            // no-op. MonoMod ignores this - we only need this to make the compiler shut up.
+        }
+
+        // improve tile grid rendering performance
+        public new void RenderAt(Vector2 position) {
+            if (Alpha <= 0f) {
+                return;
+            }
+
+            Rectangle clippedRenderTiles = GetClippedRenderTiles();
+            int tileWidth = TileWidth;
+            int tileHeight = TileHeight;
+            Color color = Color * Alpha;
+            Vector2 renderPos = new Vector2(position.X + clippedRenderTiles.Left * tileWidth, position.Y + clippedRenderTiles.Top * tileHeight);
+
+            for (int i = clippedRenderTiles.Left; i < clippedRenderTiles.Right; i++) {
+                for (int j = clippedRenderTiles.Top; j < clippedRenderTiles.Bottom; j++) {
+                    MTexture mtexture = Tiles[i, j];
+                    if (mtexture != null) {
+                        Draw.SpriteBatch.Draw(mtexture.Texture.Texture, renderPos, mtexture.ClipRect, color);
+                    }
+                    renderPos.Y += tileHeight;
+                }
+                renderPos.X += tileWidth;
+                renderPos.Y = position.Y + clippedRenderTiles.Top * tileHeight;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Makes `TileGrid.RenderAt()` roughly 1.6x faster than the vanilla implementation.
Optimizations used:
* Use `Draw.SpriteBatch.Draw` directly instead of `MTexture.Draw`. This makes it possible to use a simpler overload of `SpriteBatch.Draw` that requires less calculations than the one used by `MTexture.Draw`.
* Use one `Vector2` to store render position, then increment its `X` and `Y` properties by 8, instead of multiplying `i` and `j` by 8 and creating a new `Vector2` for each tile.
