### PR TITLE
Add mod load and register events

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Events.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Events.cs
@@ -31,6 +31,24 @@ namespace Celeste.Mod {
                     => OnShutdown?.Invoke();
             }
 
+            public static class Everest {
+                public delegate void ModLoadedHandler(EverestModuleMetadata meta);
+                /// <summary>
+                /// Called when a mod finishes loading.
+                /// </summary>
+                public static event ModLoadedHandler OnLoadMod;
+                internal static void LoadMod(EverestModuleMetadata meta)
+                    => OnLoadMod?.Invoke(meta);
+
+                public delegate void RegisterModuleHandler(EverestModule module);
+                /// <summary>
+                /// Called when a mod is registered.
+                /// </summary>
+                public static event RegisterModuleHandler OnRegisterModule;
+                internal static void RegisterModule(EverestModule module)
+                    => OnRegisterModule?.Invoke(module);
+            }
+
             [Obsolete("Use MainMenu instead.")]
             public static class OuiMainMenu {
                 public delegate void CreateButtonsHandler(_OuiMainMenu menu, List<MenuButton> buttons);

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
@@ -1,4 +1,5 @@
 ﻿using Celeste.Mod.Core;
+using Celeste.Mod.Helpers;
 using Ionic.Zip;
 using MonoMod.Utils;
 using System;
@@ -473,6 +474,8 @@ namespace Celeste.Mod {
 
                 if (meta == null)
                     return;
+
+                using var _ = new ScopeFinalizer(() => Events.Everest.LoadMod(meta));
 
                 // Add an AssemblyResolve handler for all bundled libraries.
                 AppDomain.CurrentDomain.AssemblyResolve += GenerateModAssemblyResolver(meta);

--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -748,6 +748,7 @@ namespace Celeste.Mod {
             }
 
             Logger.Log(LogLevel.Info, "core", $"Module {module.Metadata} registered.");
+            Events.Everest.RegisterModule(module);
 
             CheckDependenciesOfDelayedMods();
         }

--- a/Celeste.Mod.mm/Mod/Helpers/ScopeFinalizer.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/ScopeFinalizer.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace Celeste.Mod.Helpers {
+    public sealed class ScopeFinalizer : IDisposable {
+        private Action onExit;
+        
+        public ScopeFinalizer(Action onExit) {
+            this.onExit = onExit;
+        }
+
+        public void Dispose() {
+            onExit();
+        }
+
+    }
+}


### PR DESCRIPTION
Adds Events for loading mods and registering EverestModules.

Will be used to fix (but not close, thank you Github) https://github.com/CommunalHelper/CommunalHelper/issues/92 unless there's a better alternative available.

I didn't want to rewrite LoadMod so I added a hacky `ScopeFinalizer` that runs a callback when the current scope exits, it can be refactored appropriately if required.