### PR TITLE
Patch DeathEffect.Update to fix Percent check

### DIFF
--- a/Celeste.Mod.mm/MonoModRules.cs
+++ b/Celeste.Mod.mm/MonoModRules.cs
@@ -394,6 +394,9 @@ namespace MonoMod {
     [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchMountainRendererUpdate))]
     class PatchMountainRendererUpdate : Attribute { }
 
+    [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchDeathEffectUpdate))]
+    class PatchDeathEffectUpdateAttribute : Attribute { }
+
     static class MonoModRules {
 
         static bool IsCeleste;
@@ -2247,6 +2250,12 @@ namespace MonoMod {
             }
             if (pressedKeys.Count > 0)
                 throw new Exception("MountainRenderer failed to patch key presses for keys: " + pressedKeys.Keys);
+        }
+
+        public static void PatchDeathEffectUpdate(ILContext context, CustomAttribute attrib) {
+            ILCursor cursor = new ILCursor(context);
+            cursor.GotoNext(instr => instr.OpCode == OpCodes.Ble_Un_S);
+            cursor.Next.OpCode = OpCodes.Blt_Un_S;
         }
 
         public static void PostProcessor(MonoModder modder) {

--- a/Celeste.Mod.mm/Patches/DeathEffect.cs
+++ b/Celeste.Mod.mm/Patches/DeathEffect.cs
@@ -1,0 +1,20 @@
+using Microsoft.Xna.Framework;
+using MonoMod;
+
+namespace Celeste {
+    class patch_DeathEffect : DeathEffect {
+
+        public patch_DeathEffect(Color color, Vector2 offset)
+            : base(color, offset) { }
+
+        [MonoModIgnore]
+        [PatchDeathEffectUpdate]
+        public override extern void Update();
+
+        [MonoModReplace]
+        public override void Render() {
+            if (Entity != null)
+                Draw(Entity.Position + Position, Color, Percent);
+        }
+    }
+}


### PR DESCRIPTION
Original code, `Percent` will never actually be greater than 1f:
```cs
if (Percent > 1f)
...
Percent = Calc.Approach(Percent, 1f, Engine.DeltaTime / Duration);
```

Patched code:
```cs
if (Percent >= 1f)
```

Originally added in 7df0542f0676bec58c83dda69c9abd715e2780bd, reverted in 7279867a6cf6d405cdf5732f8553073cd7ce8021 because of a NRE involving `PlayerDeadBody.Render` calling `deathEffect.Render` after the `DeathEffect` had removed itself.

This is fixed by adding a null check to `DeathEffect.Render`. Other fixes are possible, but likely more invasive.