### PR TITLE
Catch errors when looking up console commands

### DIFF
--- a/Celeste.Mod.mm/Patches/Monocle/Commands.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Commands.cs
@@ -42,6 +42,17 @@ namespace Monocle {
 
         private static readonly Lazy<bool> celesteTASInstalled = new Lazy<bool>(() => Everest.Modules.Any(module => module.Metadata?.Name == "CelesteTAS"));
 
+        private extern void orig_ProcessMethod(MethodInfo method);
+        private void ProcessMethod(MethodInfo method) {
+            try {
+                orig_ProcessMethod(method);
+            } catch (Exception e) {
+                // we probably met a method with some missing optional dependency, so just skip it.
+                Logger.Log(LogLevel.Warn, "commands", "Could not look for custom commands in method " + method.Name);
+                Logger.LogDetailed(e);
+            }
+        }
+
         [MonoModReplace] // Don't create orig_ method.
         internal void UpdateClosed() {
             if (!canOpen) {


### PR DESCRIPTION
This is a port of https://github.com/EverestAPI/CelesteCollabUtils2/blob/master/LobbyHelper.cs#L186-L196 from Collab Utils.

That try/catch is motivated by the fact that while going through every existing class, it might encounter one using types that aren't loaded, in case a mod has an optional dependency. In the case of Collab Utils, that is CelesteNet. The fact that there is a method taking a CelesteNet type in parameter (which isn't really avoidable when trying to register a CelesteNet event) makes `ProcessMethod` crash.