### PR TITLE
Fix Discord rich presence on macOS

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Discord.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Discord.cs
@@ -47,7 +47,6 @@ namespace Celeste.Mod {
             }
 
             private static void TryLoadDiscordLib(string lib) {
-                Logger.Log(LogLevel.Info, "discord", string.Format("Attempting to load {0}", lib));
                 DynDll.Mappings["discord-rpc"] = new List<DynDllMapping>() { lib };
 
                 try {


### PR DESCRIPTION
This commit doesn't rewrite Everest's DiscordRPC integration with Discord's GameSDK (like #307 requests), but it fixes rich presence not showing up on macOS and shouldn't interfere with rich presence on other platforms (though I haven't tested that).