### PR TITLE
Fix mini textbox not closing when it's expanding and another textbox is triggered

### DIFF
--- a/Celeste.Mod.mm/Patches/MiniTextbox.cs
+++ b/Celeste.Mod.mm/Patches/MiniTextbox.cs
@@ -1,0 +1,17 @@
+using System.Collections;
+using MonoMod;
+
+namespace Celeste {
+    class patch_MiniTextbox : MiniTextbox {
+
+        public patch_MiniTextbox(string dialogId)
+            : base(dialogId) {
+            // no-op. MonoMod ignores this - we only need this to make the compiler shut up.
+        }
+
+        [MonoModIgnore]
+        [PatchMiniTextboxRoutine]
+        private extern IEnumerator Routine();
+
+    }
+}


### PR DESCRIPTION
### Issue

When a mini textbox is expanding and the player triggers another textbox, the first one will stop expanding and stay on screen until retrying the level.

https://user-images.githubusercontent.com/7558201/137159823-45f04783-958c-464e-9fbb-b3695228ef6e.mp4

### Reason

Let's say we have mini textbox A and B, when A is expanding, the code is looping here in `MiniTextbox.Routine()`:

```cs
while ((this.ease += Engine.DeltaTime * 4f) < 1f) {
    yield return null;
}
```

Then the player triggers B, the game checks and closes them if there are other textboxes in the level, also in `MiniTextbox.Routine()`:

```cs
List<Entity> entities = this.Scene.Tracker.GetEntities<MiniTextbox>();
foreach (MiniTextbox miniTextbox in entities) {
    if (miniTextbox != this) {
        miniTextbox.Add(new Coroutine(miniTextbox.Close()));
    }
}
```

Then `MiniTextbox.Close()` routine is added to A, currently A has `MiniTextbox.Close()` and `MiniTextbox.Routine()` routines running, after the routine is added, the code will loop here in `MiniTextbox.Close()`:

```cs
while ((this.ease -= Engine.DeltaTime * 4f) > 0f) {
    yield return null;
}
```

`ease` is increasing and decreasing by the same amount at the same time, causing A having a constant value of expanding progress, so it will stay on screen forever.

### Solution

Since `closing` will be set to `true` in `MiniTextbox.Close()`, we can stop the display routine if the textbox is closing, so only `MiniTextbox.Close()` is running in A when B is triggered.

```diff
 while ((this.ease += Engine.DeltaTime * 4f) < 1f) {
+    if (this.closing) {
+        yield break;
+    }
     yield return null;
 }
```

https://user-images.githubusercontent.com/7558201/137165489-b6a55027-e3a1-4f87-a336-f33932801117.mp4
