### PR TITLE
Calculate height of subheader for multiline text

### DIFF
--- a/Celeste.Mod.mm/Patches/TextMenu.cs
+++ b/Celeste.Mod.mm/Patches/TextMenu.cs
@@ -366,6 +366,10 @@ namespace Celeste {
                 ctor(label, true);
             }
 
+            [MonoModReplace]
+            public override float Height() {
+                return (Title.Length > 0 ? (ActiveFont.HeightOf(Title) * 0.6f) : 0f) + (TopPadding ? 48 : 0);
+            }
         }
 
         public class patch_Setting : Setting {


### PR DESCRIPTION
Code:
```cs
// CreateModMenuSectionHeader
menu.Add(new TextMenuExt.SubHeaderExt(Dialog.Clean("communalhelper_failedloadingdeps")) {
   TextColor = Color.OrangeRed,
   HeightExtra = 0f, // TODO: fix SubMenu height calculation for multi-line text
});
---
communalhelper_failedloadingdeps=Failed loading optional dependencies.
Send your log.txt to a CommunalHelper maintainer.
```

Before: 
![image](https://user-images.githubusercontent.com/53288101/151500221-85075578-a545-4daa-938c-34a4229d12df.png)

After:
![image](https://user-images.githubusercontent.com/53288101/151499884-5410eb59-f9c0-45be-9876-23953792f6ad.png)


Could potentially also be implemented for other TextMenu types (`Button`, `Option`, etc..), but I'd expect this would be the most common use-case.