### PR TITLE
Fix crystal heart disappearing if save & quitting after collecting it

### DIFF
--- a/Celeste.Mod.mm/MonoModRules.cs
+++ b/Celeste.Mod.mm/MonoModRules.cs
@@ -792,6 +792,17 @@ namespace MonoMod {
                     cctor_il.Emit(OpCodes.Pop); // HashSet.Add returns a bool.
                 }
 
+                if (instri > 0 &&
+                        instri < instrs.Count - 4 &&
+                        instr.MatchLdfld("Celeste.Level", "Session") &&
+                        instrs[instri + 1].MatchLdflda("Celeste.Session", "Area") &&
+                        instrs[instri + 2].MatchLdfld("Celeste.AreaKey", "Mode") &&
+                        instrs[instri + 3].OpCode == OpCodes.Brfalse
+                    ) {
+
+                    instrs.Insert(instri, il.Create(OpCodes.Ldarg_0));
+                    instrs.Insert(instri + 4, il.Create(OpCodes.Call, method.DeclaringType.FindMethod("Celeste.AreaMode _PatchHeartGemBehavior(Celeste.AreaMode)")));
+                }
             }
 
             cctor_il.Emit(OpCodes.Stsfld, f_LoadStrings);

--- a/Celeste.Mod.mm/Patches/Level.cs
+++ b/Celeste.Mod.mm/Patches/Level.cs
@@ -216,6 +216,24 @@ namespace Celeste {
             Everest.Events.Level.LoadLevel(this, playerIntro, isFromLoader);
         }
 
+        private AreaMode _PatchHeartGemBehavior(AreaMode levelMode) {
+            if (Session.Area.GetLevelSet() == "Celeste") {
+                // do not mess with vanilla.
+                return levelMode;
+            }
+
+            MapMetaModeProperties properties = Session.MapData.GetMeta();
+            if (properties != null && (properties.HeartIsEnd ?? false)) {
+                // heart ends the level: this is like B-Sides.
+                // the heart will appear even if it was collected, to avoid a softlock if we save & quit after collecting it.
+                return AreaMode.BSide;
+            } else {
+                // heart does not end the level: this is like A-Sides.
+                // the heart will disappear after it is collected.
+                return AreaMode.Normal;
+            }
+        }
+
         private IEnumerator ErrorRoutine(string message) {
             yield return null;
 


### PR DESCRIPTION
Crystal hearts can only spawn if one of those 2 conditions is met:
- the heart was not collected in the session
- the current level isn't an A-side

The second condition is here to make sure that if you collect the heart then save & quit, you don't get stuck at the end of the level... **with no heart to complete it**. _In vanilla_, the maps that end on a heart are those that aren't A-sides.

So, this is supposed to check the "end level on heart" metadata property rather than the side on custom maps. 😅 