### PR TITLE
Optimize `DreamBlock.PutInside(Vector2)` and get rid of loops

### DIFF
--- a/Celeste.Mod.mm/Patches/DreamBlock.cs
+++ b/Celeste.Mod.mm/Patches/DreamBlock.cs
@@ -168,5 +168,22 @@ namespace Celeste {
                 yield return null;
             }
         }
+
+        [MonoModReplace]
+        private Vector2 PutInside(Vector2 pos) {
+            // vanilla used loops here to move the particle inside the dream block step by step,
+            // which can decrease the performance when the dream block is very far from (0, 0)
+            if (pos.X > Right) {
+                pos.X -= (float) Math.Ceiling((pos.X - Right) / Width) * Width;
+            } else if (pos.X < Left) {
+                pos.X += (float) Math.Ceiling((Left - pos.X) / Width) * Width;
+            }
+            if (pos.Y > Bottom) {
+                pos.Y -= (float) Math.Ceiling((pos.Y - Bottom) / Height) * Height;
+            } else if (pos.Y < Top) {
+                pos.Y += (float) Math.Ceiling((Top - pos.Y) / Height) * Height;
+            }
+            return pos;
+        }
     }
 }


### PR DESCRIPTION
### Issue

In vanilla, the method used loops to move the particle inside the dream block step by step. When the dream block is very far from `(0, 0)` (usually in some hidden easter egg rooms, although there're not many now but who knows), this can cause lags, because the method is called when rendering a particle each frame.

### Solution

This patch replaces the loops to direct calculations, it reduces the time complexity of moving a single particle on each frame from `O(x / w + y / h)` to `O(1)`.
