### PR TITLE
Fix incorrect mouse -> world position conversion in console

### DIFF
--- a/Celeste.Mod.mm/Patches/Level.cs
+++ b/Celeste.Mod.mm/Patches/Level.cs
@@ -426,6 +426,40 @@ namespace Celeste {
                 ((patch_EntityList) (object) Entities).ClearEntities();
             }
         }
+
+        public Vector2 ScreenToWorld(Vector2 position) {
+            Vector2 size = new Vector2(320f, 180f);
+            Vector2 scaledSize = size / ZoomTarget;
+            Vector2 offset = ZoomTarget != 1f ? (ZoomFocusPoint - scaledSize / 2f) / (size - scaledSize) * size : Vector2.Zero;
+            float scale = Zoom * ((320f - ScreenPadding * 2f) / 320f);
+            Vector2 paddingOffset = new Vector2(ScreenPadding, ScreenPadding * 9f / 16f);
+
+            if (SaveData.Instance?.Assists.MirrorMode ?? false) {
+                position.X = 1920f - position.X;
+            }
+            position /= 1920f / 320f;
+            position -= paddingOffset;
+            position = (position - offset) / scale + offset;
+            position = Camera.ScreenToCamera(position);
+            return position;
+        }
+
+        public Vector2 WorldToScreen(Vector2 position) {
+            Vector2 size = new Vector2(320f, 180f);
+            Vector2 scaledSize = size / ZoomTarget;
+            Vector2 offset = ZoomTarget != 1f ? (ZoomFocusPoint - scaledSize / 2f) / (size - scaledSize) * size : Vector2.Zero;
+            float scale = Zoom * ((320f - ScreenPadding * 2f) / 320f);
+            Vector2 paddingOffset = new Vector2(ScreenPadding, ScreenPadding * 9f / 16f);
+
+            position = Camera.CameraToScreen(position);
+            position = (position - offset) * scale + offset;
+            position += paddingOffset;
+            position *= 1920f / 320f;
+            if (SaveData.Instance?.Assists.MirrorMode ?? false) {
+                position.X = 1920f - position.X;
+            }
+            return position;
+        }
     }
 
     public static class LevelExt {

--- a/Celeste.Mod.mm/Patches/Monocle/Commands.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Commands.cs
@@ -88,7 +88,7 @@ namespace Monocle {
             Vector2 mousePosition = new Vector2(mouseState.X, mouseState.Y);
             Vector2? mouseSnapPosition = null;
 
-            int viewScale = 1;
+            int maxCursorScale = 1;
 
             string mouseText = "";
 
@@ -102,11 +102,9 @@ namespace Monocle {
 
             if (level != null) {
                 Camera cam = level.Camera;
-                viewScale = (int) Math.Round(Engine.Instance.GraphicsDevice.PresentationParameters.BackBufferWidth / (float) cam.Viewport.Width);
-                Vector2 mouseWorldPosition = mousePosition;
-                // Convert screen to world position.
-                mouseWorldPosition = Calc.Floor(mouseWorldPosition / viewScale);
-                mouseWorldPosition = cam.ScreenToCamera(mouseWorldPosition);
+                float viewScale = (float) Engine.ViewWidth / Engine.Width;
+                // Convert screen to world position. The method assumes screen is in full size (1920x1080) so we need to scale the position.
+                Vector2 mouseWorldPosition = Calc.Floor(((patch_Level) level).ScreenToWorld(mousePosition / viewScale));
                 // CelesteTAS already displays world coordinates. If it is installed, leave that up to it.
                 if (!celesteTASInstalled.Value) {
                     mouseText += $"\n world:       {(int) Math.Round(mouseWorldPosition.X)}, {(int) Math.Round(mouseWorldPosition.Y)}";
@@ -114,16 +112,16 @@ namespace Monocle {
                 mouseWorldPosition -= level.LevelOffset;
                 mouseText += $"\n level:       {(int) Math.Round(mouseWorldPosition.X)}, {(int) Math.Round(mouseWorldPosition.Y)}";
                 // Convert world to world-snap position.
-                mouseSnapPosition = mouseWorldPosition;
-                mouseSnapPosition = Calc.Floor(mouseSnapPosition.Value / 8f);
+                mouseSnapPosition = Calc.Floor(mouseWorldPosition / 8f);
                 mouseText += $"\n level, /8:   {(int) Math.Round(mouseSnapPosition.Value.X)}, {(int) Math.Round(mouseSnapPosition.Value.Y)}";
                 mouseSnapPosition = 8f * mouseSnapPosition;
                 mouseText += $"\n level, snap: {(int) Math.Round(mouseSnapPosition.Value.X)}, {(int) Math.Round(mouseSnapPosition.Value.Y)}";
                 // Convert world-snap to screen-snap position.
                 mouseSnapPosition += new Vector2(4f, 4f); // Center the cursor on the tile.
                 mouseSnapPosition += level.LevelOffset;
-                mouseSnapPosition = cam.CameraToScreen(mouseSnapPosition.Value);
-                mouseSnapPosition *= viewScale;
+                mouseSnapPosition = Calc.Floor(((patch_Level) level).WorldToScreen(mouseSnapPosition.Value) * viewScale);
+                // Cursor shouldn't be larger than an unzoomed tile (level.Zoom and cam.Zoom are both 1)
+                maxCursorScale = Engine.ViewWidth / cam.Viewport.Width;
             }
 
             Draw.SpriteBatch.Begin();
@@ -133,7 +131,7 @@ namespace Monocle {
                 cursorScale--;
             else if (mouseScrollDelta > 0)
                 cursorScale++;
-            cursorScale = Calc.Clamp(cursorScale, 1, viewScale);
+            cursorScale = Calc.Clamp(cursorScale, 1, maxCursorScale);
             if (mouseSnapPosition != null)
                 DrawCursor(mouseSnapPosition.Value, cursorScale, Color.Red);
             DrawCursor(mousePosition, cursorScale, Color.Yellow);

--- a/Celeste.Mod.mm/Patches/Monocle/Commands.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Commands.cs
@@ -80,7 +80,7 @@ namespace Monocle {
             int viewHeight = Engine.ViewHeight;
 
             // Vector2 mousePosition = MInput.Mouse.Position;
-            // For whatever reason, MInput.Mouse.Position keeps returning 0, 0
+            // When the console is opening, MInput.Mouse.UpdateNull is called so MInput.Mouse.Position keeps returning 0, 0
             // Let's just use the XNA / FNA MouseState instead.
             MouseState mouseState = Mouse.GetState();
             int mouseScrollDelta = mouseState.ScrollWheelValue - mouseScroll;


### PR DESCRIPTION
### Issue

The mouse -> world/level position conversion is incorrect when the level is zoomed, or the game has pillarboxes, or a watchtower is activated.

Here's a video showing the situations above, recording 2A dream block cutscene in 1600x720 (the actual screen is in 1280x720), when the cursor is at the cross points of lines, the calculated position is dividable by 8, so lines can show the calculated tiles using the reverse process.

You can see that the lines are not aligned to tiles at the beginning because of the pillarboxes, and they are not scaled when the level is zooming or the watchtower is activated.

https://user-images.githubusercontent.com/7558201/137600350-0e8b45d0-b6ca-4689-9c5f-8886eeee1d82.mp4

### Reason

When the game has pillarboxes, for example, when the window's width is greater than the content width, the game will render the content in center and making two heights equal, but the game is rendered in 16:9 so there are black areas on left and right. In code, `Engine.Instance.GraphicsDevice.PresentationParameters.BackBufferWidth` is window's width. The original code calculates the view scale by `windowWidth / 320`, which gives the wrong result if the window is 1600x720. It should `Engine.ViewWidth / 320` instead.

When the game renders level, it first renders content in level to a buffer image, then renders the buffer to screen. When the level is zoomed, the game will render the buffer at different positions and different scales calculated by `Level.ZoomFocusPoint`, `Level.Zoom` and `Level.ZoomTarget`.

When a watchtower is activated, `Level.ScreenPadding` is changed.

### Solution

This patch adds two conversion methods, `Level.ScreenToWorld` and `Level.WorldToScreen`, for converting between the screen and world coordinate, considering all situations that might affect rendering (camera transform, level scale, level padding), except level rotation since currently there is no support for that (unless some mods hook the render angle). The methods assume the screen is in full size (1920x1080) because they are intended for mods to use them to do conversions when rendering HUDs ingame.

https://user-images.githubusercontent.com/7558201/137600362-ea1df70e-8104-44d3-a5f0-a3aa234b0404.mp4

![Snipaste_2021-10-16_20-10-03](https://user-images.githubusercontent.com/7558201/137600364-1212a729-3142-41c2-8422-80c8c7480749.png)
