### PR TITLE
Fix for scaling emoji added to fonts.

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Emoji.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Emoji.cs
@@ -57,11 +57,27 @@ namespace Celeste.Mod {
         /// </summary>
         /// <param name="name">The emoji name.</param>
         /// <param name="emoji">The emoji texture.</param>
-        public static void Register(string name, MTexture emoji) {
+        /// <param name="targetHeight">The height to render this emoji as. Adjusts the MTexture.ScaleFix as side-effect!</param>
+        public static void Register(string name, MTexture emoji, int targetHeight) {
+            if(emoji != null && emoji.Height != targetHeight)
+                ((patch_MTexture) emoji).ScaleFix = targetHeight / (float) emoji.Height;
+            Register(name, emoji);
+        }
+
+        /// <summary>
+        /// Register an emoji.
+        /// </summary>
+        /// <param name="name">The emoji name.</param>
+        /// <param name="emoji">The emoji texture.</param>
+        /// <param name="scale">Scaling factor for the emoji spacing. Defaults to emoji.ScaleFix.</param>
+        public static void Register(string name, MTexture emoji, float? scale = null) {
             if (!Initialized) {
                 Queue.Enqueue(new KeyValuePair<string, MTexture>(name, emoji));
                 return;
             }
+
+            if (scale == null)
+                scale = emoji != null ? ((patch_MTexture) emoji).ScaleFix : 1f;
 
             bool monochrome;
             if (monochrome = name.EndsWith(".m")) {
@@ -75,7 +91,7 @@ namespace Celeste.Mod {
             xml.SetAttr("height", emoji.Height);
             xml.SetAttr("xoffset", 0);
             xml.SetAttr("yoffset", 0);
-            xml.SetAttr("xadvance", emoji.Width);
+            xml.SetAttr("xadvance", (int) (emoji.Width * scale));
 
             int id = _Registered.IndexOf(name);
             if (id < 0) {

--- a/Celeste.Mod.mm/Mod/Everest/Emoji.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Emoji.cs
@@ -62,14 +62,28 @@ namespace Celeste.Mod {
         }
 
         /// <summary>
-        /// Register an emoji.
+        /// Register an emoji with scaling constraints.
         /// </summary>
         /// <param name="name">The emoji name.</param>
         /// <param name="emoji">The emoji texture.</param>
+        /// <param name="targetWidth">The width to render this emoji as. Adjusts the MTexture.ScaleFix as side-effect!</param>
         /// <param name="targetHeight">The height to render this emoji as. Adjusts the MTexture.ScaleFix as side-effect!</param>
-        public static void Register(string name, MTexture emoji, int targetHeight) {
-            if(emoji != null && emoji.Height != targetHeight)
-                ((patch_MTexture) emoji).ScaleFix = targetHeight / (float) emoji.Height;
+        public static void Register(string name, MTexture emoji, int targetWidth = 0, int targetHeight = 0) {
+            if (emoji == null) {
+                Register(name, emoji);
+                return;
+            }
+
+            float scaleFixW = targetWidth <= 0 ? 1f : targetWidth / (float) emoji.Width;
+            float scaleFixH = targetHeight <= 0 ? 1f : targetHeight / (float) emoji.Height;
+
+            if (targetWidth <= 0)
+                ((patch_MTexture) emoji).ScaleFix = scaleFixH;
+            else if (targetHeight <= 0)
+                ((patch_MTexture) emoji).ScaleFix = scaleFixW;
+            else
+                ((patch_MTexture) emoji).ScaleFix = System.Math.Min(scaleFixW, scaleFixH);
+
             Register(name, emoji);
         }
 

--- a/Celeste.Mod.mm/Mod/Everest/Emoji.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Emoji.cs
@@ -61,7 +61,6 @@ namespace Celeste.Mod {
             Register(name, emoji, ((patch_MTexture) emoji)?.ScaleFix ?? 1f);
         }
 
-
         /// <summary>
         /// Register an emoji.
         /// </summary>

--- a/Celeste.Mod.mm/Mod/Everest/Emoji.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Emoji.cs
@@ -57,6 +57,16 @@ namespace Celeste.Mod {
         /// </summary>
         /// <param name="name">The emoji name.</param>
         /// <param name="emoji">The emoji texture.</param>
+        public static void Register(string name, MTexture emoji) {
+            Register(name, emoji, ((patch_MTexture) emoji)?.ScaleFix ?? 1f);
+        }
+
+
+        /// <summary>
+        /// Register an emoji.
+        /// </summary>
+        /// <param name="name">The emoji name.</param>
+        /// <param name="emoji">The emoji texture.</param>
         /// <param name="targetHeight">The height to render this emoji as. Adjusts the MTexture.ScaleFix as side-effect!</param>
         public static void Register(string name, MTexture emoji, int targetHeight) {
             if(emoji != null && emoji.Height != targetHeight)
@@ -70,14 +80,11 @@ namespace Celeste.Mod {
         /// <param name="name">The emoji name.</param>
         /// <param name="emoji">The emoji texture.</param>
         /// <param name="scale">Scaling factor for the emoji spacing. Defaults to emoji.ScaleFix.</param>
-        public static void Register(string name, MTexture emoji, float? scale = null) {
+        public static void Register(string name, MTexture emoji, float scale) {
             if (!Initialized) {
                 Queue.Enqueue(new KeyValuePair<string, MTexture>(name, emoji));
                 return;
             }
-
-            if (scale == null)
-                scale = emoji != null ? ((patch_MTexture) emoji).ScaleFix : 1f;
 
             bool monochrome;
             if (monochrome = name.EndsWith(".m")) {


### PR DESCRIPTION
So, emoji scaling. I tried turning game assets into Everest Emoji within its font, and noticed that the "xadvance" property does not get set correctly for the emoji characters in the font, when `MTexture emoji.ScaleFix != 1f`. 
This means if I grab a Texture and apply scaling via ScaleFix e.g. `= .5f` the emoji gets rendered at halfs its size, but the following characters in the text still got spaced out by the original size.

Initially my fix was simply:
```c#
xml.SetAttr("xadvance", (int) (emoji.Width * ((patch_MTexture) emoji).ScaleFix));
```

but that felt a bit too much like a hack based on a hack (fix). I'm not 100% what problem ScaleFix solves and if I may use it freely tbh!

So now I have altered:
```c#
public static void Register(string name, MTexture emoji, float? scale = null)
```
with that nullable float, where it internally replaces null with `((patch_MTexture) emoji).ScaleFix)` if `emoji != null`; and `1f` otherwise. (ScaleFix defaults to `1f` maybe probably most likely?) 

A new problem now is that `scale` only applies to "xadvance" for rendering the emoji.

So I have one overload for Emoji.Register:
```c#
public static void Register(string name, MTexture emoji, int targetHeight)
```

**But** this one modifies the MTexture in that it sets 
```c#
((patch_MTexture) emoji).ScaleFix = targetHeight / (float) emoji.Height;
```
i.e. you can specify the height you wish the emoji to render at and it alters the ScaleFix _for you_.
I'm not 100% sure if this is reasonable or not, since altering the MTexture feels wrong. But it would be a useful feature to set the scaling of the Texture correctly. :thinkeline:

Thoughts? :)