### PR TITLE
Use MonoModLinkTo for base.base. calls

### DIFF
--- a/Celeste.Mod.mm/Patches/BounceBlock.cs
+++ b/Celeste.Mod.mm/Patches/BounceBlock.cs
@@ -5,7 +5,6 @@ using Monocle;
 using MonoMod;
 
 namespace Celeste {
-    // : Solid because base.Added
     class patch_BounceBlock : BounceBlock {
 
         // We're effectively in BounceBlock, but still need to "expose" private fields to our mod.

--- a/Celeste.Mod.mm/Patches/BounceBlock.cs
+++ b/Celeste.Mod.mm/Patches/BounceBlock.cs
@@ -28,7 +28,7 @@ namespace Celeste {
         public extern void base_Added(Scene scene);
         [MonoModReplace]
         public override void Added(Scene scene) {
-            base.Added(scene);
+            base_Added(scene);
             iceModeNext = iceMode = SceneAs<Level>().CoreMode == Session.CoreModes.Cold || notCoreMode;
             ToggleSprite();
         }

--- a/Celeste.Mod.mm/Patches/BounceBlock.cs
+++ b/Celeste.Mod.mm/Patches/BounceBlock.cs
@@ -6,7 +6,7 @@ using MonoMod;
 
 namespace Celeste {
     // : Solid because base.Added
-    class patch_BounceBlock : Solid {
+    class patch_BounceBlock : BounceBlock {
 
         // We're effectively in BounceBlock, but still need to "expose" private fields to our mod.
         private bool iceMode;
@@ -14,19 +14,19 @@ namespace Celeste {
 
         private bool notCoreMode;
 
-        public patch_BounceBlock(EntityData data, Vector2 offset) 
-            : base(data.Position + offset, data.Width, data.Height, false) {
-            // no-op. MonoMod ignores this - we only need this to make the compiler shut up.
-        }
+        [MonoModIgnore]
+        public extern patch_BounceBlock(Vector2 position, float width, float height);
 
-        public extern void orig_ctor(EntityData data, Vector2 offset);
         [MonoModConstructor]
-        public void ctor(EntityData data, Vector2 offset) {
-            orig_ctor(data, offset);
-
+        [MonoModReplace]
+        public patch_BounceBlock(EntityData data, Vector2 offset)
+            : this(data.Position + offset, data.Width, data.Height) {
             notCoreMode = data.Bool("notCoreMode");
         }
 
+        [MonoModLinkTo("Monocle.Entity", "Added")]
+        [MonoModIgnore]
+        public extern void base_Added(Scene scene);
         [MonoModReplace]
         public override void Added(Scene scene) {
             base.Added(scene);

--- a/Celeste.Mod.mm/Patches/Checkpoint.cs
+++ b/Celeste.Mod.mm/Patches/Checkpoint.cs
@@ -3,18 +3,27 @@
 
 using Microsoft.Xna.Framework;
 using Monocle;
+using MonoMod;
 using System;
 
 namespace Celeste {
-    class patch_Checkpoint : Entity {
+    class patch_Checkpoint : Checkpoint {
 
         private string bg;
         private Image image;
         private Sprite sprite;
         private Sprite flash;
 
+        public patch_Checkpoint(Vector2 position, string bg = "", Vector2? spawnTarget = null)
+            : base(position, bg, spawnTarget) {
+            //no-op
+        }
+
+        [MonoModLinkTo("Monocle.Entity", "Awake")]
+        [MonoModIgnore]
+        public extern void base_Awake(Scene scene);
         public override void Awake(Scene scene) {
-            base.Awake(scene);
+            base_Awake(scene);
 
             Level level = scene as Level;
             if (level == null || level.Session.Area.GetLevelSet() == "Celeste")

--- a/Celeste.Mod.mm/Patches/InputMappingInfo.cs
+++ b/Celeste.Mod.mm/Patches/InputMappingInfo.cs
@@ -1,6 +1,7 @@
 ﻿using MonoMod;
 
 namespace Celeste {
+    // Extend patch_Item so we can override AlwaysRender properly
     class patch_InputMappingInfo : patch_TextMenu.patch_Item {
         // we want it to always render, as it overlays on top of the menu when scrolling down (so it never goes off-screen).
         public override bool AlwaysRender => true;

--- a/Celeste.Mod.mm/Patches/IntroCrusher.cs
+++ b/Celeste.Mod.mm/Patches/IntroCrusher.cs
@@ -10,8 +10,7 @@ using System.Collections;
 using System.Linq;
 
 namespace Celeste {
-    // : Solid because base.Added
-    class patch_IntroCrusher : Solid {
+    class patch_IntroCrusher : IntroCrusher {
 
         // We're effectively in IntroCrusher, but still need to "expose" private fields to our mod.
         private Vector2 end;
@@ -19,15 +18,10 @@ namespace Celeste {
 
         public string levelFlags;
 
-        public patch_IntroCrusher(Vector2 position, int width, int height, Vector2 node)
-            : base(position, width, height, true) {
-            // no-op. MonoMod ignores this - we only need this to make the compiler shut up.
-        }
-
         [MonoModConstructor]
         [MonoModReplace]
         public patch_IntroCrusher(EntityData data, Vector2 offset)
-            : this(data.Position + offset, data.Width, data.Height, data.Nodes[0] + offset) {
+            : base(data.Position + offset, data.Width, data.Height, data.Nodes[0] + offset) {
 
             levelFlags = data.Attr("flags");
 
@@ -38,6 +32,9 @@ namespace Celeste {
             }
         }
 
+        [MonoModLinkTo("Monocle.Entity", "Added")]
+        [MonoModIgnore]
+        public extern void base_Added(Scene scene);
         public extern void orig_Added(Scene scene);
         public override void Added(Scene scene) {
             Level level = scene as Level;
@@ -46,7 +43,7 @@ namespace Celeste {
                 return;
             }
 
-            base.Added(scene);
+            base_Added(scene);
 
             if (levelFlags.Split(',').Any(flag => level.Session.GetLevelFlag(flag))) {
                 Position = end;

--- a/Celeste.Mod.mm/Patches/LevelEnter.cs
+++ b/Celeste.Mod.mm/Patches/LevelEnter.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections;
 
 namespace Celeste {
+    // LevelEnter has a private .ctor
     class patch_LevelEnter : Scene {
 
         /// <summary>

--- a/Celeste.Mod.mm/Patches/RotateSpinner.cs
+++ b/Celeste.Mod.mm/Patches/RotateSpinner.cs
@@ -13,7 +13,7 @@ namespace Celeste {
             [MonoModReplace]
             get => fixAngle ?
                 MathHelper.Lerp(MathHelper.Pi, -MathHelper.Pi, Easer(rotationPercent)) :
-                MathHelper.Lerp(4.712389f, -(float)Math.PI / 2f, Easer(rotationPercent));
+                MathHelper.Lerp(MathHelper.Pi + MathHelper.Pi / 2, -MathHelper.Pi / 2, Easer(rotationPercent));
         }
 
         private bool fixAngle;

--- a/Celeste.Mod.mm/Patches/RotateSpinner.cs
+++ b/Celeste.Mod.mm/Patches/RotateSpinner.cs
@@ -4,15 +4,18 @@
 using Microsoft.Xna.Framework;
 using Monocle;
 using MonoMod;
+using System;
 
 namespace Celeste {
     // : Entity because there's no original Awake method to hook, thus base.Awake must be Entity::Awake.
-    class patch_RotateSpinner : Entity {
+    class patch_RotateSpinner : RotateSpinner {
 
-        public float Angle =>
-            fixAngle ?
-            MathHelper.Lerp(MathHelper.Pi, -MathHelper.Pi, Easer(rotationPercent)) :
-            MathHelper.Lerp(4.712389f, -1.57079637f, Easer(rotationPercent));
+        public new float Angle {
+            [MonoModReplace]
+            get => fixAngle ?
+                MathHelper.Lerp(MathHelper.Pi, -MathHelper.Pi, Easer(rotationPercent)) :
+                MathHelper.Lerp(4.712389f, -(float)Math.PI / 2f, Easer(rotationPercent));
+        }
 
         private bool fixAngle;
 
@@ -24,7 +27,7 @@ namespace Celeste {
         private Vector2 startPosition;
 
         public patch_RotateSpinner(EntityData data, Vector2 offset)
-            : base(data.Position + offset) {
+            : base(data, offset) {
             // no-op. MonoMod ignores this - we only need this to make the compiler shut up.
         }
 

--- a/Celeste.Mod.mm/Patches/RotateSpinner.cs
+++ b/Celeste.Mod.mm/Patches/RotateSpinner.cs
@@ -7,7 +7,6 @@ using MonoMod;
 using System;
 
 namespace Celeste {
-    // : Entity because there's no original Awake method to hook, thus base.Awake must be Entity::Awake.
     class patch_RotateSpinner : RotateSpinner {
 
         public new float Angle {

--- a/Celeste.Mod.mm/Patches/StarJumpBlock.cs
+++ b/Celeste.Mod.mm/Patches/StarJumpBlock.cs
@@ -7,14 +7,16 @@ using MonoMod;
 using System.Collections.Generic;
 
 namespace Celeste {
-    // : Solid because base.Awake
-    class patch_StarJumpBlock : Solid {
+    class patch_StarJumpBlock : StarJumpBlock {
         private Level level;
 
         public patch_StarJumpBlock(Vector2 position, float width, float height, bool sinks) : base(position, width, height, sinks) {
             // no-op. MonoMod ignores this - we only need this to make the compiler shut up.
         }
 
+        [MonoModLinkTo("Celeste.Solid", "Awake")]
+        [MonoModIgnore]
+        public extern void base_Awake(Scene scene);
         public extern void orig_Awake(Scene scene);
         public override void Awake(Scene scene) {
             if ((scene as Level).Session.Area.GetLevelSet() == "Celeste") {
@@ -27,7 +29,7 @@ namespace Celeste {
 
             // TODO: Inner corner textures? Or keep them empty as-is?
 
-            base.Awake(scene);
+            base_Awake(scene);
 
             level = SceneAs<Level>();
 
@@ -177,6 +179,9 @@ namespace Celeste {
             }
         }
 
+        [MonoModLinkTo("Monocle.Entity", "Render")]
+        [MonoModIgnore]
+        public extern void base_Render();
         public extern void orig_Render();
         public override void Render() {
             if (SceneAs<Level>().Session.Area.GetLevelSet() == "Celeste") {
@@ -208,7 +213,7 @@ namespace Celeste {
                 );
             }
 
-            base.Render();
+            base_Render();
         }
 
         [MonoModIgnore]


### PR DESCRIPTION
- part of #351 

Standardizes use of `[MonoModLinkTo]` to call `base.` methods in patch classes, allowing those classes to extend their vanilla counterparts.

`patch_BackgroundTiles` was not changed because doing so would require changing how its constructor is handled.

Other changes:
- Streamlines the `BounceBlock` constructor from `.ctor` -> `orig_ctor` -> `.ctor` to `.ctor` -> `.ctor`
- Removes the unused `RotateSpinner.orig_get_Angle` method
