### PR TITLE
Restructure pipeline to include patch verification

### DIFF
--- a/azure-pipelines-postbuild.ps1
+++ b/azure-pipelines-postbuild.ps1
@@ -23,6 +23,7 @@ Compress-Archive @compress
 
 Write-Output "Building Olympus metadata artifact"
 Write-Output (Get-Item -Path $ZIP).length | Out-File -FilePath $OLYMPUS/meta/size.txt
+Write-Host "##vso[task.setvariable variable=olympus]True"
 
 # lib-stripped setup
 if ([string]::IsNullOrEmpty("$env:BIN_URL") -or ($env:BIN_URL -eq '$(BIN_URL)')) {
@@ -40,15 +41,8 @@ Remove-Item -ErrorAction Ignore -Recurse -Force -Path $LIB_STRIPPED
 New-Item -ItemType "directory" -Path $LIB_STRIPPED
 New-Item -ItemType "directory" -Path $LIB_STRIPPED/build
 
-Write-Output "Downloading Celeste package"
-$creds = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes("$($env:BIN_USERNAME):$($env:BIN_PASSWORD)"))
-$headers = @{'Authorization'= "Basic $creds"}
-Invoke-WebRequest -URI "$env:BIN_URL/Celeste_Linux.zip" -OutFile "$env:AGENT_TEMPDIRECTORY/Celeste.zip" -Headers $headers
-Expand-Archive -Path "$env:AGENT_TEMPDIRECTORY/Celeste.zip" -DestinationPath $LIB_STRIPPED
-
-Write-Output "Applying Everest patch"
-Copy-Item -Path "$env:BUILD_ARTIFACTSTAGINGDIRECTORY/main/*" -Destination $LIB_STRIPPED
-Start-Process -FilePath "mono" -ArgumentList "$LIB_STRIPPED/MiniInstaller.exe" -WorkingDirectory $LIB_STRIPPED -Wait
+Write-Output "Copying patched files"
+Copy-Item -Path "$env:BUILD_ARTIFACTSTAGINGDIRECTORY/patch/*" -Destination $LIB_STRIPPED
 
 Write-Output "Generating stripped files"
 $files = Get-ChildItem -Path "$LIB_STRIPPED/*" -Include *.dll,*.exe

--- a/azure-pipelines-verify.ps1
+++ b/azure-pipelines-verify.ps1
@@ -1,0 +1,25 @@
+# Patch verification
+if ([string]::IsNullOrEmpty("$env:BIN_URL") -or ($env:BIN_URL -eq '$(BIN_URL)')) {
+	Write-Output "Skipping patch verification"
+	Exit 0
+}
+
+$PATCH="$env:BUILD_ARTIFACTSTAGINGDIRECTORY/patch"
+if ($PATCH -eq "/patch") {
+	$PATCH = "./tmp-patch"
+}
+
+Write-Output "Creating patch directories"
+Remove-Item -ErrorAction Ignore -Recurse -Force -Path $PATCH
+New-Item -ItemType "directory" -Path $PATCH
+New-Item -ItemType "directory" -Path $PATCH/build
+
+Write-Output "Downloading Celeste package"
+$creds = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes("$($env:BIN_USERNAME):$($env:BIN_PASSWORD)"))
+$headers = @{'Authorization'= "Basic $creds"}
+Invoke-WebRequest -URI "$env:BIN_URL/Celeste_Linux.zip" -OutFile "$env:AGENT_TEMPDIRECTORY/Celeste.zip" -Headers $headers
+Expand-Archive -Path "$env:AGENT_TEMPDIRECTORY/Celeste.zip" -DestinationPath $PATCH
+
+Write-Output "Applying Everest patch"
+Copy-Item -Path "$env:BUILD_ARTIFACTSTAGINGDIRECTORY/main/*" -Destination $PATCH
+Start-Process -FilePath "mono" -ArgumentList "$PATCH/MiniInstaller.exe" -WorkingDirectory $PATCH -Wait

--- a/azure-pipelines-verify.ps1
+++ b/azure-pipelines-verify.ps1
@@ -1,6 +1,13 @@
 # Patch verification
 if ([string]::IsNullOrEmpty("$env:BIN_URL") -or ($env:BIN_URL -eq '$(BIN_URL)')) {
 	Write-Output "Skipping patch verification"
+
+	if ($env:CACHE_RESTORED -eq "false") {
+		# Add placeholder for vanilla path to prevent cache warnings
+		New-Item -ItemType "directory" -Path $env:VANILLA_CACHE
+		Write-Output "Vanilla cache not available" | Out-File -FilePath $env:VANILLA_CACHE/placeholder.txt
+	}
+
 	Exit 0
 }
 

