### PR TITLE
Hide C-Side/Golden postcard if LevelSet has no C-Sides

### DIFF
--- a/Celeste.Mod.mm/Patches/LevelSetStats.cs
+++ b/Celeste.Mod.mm/Patches/LevelSetStats.cs
@@ -1,0 +1,22 @@
+namespace Celeste {
+    class patch_LevelSetStats : LevelSetStats {
+        public int MaxAreaMode { 
+            get {
+                if (Name == "Celeste") {
+                    return (int) AreaMode.CSide;
+                }
+                int areaOffset = AreaOffset;
+                int maxAreaMode = 0;
+                for (int i = 0; i <= MaxArea; i++) {
+                    ModeProperties[] mode = AreaData.Areas[areaOffset + i].Mode;
+                    foreach (ModeProperties modeProperties in mode) {
+                        if ((int) modeProperties.MapData.Area.Mode > maxAreaMode) {
+                            maxAreaMode = (int) modeProperties.MapData.Area.Mode;
+                        }
+                    }
+                }
+                return maxAreaMode;
+            }
+        }
+    }
+}

--- a/Celeste.Mod.mm/Patches/OverworldLoader.cs
+++ b/Celeste.Mod.mm/Patches/OverworldLoader.cs
@@ -18,7 +18,7 @@ namespace Celeste {
         private extern void CheckVariantsPostcardAtLaunch();
 
         [MonoModIgnore] // don't change anything in the method...
-        [PatchTotalHeartGemChecksInRoutine] // except for replacing TotalHeartGems with TotalHeartGemsInVanilla through MonoModRules
+        [PatchTotalHeartGemCSidePostcard] // except for replacing TotalHeartGems with TotalHeartGemsInVanilla through MonoModRules
         private extern IEnumerator Routine(Session session);
     }
 }


### PR DESCRIPTION
- Fixes #357 

Relatively simple hack to only show the C-Side Unlock Postcard if the level set has a C-Side.

Adds a public `LevelSetStats.MaxAreaMode` property that returns an `int` representation of the highest available `AreaMode` for the current level set.
Returning an `int` makes for a slightly simpler IL patch, and hopefully promotes compatibility with some future integration of the [AltSidesHelper](https://github.com/l-Luna/AltSidesHelper) mod into Everest. This can easily be changed to return an `AreaMode` if desired.