### PR TITLE
Warn if mod assembly doesn't contain an EverestModule

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
@@ -576,7 +576,7 @@ namespace Celeste.Mod {
 
                     if (typeof(EverestModule).IsAssignableFrom(type) && !type.IsAbstract) {
                         foundModule = true;
-                        if(!typeof(NullModule).IsAssignableFrom(type)) {
+                        if (!typeof(NullModule).IsAssignableFrom(type)) {
                             EverestModule mod = (EverestModule) type.GetConstructor(_EmptyTypeArray).Invoke(_EmptyObjectArray);
                             mod.Metadata = meta;
                             mod.Register();

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
@@ -570,15 +570,23 @@ namespace Celeste.Mod {
                     return;
                 }
 
+                bool foundModule = false;
                 for (int i = 0; i < types.Length; i++) {
                     Type type = types[i];
 
-                    if (typeof(EverestModule).IsAssignableFrom(type) && !type.IsAbstract && !typeof(NullModule).IsAssignableFrom(type)) {
-                        EverestModule mod = (EverestModule) type.GetConstructor(_EmptyTypeArray).Invoke(_EmptyObjectArray);
-                        mod.Metadata = meta;
-                        mod.Register();
+                    if (typeof(EverestModule).IsAssignableFrom(type) && !type.IsAbstract) {
+                        foundModule = true;
+                        if(!typeof(NullModule).IsAssignableFrom(type)) {
+                            EverestModule mod = (EverestModule) type.GetConstructor(_EmptyTypeArray).Invoke(_EmptyObjectArray);
+                            mod.Metadata = meta;
+                            mod.Register();
+                        }
                     }
                 }
+                
+                // Warn if we didn't find a module, as that could indicate an oversight from the developer
+                if (!foundModule)
+                    Logger.Log(LogLevel.Warn, "loader", "Assembly doesn't contain an EverestModule!");
             }
 
             internal static void ReloadModAssembly(object source, FileSystemEventArgs e, bool retrying = false) {


### PR DESCRIPTION
Log a warning if the assembly of a code mod doesn't contain an `EverestModule`. All code mods should have one, and the ones who don't can bypass this warning by creating an `EverestModule` which either does nothing or subclasses `NullModule`. This can help developers catch errors when they either break the module, or it somehow fails to load (in which case it's not returned by `asm.GetTypesSafe()`).