--- a/azure-pipelines-verify.ps1
+++ b/azure-pipelines-verify.ps1
@@ -12,13 +12,16 @@ if ($PATCH -eq "/patch") {
 Write-Output "Creating patch directories"
 Remove-Item -ErrorAction Ignore -Recurse -Force -Path $PATCH
 New-Item -ItemType "directory" -Path $PATCH
-New-Item -ItemType "directory" -Path $PATCH/build
 
-Write-Output "Downloading Celeste package"
-$creds = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes("$($env:BIN_USERNAME):$($env:BIN_PASSWORD)"))
-$headers = @{'Authorization'= "Basic $creds"}
-Invoke-WebRequest -URI "$env:BIN_URL/Celeste_Linux.zip" -OutFile "$env:AGENT_TEMPDIRECTORY/Celeste.zip" -Headers $headers
-Expand-Archive -Path "$env:AGENT_TEMPDIRECTORY/Celeste.zip" -DestinationPath $PATCH
+if ($env:CACHE_RESTORED -eq "false") {
+	Write-Output "Downloading Celeste package"
+	$creds = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes("$($env:BIN_USERNAME):$($env:BIN_PASSWORD)"))
+	$headers = @{'Authorization'= "Basic $creds"}
+	Invoke-WebRequest -URI "$env:BIN_URL/Celeste_Linux.zip" -OutFile "$env:AGENT_TEMPDIRECTORY/Celeste.zip" -Headers $headers
+	Expand-Archive -Path "$env:AGENT_TEMPDIRECTORY/Celeste.zip" -DestinationPath $env:VANILLA_CACHE
+}
+
+Copy-Item -Path "$env:VANILLA_CACHE/*" - Destination $PATCH
 
 Write-Output "Applying Everest patch"
 Copy-Item -Path "$env:BUILD_ARTIFACTSTAGINGDIRECTORY/main/*" -Destination $PATCH

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,7 +73,7 @@ steps:
 # Post-build steps.
 - task: PowerShell@2
   name: PostBuild
-  condition: and(succeeded()
+  condition: and(succeeded())
   displayName: 'Run azure-pipelines-postbuild.ps1'
   continueOnError: true
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,21 +52,29 @@ steps:
     artifactName: 'main'
     publishLocation: 'Container'
 
-# Post-build steps.
+# Verify patches.
 - task: PowerShell@2
-  name: PostBuild
-  condition: succeeded()
-  displayName: 'Run azure-pipelines-postbuild.ps1'
+  condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
+  displayName: 'Verify patches'
   inputs:
-    filePath: 'azure-pipelines-postbuild.ps1'
+    filePath: 'azure-pipelines-verify.ps1'
   env:
     BIN_URL: $(BIN_URL)
     BIN_USERNAME: $(BIN_USERNAME)
     BIN_PASSWORD: $(BIN_PASSWORD)
 
+# Post-build steps.
+- task: PowerShell@2
+  name: PostBuild
+  condition: and(succeeded()
+  displayName: 'Run azure-pipelines-postbuild.ps1'
+  continueOnError: true
+  inputs:
+    filePath: 'azure-pipelines-postbuild.ps1'
+
 # Create and "publish" Olympus artifacts.
 - task: PublishBuildArtifacts@1
-  condition: succeeded()
+  condition: eq(variables['olympus'], 'True')
   displayName: 'Publish olympus-meta artifact'
   continueOnError: true
   inputs:
@@ -74,7 +82,7 @@ steps:
     artifactName: 'olympus-meta'
     publishLocation: 'Container'
 - task: PublishBuildArtifacts@1
-  condition: succeeded()
+  condition: eq(variables['olyumpus'], 'True')
   displayName: 'Publish olympus-build artifact'
   continueOnError: true
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,7 @@ steps:
     path: $(VANILLA_CACHE)
     cacheHitVar: CACHE_RESTORED
 - task: PowerShell@2
-  condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
+  condition: succeeded()
   displayName: 'Verify patches'
   inputs:
     filePath: 'azure-pipelines-verify.ps1'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,6 +10,7 @@ variables:
   solution: '**/*.sln'
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
+  VANILLA_CACHE: $(Pipeline.Workspace)/vanilla
 
 name: '$(Build.BuildId)+$(Build.BuildIdOffset)'
 
@@ -53,6 +54,12 @@ steps:
     publishLocation: 'Container'
 
 # Verify patches.
+- task: Cache@2
+  displayName: Cache Vanilla files
+  inputs:
+    key: '"lib-stripped" | "$(BIN_USERNAME)" | "$(BIN_PASSWORD)"'
+    path: $(VANILLA_CACHE)
+    cacheHitVar: CACHE_RESTORED
 - task: PowerShell@2
   condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
   displayName: 'Verify patches'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,7 +73,7 @@ steps:
 # Post-build steps.
 - task: PowerShell@2
   name: PostBuild
-  condition: and(succeeded())
+  condition: succeeded()
   displayName: 'Run azure-pipelines-postbuild.ps1'
   continueOnError: true
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,6 +56,7 @@ steps:
 # Verify patches.
 - task: Cache@2
   displayName: Cache Vanilla files
+  continueOnError: true
   inputs:
     key: '"lib-stripped" | "$(BIN_USERNAME)" | "$(BIN_PASSWORD)"'
     path: $(VANILLA_CACHE)


### PR DESCRIPTION
Restructures build pipeline to verify patches against Celeste earlier, (hopefully) failing if the patch fails.
- PR builds should not have access to vanilla files, patch verify and lib-stripped steps are skipped
- Main build artifact should always be uploaded even on failure, and Olympus artifact should still be uploaded for builds that don't access vanilla files

Also adds caching for Vanilla files with key including pipeline secrets for security
