### PR TITLE
Fix release pipeline build number and artifacts

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -28,10 +28,11 @@ steps:
     declare -i BUILD_NUMBER=$(resources.pipeline.build.runID)+$(Build.BuildIdOffset)
     echo "##vso[task.setvariable variable=build_number]$BUILD_NUMBER"
 
-    zip -9r $(Build.ArtifactStagingDirectory)/main.zip $(Build.ArtifactStagingDirectory)/main/
-    zip -9r $(Build.ArtifactStagingDirectory)/olympus-meta.zip $(Build.ArtifactStagingDirectory)/olympus-meta/
-    zip -9r $(Build.ArtifactStagingDirectory)/olympus-build.zip $(Build.ArtifactStagingDirectory)/olympus-build/
-    zip -9r $(Build.ArtifactStagingDirectory)/lib-stripped.zip $(Build.ArtifactStagingDirectory)/lib-stripped/
+    cd $(Build.ArtifactStagingDirectory)
+    zip -9r main.zip ./main/
+    zip -9r olympus-meta.zip olympus-meta
+    zip -9r olympus-build.zip olympus-build
+    zip -9r lib-stripped.zip lib-stripped
 
 # Create GitHub release for new stable versions.
 - task: GitHubRelease@1

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -25,8 +25,7 @@ steps:
 
 # Define build_number variable and zip build artifacts
 - script: |
-    # TODO: -1 hackfix to match triggering build, should be replaced with actual reference
-    declare -i BUILD_NUMBER=$(Build.BuildId)+$(Build.BuildIdOffset)-1
+    declare -i BUILD_NUMBER=$(resources.pipeline.build.runID)+$(Build.BuildIdOffset)
     echo "##vso[task.setvariable variable=build_number]$BUILD_NUMBER"
 
     zip -9r $(Build.ArtifactStagingDirectory)/main.zip $(Build.ArtifactStagingDirectory)/main/


### PR DESCRIPTION
This should hopefully reference the build number of the triggering pipeline for stable releases.
Also attempts to fix release artifact structure