### PR TITLE
Support removing specified key/button (again)

### DIFF
--- a/Celeste.Mod.mm/Patches/ButtonConfigUI.cs
+++ b/Celeste.Mod.mm/Patches/ButtonConfigUI.cs
@@ -28,6 +28,7 @@ namespace Celeste {
         private bool resetHeld;
         private float resetTime;
         private float resetDelay;
+        private float inputDelay;
 
         public extern void orig_ctor();
         [MonoModConstructor]
@@ -205,9 +206,21 @@ namespace Celeste {
         [MonoModLinkFrom("System.Void Celeste.ButtonConfigUI::ClearRemap(Monocle.Binding)")]
         public extern void Clear(Binding binding);
 
-        [MonoModIgnore]
-        [MakeMethodPublic]
-        public extern void AddRemap(Buttons btn);
+        [MonoModReplace]
+        public void AddRemap(Buttons btn) {
+            remapping = false;
+            inputDelay = 0.25f;
+            bool valid = remappingBinding.Controller.Contains(btn)
+                ? ((patch_Binding) remappingBinding).Remove(btn)
+                : remappingBinding.Add(btn);
+            if (!valid) {
+                Audio.Play("event:/ui/main/button_invalid");
+            }
+            while (remappingBinding.Controller.Count > Input.MaxBindings) {
+                remappingBinding.Controller.RemoveAt(0);
+            }
+            Input.Initialize();
+        }
 
         #region Legacy Input
 

--- a/Celeste.Mod.mm/Patches/KeyboardConfigUI.cs
+++ b/Celeste.Mod.mm/Patches/KeyboardConfigUI.cs
@@ -26,6 +26,7 @@ namespace Celeste {
         private bool resetHeld;
 		private float resetTime;
 		private float resetDelay;
+        private float inputDelay;
 
 #pragma warning disable CS0626 // method is external and has no attribute
         public extern void orig_ctor();
@@ -197,11 +198,20 @@ namespace Celeste {
         [MonoModLinkFrom("System.Void Celeste.KeyboardConfigUI::ClearRemap(Monocle.Binding)")]
         public extern void Clear(Binding binding);
 
-        [MonoModIgnore]
-        public extern void orig_AddRemap(Keys key);
-        [MakeMethodPublic]
+        [MonoModReplace]
         public void AddRemap(Keys key) {
-            orig_AddRemap(key);
+            remapping = false;
+            inputDelay = 0.25f;
+            bool valid = remappingBinding.Keyboard.Contains(key)
+                ? ((patch_Binding) remappingBinding).Remove(key)
+                : remappingBinding.Add(key);
+            if (!valid) {
+                Audio.Play("event:/ui/main/button_invalid");
+            }
+            while (remappingBinding.Keyboard.Count > Input.MaxBindings) {
+                remappingBinding.Keyboard.RemoveAt(0);
+            }
+            Input.Initialize();
             CoreModule.Settings.DebugConsole.ConsumePress();
             CoreModule.Settings.ToggleMountainFreeCam.ConsumePress();
         }

--- a/Celeste.Mod.mm/Patches/Monocle/Binding.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Binding.cs
@@ -1,0 +1,53 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Xna.Framework.Input;
+
+namespace Monocle {
+    class patch_Binding : Binding {
+
+        public bool Remove(params Keys[] keys) {
+            // use a stupid way: pretend the keys are removed and check if the rest are still valid
+            List<Keys> before = new List<Keys>(Keyboard);
+            List<Keys> after = Keyboard.Where(key => !keys.Contains(key)).ToList();
+            if (after.Count == 0 && ExclusiveFrom.Count > 0) {
+                return false;
+            }
+
+            // assign to field is necessary because it's accessed when cross references exist
+            Keyboard = after;
+            bool result = true;
+            foreach (Keys key in after) {
+                if (ExclusiveFrom.Any(b => b.Needs(key))) {
+                    result = false;
+                    break;
+                }
+            }
+            Keyboard = result ? after : before;
+
+            return result;
+        }
+
+        public bool Remove(params Buttons[] buttons) {
+            // use a stupid way: pretend the buttons are removed and check if the rest are still valid
+            List<Buttons> before = new List<Buttons>(Controller);
+            List<Buttons> after = Controller.Where(button => !buttons.Contains(button)).ToList();
+            if (after.Count == 0 && ExclusiveFrom.Count > 0) {
+                return false;
+            }
+
+            // assign to field is necessary because it's accessed when cross references exist
+            Controller = after;
+            bool result = true;
+            foreach (Buttons button in after) {
+                if (ExclusiveFrom.Any(b => b.Needs(button))) {
+                    result = false;
+                    break;
+                }
+            }
+            Controller = result ? after : before;
+
+            return result;
+        }
+
+    }
+}


### PR DESCRIPTION
### Issue

#265 added this feature but it got removed when we migrate to the new input system. Although the new system allows us to have multiple keys and also removing them, it currently removes all keys so it's pretty annoying if we only want to remove one.

### Solution

The implementation is pretty stupid because I can't fully understand the exclusive binding thing, so I just pretend the keys are removed and check if the rest are still valid. Currently, there is no UI text about this feature since I can't think of a better way without modifying vanilla dialog. (`PRESS | TO ADD A BUTTON` -> `PRESS | TO ADD OR REMOVE A BUTTON`)