### PR TITLE
Adds UpdatePreceder and UpdateFinalizer functionality through List<Action>

### DIFF
--- a/Celeste.Mod.mm/MonoModRules.cs
+++ b/Celeste.Mod.mm/MonoModRules.cs
@@ -415,6 +415,9 @@ namespace MonoMod {
     [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchEmulatorConstructor))]
     class PatchEmulatorConstructorAttribute : Attribute { }
 
+    [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchEntityListUpdate))]
+    class PatchEntityListUpdateAttribute : Attribute { }
+
     static class MonoModRules {
 
         static bool IsCeleste;
@@ -2407,6 +2410,50 @@ namespace MonoMod {
             foreach (TypeDefinition nested in type.NestedTypes)
                 PostProcessType(modder, nested);
         }
+        /*
+        public static void PatchEntityListUpdate(ILContext context, CustomAttribute attrib) {
+            TypeDefinition entityType = MonoModRule.Modder.FindType("Monocle.Entity").Resolve();
+            FieldDefinition entity_UpdateFinalizer = entityType.FindField("UpdateFinalizer");
+            GenericInstanceType action_entity = new GenericInstanceType(MonoModRule.Modder.FindType("System.Action"));
+            action_entity.GenericArguments.Add(entityType);
+            ILCursor cursor = new ILCursor(context);
+            ILLabel iterateLoop = cursor.DefineLabel();
+            cursor.GotoNext(MoveType.Before, instr => instr.MatchBr(out iterateLoop)); //Retrieve loop iterator code (at the end of the loop)
+            cursor.GotoNext(MoveType.After, instr => instr.MatchLdloc(1), instr => instr.MatchCallvirt("Monocle.Entity", "Update")); // Go after entity.Update
+            //entity.UpdateFinalizer?.Invoke();
+            //entity to stack
+            cursor.Emit(OpCodes.Ldloc_1);
+            //entity.UpdateFinalizer to stack
+            cursor.Emit(OpCodes.Ldfld, entity_UpdateFinalizer);
+            //entity.UpdateFinalizer to stack x2
+            cursor.Emit(OpCodes.Dup);
+            //Mark this as a label 
+            ILLabel passCheck = cursor.MarkLabel();
+            //Invoke the UpdateFinalizer
+            cursor.Emit(OpCodes.Ldloc_1);
+            cursor.Emit(OpCodes.Callvirt, action_entity_Invoke);
+            cursor.Emit(OpCodes.Nop); //Necessary according to SharpLab. idfk
+            //Goes behind the passCheck label, after the Dup instruction but before the lable for callvirt. This lets me insert code at this point
+            cursor.GotoLabel(passCheck, MoveType.Before);
+            //takes the latter of the entity.UpdateFinalizer on the stack and compares to null, branch to passCheck if true
+            cursor.Emit(OpCodes.Brtrue, passCheck);
+            //Assuming this false, it pops the latter of the UpdateFinalizers off stack and branches to the iteration loop, the instruction after this point
+            cursor.Emit(OpCodes.Pop);
+            cursor.Emit(OpCodes.Br, iterateLoop);
+        }*/
 
+        public static void PatchEntityListUpdate(ILContext context, CustomAttribute attrib) {
+            TypeDefinition Entity = MonoModRule.Modder.FindType("Monocle.Entity").Resolve();
+            MethodDefinition entity_UpdatePreceder = Entity.FindMethod("UpdatePreceder");
+            MethodDefinition entity_UpdateFinalizer = Entity.FindMethod("UpdateFinalizer");
+
+            ILCursor cursor = new ILCursor(context);
+            cursor.GotoNext(MoveType.Before, instr => instr.MatchLdloc(1), instr => instr.MatchCallvirt("Monocle.Entity", "Update")); // Go after entity.Update
+            cursor.Emit(OpCodes.Ldloc_1);
+            cursor.Emit(OpCodes.Callvirt, entity_UpdatePreceder);
+            cursor.Index += 2;
+            cursor.Emit(OpCodes.Ldloc_1);
+            cursor.Emit(OpCodes.Callvirt, entity_UpdateFinalizer);
+        }
     }
 }

--- a/Celeste.Mod.mm/Patches/Monocle/Entity.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Entity.cs
@@ -1,5 +1,7 @@
 ﻿
 using MonoMod;
+using System;
+using System.Collections.Generic;
 
 namespace Monocle {
     class patch_Entity : Entity {
@@ -12,6 +14,25 @@ namespace Monocle {
 
         internal void DissociateFromScene() {
             Scene = null;
+        }
+
+        public List<Action> UpdatePrecederActions;
+        public List<Action> UpdateFinalizerActions;
+
+        internal void UpdatePreceder() {
+            if(UpdatePrecederActions?.Count > 0) {
+                foreach(Action action in UpdateFinalizerActions) {
+                    action?.Invoke();
+                }
+            }
+        }
+
+        internal void UpdateFinalizer() {
+            if (UpdateFinalizerActions?.Count > 0) { 
+                foreach (Action action in UpdateFinalizerActions) {
+                    action?.Invoke();
+                }
+            }
         }
     }
 }

--- a/Celeste.Mod.mm/Patches/Monocle/Entity.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Entity.cs
@@ -19,6 +19,8 @@ namespace Monocle {
         public List<Action> UpdatePrecederActions;
         public List<Action> UpdateFinalizerActions;
 
+        //For some reason this compiles to be significantly slower than it could be in theory, most likely to do patch structure in MonoMod.
+        //If you want me to update this to be written in pure IL I can do that as well, just let me know in PR review
         internal void UpdatePreceder() {
             if(UpdatePrecederActions?.Count > 0) {
                 foreach(Action action in UpdateFinalizerActions) {

--- a/Celeste.Mod.mm/Patches/Monocle/EntityList.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/EntityList.cs
@@ -1,5 +1,6 @@
 ﻿#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
 
+using MonoMod;
 using System.Collections.Generic;
 
 namespace Monocle {
@@ -18,6 +19,10 @@ namespace Monocle {
         internal void ClearEntities() {
             entities.Clear();
         }
+
+        [MonoModIgnore]
+        [PatchEntityListUpdate]
+        internal extern void Update();
     }
     public static class EntityListExt {
 


### PR DESCRIPTION
The main purpose of this is specifically to have a scenario where you can add some function to the end of an Update call from the perspective of EntityList.Update, without having to hook every scenario you want it in.
Example:
```
Glider.Update {
  (A1)
  ... (B1)
  Actor.Update
  ... (C1)
  (D1)
}

Seeker.Update {
  (A2)
  ... (B2)
  Actor.Update
  ... (C2)
  (D2)
}
```
let's say, I'd want my "hook" to work on both Seeker and Glider at the point D. Unless I hook Seeker and Glider's Update functions, this simply will not be able to work, and if I don't know what the entity I want to "hook" _is_, then there's currently no way to do this.
Real world scenarios of this are specifically Flag Toggle Containers and Floaty Containers in EeveeHelper, which get around this by using a second entity that "contains" the information of the entity and changes it over time, which has recently caused some high memory usage (possibly a memory leak? researching atm), and this can also offer a resolution to those bugs.

Current methodology is using two List<Action>'s for Preceding Actions and Proceeding (Finalizing) Actions, since this isn't expected to be a commonplace thing, which might call for the use of implementing UpdateFinalizers and UpdatePreceders with Components (in practice, you could just add the Actions through the components)

The major issue with this currently that I can see is that the features aren't IL optimized at all due to in-patch construction, and given the extreme load scenario this could give, I think implementing these features with IL directly isn't a bad call. Let me know what you think, please.
