### PR TITLE
Add dialog key for start checkpoint

### DIFF
--- a/Celeste.Mod.mm/MonoModRules.cs
+++ b/Celeste.Mod.mm/MonoModRules.cs
@@ -1379,7 +1379,7 @@ namespace MonoMod {
         public static void PatchChapterPanelSwapRoutine(MethodDefinition method, CustomAttribute attrib) {
             MethodDefinition m_GetCheckpoints = method.DeclaringType.FindMethod("System.Collections.Generic.HashSet`1<System.String> _GetCheckpoints(Celeste.SaveData,Celeste.AreaKey)");
             FieldDefinition f_Area = method.DeclaringType.FindField("Area");
-            MethodDefinition m_GetCheckpointName = MonoModRule.Modder.FindType("Celeste.AreaData").Resolve().FindMethod("System.String GetCheckpointName(Celeste.AreaKey,System.String)");
+            MethodDefinition m_GetStartName = MonoModRule.Modder.FindType("Celeste.AreaData").Resolve().FindMethod("System.String GetStartName(Celeste.AreaKey)");
 
             // The gem collection routine is stored in a compiler-generated method.
             foreach (TypeDefinition nest in method.DeclaringType.NestedTypes) {
@@ -1396,13 +1396,12 @@ namespace MonoMod {
                 cursor.Next.Operand = m_GetCheckpoints;
 
                 cursor.GotoNext(instr => instr.MatchLdstr("overworld_start"));
-                // Emit before
+                cursor.Remove(); // Remove ldstr
+                cursor.Remove(); // Remove ldnull
+                // Load this.Area
                 cursor.Emit(OpCodes.Ldloc_1);
                 cursor.Emit(OpCodes.Ldfld, f_Area);
-                // Move after
-                cursor.Goto(cursor.Next, MoveType.After);
-                cursor.Remove(); // Remove ldnull
-                cursor.Next.Operand = m_GetCheckpointName;
+                cursor.Next.Operand = m_GetStartName;
             });
         }
 

--- a/Celeste.Mod.mm/Patches/AreaData.cs
+++ b/Celeste.Mod.mm/Patches/AreaData.cs
@@ -451,15 +451,15 @@ namespace Celeste {
             return 0;
         }
 
+        public static string GetStartName(AreaKey area) {
+            string start_key = $"{area.GetSID()}/{(char) ('A' + (int) area.Mode)}/start";
+                if (AreaData.Get(area).GetLevelSet() == "Celeste" || !Dialog.Has(start_key))
+                    return Dialog.Clean("overworld_start");
+                return Dialog.Clean(start_key);
+        }
+
         public static extern string orig_GetCheckpointName(AreaKey area, string level);
         public static new string GetCheckpointName(AreaKey area, string level) {
-            if (level == "overworld_start") {
-                string start_key = area.GetSID() + "/" + level;
-                if (AreaData.Get(area).GetLevelSet() == "Celeste" || !Dialog.Has(start_key))
-                    return Dialog.Clean(level);
-                return Dialog.Clean(start_key);
-            }
-
             int split = level?.IndexOf('|') ?? -1;
             if (split >= 0) {
                 area = Get(level.Substring(0, split))?.ToKey(area.Mode) ?? area;

--- a/Celeste.Mod.mm/Patches/AreaData.cs
+++ b/Celeste.Mod.mm/Patches/AreaData.cs
@@ -453,6 +453,13 @@ namespace Celeste {
 
         public static extern string orig_GetCheckpointName(AreaKey area, string level);
         public static new string GetCheckpointName(AreaKey area, string level) {
+            if (level == "overworld_start") {
+                string start_key = area.GetSID() + "/" + level;
+                if (AreaData.Get(area).GetLevelSet() == "Celeste" || !Dialog.Has(start_key))
+                    return Dialog.Clean(level);
+                return Dialog.Clean(start_key);
+            }
+
             int split = level?.IndexOf('|') ?? -1;
             if (split >= 0) {
                 area = Get(level.Substring(0, split))?.ToKey(area.Mode) ?? area;

--- a/Celeste.Mod.mm/Patches/AreaData.cs
+++ b/Celeste.Mod.mm/Patches/AreaData.cs
@@ -453,9 +453,9 @@ namespace Celeste {
 
         public static string GetStartName(AreaKey area) {
             string start_key = $"{area.GetSID()}/{(char) ('A' + (int) area.Mode)}/start";
-                if (AreaData.Get(area).GetLevelSet() == "Celeste" || !Dialog.Has(start_key))
-                    return Dialog.Clean("overworld_start");
-                return Dialog.Clean(start_key);
+            if (AreaData.Get(area).GetLevelSet() == "Celeste" || !Dialog.Has(start_key))
+                return Dialog.Clean("overworld_start");
+            return Dialog.Clean(start_key);
         }
 
         public static extern string orig_GetCheckpointName(AreaKey area, string level);


### PR DESCRIPTION
Format: `{SID}/{side}/start`

For a map `coloursofnoise/testmaps/mytestmap.bin`:
`coloursofnoise_testmaps_mytestmap_A_start=Start Checkpoint`

IL code change:
`Label = Dialog.Clean("overworld_start")` => `Label = AreaData.GetStartName(Area)`