### PR TITLE
Add ButtonBinding options for Debug Console and MountainRenderer keys

### DIFF
--- a/Celeste.Mod.mm/Mod/Core/CoreModuleSettings.cs
+++ b/Celeste.Mod.mm/Mod/Core/CoreModuleSettings.cs
@@ -1,4 +1,5 @@
-﻿using Monocle;
+﻿using Microsoft.Xna.Framework.Input;
+using Monocle;
 using MonoMod;
 using System;
 using System.Collections.Generic;
@@ -298,6 +299,46 @@ namespace Celeste.Mod.Core {
 
         [SettingInGame(false)]
         public ButtonBinding MenuPageDown { get; set; }
+
+        [SettingInGame(false)]
+        [DefaultButtonBinding(0, Keys.OemPeriod)]
+        public ButtonBinding DebugConsole { get; set; }
+
+        [SettingInGame(false)]
+        [DefaultButtonBinding(0, Keys.W)]
+        public ButtonBinding CameraForward { get; set; }
+
+        [SettingInGame(false)]
+        [DefaultButtonBinding(0, Keys.S)]
+        public ButtonBinding CameraBackward { get; set; }
+
+        [SettingInGame(false)]
+        [DefaultButtonBinding(0, Keys.D)]
+        public ButtonBinding CameraRight { get; set; }
+
+        [SettingInGame(false)]
+        [DefaultButtonBinding(0, Keys.A)]
+        public ButtonBinding CameraLeft { get; set; }
+
+        [SettingInGame(false)]
+        [DefaultButtonBinding(0, Keys.Q)]
+        public ButtonBinding CameraUp { get; set; }
+
+        [SettingInGame(false)]
+        [DefaultButtonBinding(0, Keys.Z)]
+        public ButtonBinding CameraDown { get; set; }
+
+        [SettingInGame(false)]
+        [DefaultButtonBinding(0, Keys.LeftShift)]
+        public ButtonBinding CameraSlow { get; set; }
+
+        [SettingInGame(false)]
+        [DefaultButtonBinding(0, Keys.P)]
+        public ButtonBinding CameraPrint { get; set; }
+
+        [SettingInGame(false)]
+        [DefaultButtonBinding(0, Keys.Space)]
+        public ButtonBinding ToggleMountainFreeCam { get; set; }
 
         /*
         [SettingRange(0, 10)]

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
@@ -91,7 +91,10 @@ namespace Celeste.Mod {
                 { "BGswitch", new Version(0, 1, 0, 0) },
 
                 // Infinite Saves 1.0.0 does not work well with the "extra save slots" feature of Everest
-                { "InfiniteSaves", new Version(1, 0, 1) }
+                { "InfiniteSaves", new Version(1, 0, 1) },
+                // Both deprecated by integration into Everest
+                { "DebugRebind", new Version(1, 0, 1) },
+                { "RebindPeriod", new Version(1, 0, 1) },
             };
 
             /// <summary>

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
@@ -89,12 +89,6 @@ namespace Celeste.Mod {
                 { "testroom", new Version(1, 0, 1, 0) },
                 { "Elemental Chaos", new Version(1, 0, 0, 0) },
                 { "BGswitch", new Version(0, 1, 0, 0) },
-
-                // Infinite Saves 1.0.0 does not work well with the "extra save slots" feature of Everest
-                { "InfiniteSaves", new Version(1, 0, 1) },
-                // Both deprecated by integration into Everest
-                { "DebugRebind", new Version(1, 0, 1) },
-                { "RebindPeriod", new Version(1, 0, 1) },
             };
 
             /// <summary>

--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -436,6 +436,18 @@ namespace Celeste.Mod {
                 Name = "UpdateChecker",
                 VersionString = "1.0.2"
             }).Register();
+            new NullModule(new EverestModuleMetadata() {
+                Name = "InfiniteSaves",
+                VersionString = "1.0.0"
+            }).Register();
+            new NullModule(new EverestModuleMetadata() {
+                Name = "DebugRebind",
+                VersionString = "1.0.0"
+            }).Register();
+            new NullModule(new EverestModuleMetadata() {
+                Name = "RebindPeriod",
+                VersionString = "1.0.0"
+            }).Register();
 
             LuaLoader.Initialize();
 

--- a/Celeste.Mod.mm/MonoModRules.cs
+++ b/Celeste.Mod.mm/MonoModRules.cs
@@ -388,6 +388,12 @@ namespace MonoMod {
     [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchCassetteBlockAwake))]
     class PatchCassetteBlockAwakeAttribute : Attribute { }
 
+    /// <summary>
+    /// Replaces hard-coded key checks with Everest CoreModule ButtonBinding checks
+    /// </summary>
+    [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchMountainRendererUpdate))]
+    class PatchMountainRendererUpdate : Attribute { }
+
     static class MonoModRules {
 
         static bool IsCeleste;
@@ -2179,6 +2185,68 @@ namespace MonoMod {
             cursor.Emit(OpCodes.Brtrue, target);
             cursor.Emit(OpCodes.Ldarg_0);
             cursor.Emit(OpCodes.Call, m_Platform_DisableStaticMovers);
+        }
+
+        public static void PatchMountainRendererUpdate(ILContext context, CustomAttribute attrib) {
+            ILCursor cursor = new ILCursor(context);
+
+            MethodReference m_Everest_CoreModule_Settings = MonoModRule.Modder.Module.GetType("Celeste.Mod.Core.CoreModule").FindProperty("Settings").GetMethod;
+            TypeDefinition t_Everest_CoreModuleSettings = MonoModRule.Modder.Module.GetType("Celeste.Mod.Core.CoreModuleSettings");
+
+            MethodReference m_ButtonBinding_Check = MonoModRule.Modder.Module.GetType("Celeste.Mod.ButtonBinding").FindProperty("Check").GetMethod;
+            MethodReference m_ButtonBinding_Pressed = MonoModRule.Modder.Module.GetType("Celeste.Mod.ButtonBinding").FindProperty("Pressed").GetMethod;
+
+            var checkKeys = new Dictionary<int, string>() {
+                { 87 /* Keys.W */, "CameraForward" },
+                { 83 /* Keys.S */, "CameraBackward" },
+                { 68 /* Keys.D */, "CameraRight" },
+                { 65 /* Keys.A */, "CameraLeft" },
+                { 81 /* Keys.Q */, "CameraUp" },
+                { 90 /* Keys.Z */, "CameraDown" },
+                { 160 /* Keys.LeftShift */, "CameraSlow" },
+            };
+
+            int key = 0;
+            while (cursor.TryGotoNext(MoveType.AfterLabel,
+                instr => instr.MatchCall("Monocle.MInput", "get_Keyboard"),
+                instr => instr.MatchLdcI4(out key),
+                instr => instr.MatchCallvirt("Monocle.MInput/KeyboardData", "Check"))) {
+
+                cursor.Emit(OpCodes.Call, m_Everest_CoreModule_Settings);
+                cursor.Emit(OpCodes.Call, t_Everest_CoreModuleSettings.FindProperty(checkKeys[key]).GetMethod);
+                cursor.Emit(OpCodes.Call, m_ButtonBinding_Check);
+
+                cursor.RemoveRange(3);
+                checkKeys.Remove(key);
+            }
+            if (checkKeys.Count > 0)
+                throw new Exception("MountainRenderer failed to patch key checks for keys: " + checkKeys.Keys);
+
+            var pressedKeys = new Dictionary<int, string>() {
+                { 80 /* Keys.P */, "CameraPrint" },
+                //{ 113 /* Keys.F2 */, "ReloadOverworld" },
+                { 0x20 /* Keys.Space */, "ToggleMountainFreeCam" },
+                //{ 112 /* Keys.F1 */, "ReloadMountainViews" },
+            };
+
+            while (cursor.TryGotoNext(MoveType.AfterLabel,
+                instr => instr.MatchCall("Monocle.MInput", "get_Keyboard"),
+                instr => instr.MatchLdcI4(out key),
+                instr => instr.MatchCallvirt("Monocle.MInput/KeyboardData", "Pressed"))) {
+
+                // Only some pressed keys are currently handled
+                if (!pressedKeys.ContainsKey(key))
+                    continue;
+
+                cursor.Emit(OpCodes.Call, m_Everest_CoreModule_Settings);
+                cursor.Emit(OpCodes.Call, t_Everest_CoreModuleSettings.FindProperty(pressedKeys[key]).GetMethod);
+                cursor.Emit(OpCodes.Call, m_ButtonBinding_Pressed);
+
+                cursor.RemoveRange(3);
+                pressedKeys.Remove(key);
+            }
+            if (pressedKeys.Count > 0)
+                throw new Exception("MountainRenderer failed to patch key presses for keys: " + pressedKeys.Keys);
         }
 
         public static void PostProcessor(MonoModder modder) {

--- a/Celeste.Mod.mm/Patches/KeyboardConfigUI.cs
+++ b/Celeste.Mod.mm/Patches/KeyboardConfigUI.cs
@@ -2,6 +2,7 @@
 #pragma warning disable CS0414 // The field is assigned to, but never used
 #pragma warning disable CS0108 // Member hides inherited member; missing new keyword
 
+using Celeste.Mod.Core;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
 using Monocle;
@@ -197,8 +198,13 @@ namespace Celeste {
         public extern void Clear(Binding binding);
 
         [MonoModIgnore]
+        public extern void orig_AddRemap(Keys key);
         [MakeMethodPublic]
-        public extern void AddRemap(Keys key);
+        public void AddRemap(Keys key) {
+            orig_AddRemap(key);
+            CoreModule.Settings.DebugConsole.ConsumePress();
+            CoreModule.Settings.ToggleMountainFreeCam.ConsumePress();
+        }
 
         #region Legacy Input
 

--- a/Celeste.Mod.mm/Patches/Monocle/Commands.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Commands.cs
@@ -47,7 +47,7 @@ namespace Monocle {
             if (!canOpen) {
                 canOpen = true;
             // Original code only checks OemTillde and Oem8, leaving QWERTZ users in the dark...
-            } else if (MInput.Keyboard.Pressed(Keys.OemTilde, Keys.Oem8, Keys.OemPeriod)) {
+            } else if (MInput.Keyboard.Pressed(Keys.OemTilde, Keys.Oem8) || CoreModule.Settings.DebugConsole.Pressed) {
                 Open = true;
                 currentState = Keyboard.GetState();
                 if (!installedListener) {

--- a/Celeste.Mod.mm/Patches/MountainRenderer.cs
+++ b/Celeste.Mod.mm/Patches/MountainRenderer.cs
@@ -17,6 +17,7 @@ namespace Celeste {
             return EaseCamera(area, transform, duration, nearTarget, false);
         }
 
+        [PatchMountainRendererUpdate]
         public extern void orig_Update(Scene scene);
         public override void Update(Scene scene) {
             AreaData area = -1 < Area && Area < (AreaData.Areas?.Count ?? 0) ? AreaData.Get(Area) : null;


### PR DESCRIPTION
Replaces hardcoded `MInput.Keys.{Check/Pressed}` calls with the appropriate CoreModuleSettings ButtonBinding checks.

Deprecates (and blacklists) the following mods:
- [Rebind Period](https://gamebanana.com/mods/306503)
- [Debug Rebind](https://gamebanana.com/mods/314866)

Possible improvements:
- Key presses are not consumed when rebinding, which causes the debug console to open/mountain cam to toggle while rebinding those keys
- Vanilla debug keys (`OemTilde` and `Oem8`) could be removed entirely in favour of Everest binding
- Function keys for reloading (vanilla and Everest) could also be made rebindable