### PR TITLE
Mark patching failed if MonoMod returns a non-zero code

### DIFF
--- a/MiniInstaller/Program.cs
+++ b/MiniInstaller/Program.cs
@@ -279,7 +279,10 @@ namespace MiniInstaller {
             Environment.SetEnvironmentVariable("MONOMOD_DEPDIRS", PathGame);
             Environment.SetEnvironmentVariable("MONOMOD_MODS", string.Join(Path.PathSeparator.ToString(), dllPaths));
             Environment.SetEnvironmentVariable("MONOMOD_DEPENDENCY_MISSING_THROW", "0");
-            AsmMonoMod.EntryPoint.Invoke(null, new object[] { new string[] { asmFrom, asmTo + ".tmp" } });
+            int returnCode = (int) AsmMonoMod.EntryPoint.Invoke(null, new object[] { new string[] { asmFrom, asmTo + ".tmp" } });
+
+            if (returnCode != 0 && File.Exists(asmTo + ".tmp"))
+                File.Delete(asmTo + ".tmp");
 
             if (!File.Exists(asmTo + ".tmp"))
                 throw new Exception("MonoMod failed creating a patched assembly!");


### PR DESCRIPTION
### Issue

If something wrong happened when patching the game but `Celeste.exe.tmp` is created, MiniInstaller will think the patch succeeded and continue to generate hooks, this can cause `Celeste.exe` became corrupted unless reinstalling or manually restore the backup from `orig` folder.

This can happen if MonoMod failed writing modded module to the output file.

```
[MonoMod] [Write] Writing modded module into output file.
System.ArgumentException: Member 'System.Void System.Runtime.CompilerServices.IteratorStateMachineAttribute::.ctor(System.Type)' is declared in another module and needs to be imported
   at Mono.Cecil.MetadataBuilder.LookupToken(IMetadataTokenProvider provider)
   at Mono.Cecil.MetadataBuilder.AddCustomAttributes(ICustomAttributeProvider owner)
   at Mono.Cecil.MetadataBuilder.AddMethod(MethodDefinition method)
   at Mono.Cecil.MetadataBuilder.AddMethods(TypeDefinition type)
   at Mono.Cecil.MetadataBuilder.AddType(TypeDefinition type)
   at Mono.Cecil.MetadataBuilder.AddTypes()
   at Mono.Cecil.MetadataBuilder.BuildTypes()
   at Mono.Cecil.MetadataBuilder.BuildModule()
   at Mono.Cecil.MetadataBuilder.BuildMetadata()
   at Mono.Cecil.ModuleWriter.<>c.<BuildMetadata>b__2_0(MetadataBuilder builder, MetadataReader _)
   at Mono.Cecil.ModuleDefinition.Read[TItem,TRet](TItem item, Func`3 read)
   at Mono.Cecil.ModuleWriter.Write(ModuleDefinition module, Disposable`1 stream, WriterParameters parameters)
   at Mono.Cecil.ModuleWriter.WriteModule(ModuleDefinition module, Disposable`1 stream, WriterParameters parameters)
   at Mono.Cecil.ModuleDefinition.Write(String fileName, WriterParameters parameters)
   at MonoMod.Program.Main(String[] args)

Running MonoMod.RuntimeDetour.HookGen for E:\SteamLibrary\steamapps\common\Celeste\Celeste.exe
MonoMod.RuntimeDetour.HookGen 21.7.22.3
using MonoMod 21.7.22.3
using MonoMod.RuntimeDetour 21.7.22.3
[MonoMod] Reading input file into module.

System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.BadImageFormatException: Format of the executable (.exe) or library (.dll) is invalid.
   at Mono.Cecil.PE.ImageReader.ReadImage()
   at Mono.Cecil.PE.ImageReader.ReadImage(Disposable`1 stream, String file_name)
   at Mono.Cecil.ModuleDefinition.ReadModule(String fileName, ReaderParameters parameters)
   at MonoMod.MonoModder.Read()
   at MonoMod.RuntimeDetour.HookGen.Program.Main(String[] args)
   --- End of inner exception stack trace ---
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor)
   at System.Reflection.RuntimeMethodInfo.UnsafeInvokeInternal(Object obj, Object[] parameters, Object[] arguments)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at MiniInstaller.Program.RunHookGen(String asm, String target)
   at MiniInstaller.Program.Main(String[] args)

Installing Everest failed.
```

### Solution

The patch simply adds a MonoMod return code check, if it returns a non-zero value, delete `Celeste.exe.tmp` so the `MonoMod failed creating a patched assembly!` exception will be thrown before overwriting `Celeste.exe` with the invalid file.
