### PR TITLE
Retrieve everest_update.yaml in gzipped form to spare bandwidth

### DIFF
--- a/Celeste.Mod.mm/Mod/Helpers/ModUpdaterHelper.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/ModUpdaterHelper.cs
@@ -7,6 +7,18 @@ using System.Threading.Tasks;
 
 namespace Celeste.Mod.Helpers {
     public class ModUpdaterHelper {
+        private class CompressedWebClient : WebClient {
+            protected override WebRequest GetWebRequest(Uri address) {
+                // In order to compress the response, Accept-Encoding and User-Agent both have to contain "gzip":
+                // https://cloud.google.com/appengine/docs/standard/java/how-requests-are-handled#response_compression
+                HttpWebRequest request = (HttpWebRequest) base.GetWebRequest(address);
+                request.AutomaticDecompression = DecompressionMethods.GZip;
+                request.UserAgent = "Everest/" + Everest.VersionString + "; gzip";
+
+                return request;
+            }
+        }
+
         private class MostRecentUpdatedFirst : IComparer<ModUpdateInfo> {
             public int Compare(ModUpdateInfo x, ModUpdateInfo y) {
                 if (x.LastUpdate != y.LastUpdate) {
@@ -29,7 +41,7 @@ namespace Celeste.Mod.Helpers {
 
                 Logger.Log("ModUpdaterHelper", $"Downloading last versions list from {modUpdaterDatabaseUrl}");
 
-                using (WebClient wc = new WebClient()) {
+                using (WebClient wc = new CompressedWebClient()) {
                     string yamlData = wc.DownloadString(modUpdaterDatabaseUrl);
                     updateCatalog = YamlHelper.Deserializer.Deserialize<Dictionary<string, ModUpdateInfo>>(yamlData);
                     foreach (string name in updateCatalog.Keys) {


### PR DESCRIPTION
Currently everest_update.yaml is 221.31 KiB / 43.27 KiB gzipped (which is a 80% save), is downloaded ~6000 times a day, and getting it in gzipped form is just about including two extra headers in the request. 😅 