### PR TITLE
Use string.ToLower to match decals from Game Atlas with special character decal registry paths

### DIFF
--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistry.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistry.cs
@@ -247,7 +247,7 @@ namespace Celeste.Mod {
                         GFX.Game.GetTextures().Keys
                         .GroupBy(
                             s => s.StartsWith("decals/") ?
-                                s.Substring(7).TrimEnd('0','1','2','3','4','5','6','7','8','9') :
+                                s.Substring(7).TrimEnd('0','1','2','3','4','5','6','7','8','9').ToLower() :
                                 null,
                             (s, matches) => s
                         )


### PR DESCRIPTION
Decal paths are put to lowercase when tested against decal registry paths, something that was not done for the case in which the path had a wildcard character, so decals in, for example, a decal in a folder containing uppercase letters wouldn't be matched. This fixes the issue.