### PR TITLE
Improvements for cassette music maps

### DIFF
--- a/Celeste.Mod.mm/Mod/Meta/MapMeta.cs
+++ b/Celeste.Mod.mm/Mod/Meta/MapMeta.cs
@@ -527,6 +527,7 @@ namespace Celeste.Mod.Meta {
         public int TicksPerSwap { get; set; } = 2;
         public int Blocks { get; set; } = 2;
         public int BeatsMax { get; set; } = 256;
+        public int BeatIndexOffset { get; set; } = 0;
         public bool OldBehavior { get; set; } = false;
 
         public void Parse(BinaryPacker.Element meta) {
@@ -536,6 +537,7 @@ namespace Celeste.Mod.Meta {
             meta.AttrIfInt("TicksPerSwap", v => TicksPerSwap = v);
             meta.AttrIfInt("Blocks", v => Blocks = v);
             meta.AttrIfInt("BeatsMax", v => BeatsMax = v);
+            meta.AttrIfInt("BeatIndexOffset", v => BeatIndexOffset = v);
             meta.AttrIfBool("OldBehavior", v => OldBehavior = v);
         }
     }

--- a/Celeste.Mod.mm/Patches/CassetteBlockManager.cs
+++ b/Celeste.Mod.mm/Patches/CassetteBlockManager.cs
@@ -52,6 +52,7 @@ namespace Celeste {
                 beatsPerTick = meta.BeatsPerTick;
                 ticksPerSwap = meta.TicksPerSwap;
                 beatIndexMax = meta.BeatsMax;
+                beatIndexOffset = meta.BeatIndexOffset;
             }
         }
 
@@ -114,7 +115,7 @@ namespace Celeste {
                 maxBeat = level.CassetteBlockBeats;
                 tempoMult = level.CassetteBlockTempo;
 
-                if (beatIndex % 8 >= 5) {
+                if (beatIndex % (beatsPerTick * ticksPerSwap) > ((beatsPerTick * ticksPerSwap) / 2)) {
                     currentIndex = maxBeat - 2;
                 } else {
                     currentIndex = maxBeat - 1;


### PR DESCRIPTION
This adjusts two things in `CassetteBlockManager`:
- `BeatIndexOffset` can now be set in map metadata instead of being forced to 5 for levels where the cassette track is the main music event (it's set to 5 in `Awake`)
- the `beatIndex` adjustment is no longer hardcoded to 8 but will adjust to always use the second-to-last cassette colour if the beat is within the second half of a swap and the last colour if it's within the first half.

`BeatIndexOffset` should probably default to 0 for all non-vanilla levels. I believe this is what it should be, since it starting at 5 for levels with the cassette track as the main track is somewhat arbitrary (I believe only Farewell uses that in Vanilla). I wonder whether changing this default will break something; Is the offset of 5 beats compensated for within the FMOD project? Cassette swap cycles are usually eight beats, so that doesn't align with 5 at all.