### PR TITLE
Disable anchors in serialized yaml

### DIFF
--- a/Celeste.Mod.mm/Mod/Helpers/YamlHelper.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/YamlHelper.cs
@@ -6,7 +6,7 @@ namespace Celeste.Mod {
     public static class YamlHelper {
 
         public static IDeserializer Deserializer = new DeserializerBuilder().IgnoreUnmatchedProperties().Build();
-        public static ISerializer Serializer = new SerializerBuilder().ConfigureDefaultValuesHandling(DefaultValuesHandling.Preserve).Build();
+        public static ISerializer Serializer = new SerializerBuilder().ConfigureDefaultValuesHandling(DefaultValuesHandling.Preserve).DisableAliases().Build();
 
         /// <summary>
         /// Builds a deserializer that will provide YamlDotNet with the given object instead of creating a new one.


### PR DESCRIPTION
If the object has multiple same values (checked by `Equals()` and `GetHashCode()`), the serializer will use anchors by default to reduce file size. However, those values will share the same reference after deserializing, causing some unexpected behaviors.

```cs
internal class Program {
    public record Point {
        public int X { get; set; }
        public int Y { get; set; }

        public Point() {
        }

        public Point(int x, int y) {
            X = x;
            Y = y;
        }
    }

    public record Node {
        public Point Position { get; set; }
        public int Scale { get; set; }
    }

    public static void Main(string[] args) {
        List<Node> nodes = new List<Node> {
            new Node {Position = new Point(0, 0), Scale = 1},
            new Node {Position = new Point(0, 0), Scale = 1},
            new Node {Position = new Point(0, 0), Scale = 2}
        };

        string yaml = YamlHelper.Serializer.Serialize(nodes);
        // Outputs:
        // - &o0
        //   Position: &o1
        //     X: 0
        //     Y: 0
        //   Scale: 1
        // - *o0
        // - Position: *o1
        //   Scale: 2
        Console.WriteLine(yaml);

        List<Node> result = YamlHelper.Deserializer.Deserialize<List<Node>>(yaml);
        // Outputs: True True
        Console.WriteLine(ReferenceEquals(result[0], result[1]));
        Console.WriteLine(ReferenceEquals(result[0].Position, result[2].Position));
    }
}
```

Suppose the player wants to change the scale of the first node in mod settings, and the code is `result[0].Scale = 2`, then the second node is also changed.
