### PR TITLE
Implement parsing Backdrop Tags as a comma separated list

### DIFF
--- a/Celeste.Mod.mm/MonoModRules.cs
+++ b/Celeste.Mod.mm/MonoModRules.cs
@@ -832,17 +832,21 @@ namespace MonoMod {
             cursor.Emit(OpCodes.Brtrue, branchCustomToSetup);
 
             // Allow multiple comma separated tags
-            OpCode argOpcode = OpCodes.Ldarg_1;
+            int matches = 0;
             while (cursor.TryGotoNext(MoveType.After, instr => instr.MatchLdstr("tag"), instr => instr.MatchCallvirt("Celeste.BinaryPacker/Element", "HasAttr"))) {
                 cursor.Index++; // move past the branch
                 cursor.RemoveRange(8); // remove old code
 
-                cursor.Emit(argOpcode); // child
+                cursor.Emit(matches switch {
+                    0 => OpCodes.Ldarg_1, // child
+                    1 => OpCodes.Ldarg_2, // above
+                    _ => throw new Exception($"Incorrect number of matches for HasAttr(\"tag\"): {matches}")
+                }); // child
                 cursor.Emit(OpCodes.Ldloc_0); // backdrop
 
                 cursor.Emit(OpCodes.Call, m_ParseTags);
 
-                argOpcode = OpCodes.Ldarg_2;
+                matches++;
             }
         }
 

--- a/Celeste.Mod.mm/MonoModRules.cs
+++ b/Celeste.Mod.mm/MonoModRules.cs
@@ -840,7 +840,7 @@ namespace MonoMod {
                 cursor.Emit(matches switch {
                     0 => OpCodes.Ldarg_1, // child
                     1 => OpCodes.Ldarg_2, // above
-                    _ => throw new Exception($"Too many of matches for HasAttr(\"tag\"): {matches}")
+                    _ => throw new Exception($"Too many matches for HasAttr(\"tag\"): {matches}")
                 }); // child
                 cursor.Emit(OpCodes.Ldloc_0); // backdrop
 

--- a/Celeste.Mod.mm/MonoModRules.cs
+++ b/Celeste.Mod.mm/MonoModRules.cs
@@ -811,6 +811,7 @@ namespace MonoMod {
 
         public static void PatchBackdropParser(ILContext context, CustomAttribute attrib) {
             MethodDefinition m_LoadCustomBackdrop = context.Method.DeclaringType.FindMethod("Celeste.Backdrop LoadCustomBackdrop(Celeste.BinaryPacker/Element,Celeste.BinaryPacker/Element,Celeste.MapData)");
+            MethodDefinition m_ParseTags = context.Method.DeclaringType.FindMethod("System.Void ParseTags(Celeste.BinaryPacker/Element,Celeste.Backdrop)");
 
             ILCursor cursor = new ILCursor(context);
             // Remove soon-to-be-unneeded instructions
@@ -829,6 +830,20 @@ namespace MonoMod {
             cursor.FindNext(out ILCursor[] cursors, instr => instr.MatchLdstr("tag"));
             Instruction branchCustomToSetup = cursors[0].Prev;
             cursor.Emit(OpCodes.Brtrue, branchCustomToSetup);
+
+            // Allow multiple comma separated tags
+            OpCode argOpcode = OpCodes.Ldarg_1;
+            while (cursor.TryGotoNext(MoveType.After, instr => instr.MatchLdstr("tag"), instr => instr.MatchCallvirt("Celeste.BinaryPacker/Element", "HasAttr"))) {
+                cursor.Index++; // move past the branch
+                cursor.RemoveRange(8); // remove old code
+
+                cursor.Emit(argOpcode); // child
+                cursor.Emit(OpCodes.Ldloc_0); // backdrop
+
+                cursor.Emit(OpCodes.Call, m_ParseTags);
+
+                argOpcode = OpCodes.Ldarg_2;
+            }
         }
 
         public static void PatchLevelCanPause(ILContext il, CustomAttribute attrib) {

--- a/Celeste.Mod.mm/MonoModRules.cs
+++ b/Celeste.Mod.mm/MonoModRules.cs
@@ -840,13 +840,16 @@ namespace MonoMod {
                 cursor.Emit(matches switch {
                     0 => OpCodes.Ldarg_1, // child
                     1 => OpCodes.Ldarg_2, // above
-                    _ => throw new Exception($"Incorrect number of matches for HasAttr(\"tag\"): {matches}")
+                    _ => throw new Exception($"Too many of matches for HasAttr(\"tag\"): {matches}")
                 }); // child
                 cursor.Emit(OpCodes.Ldloc_0); // backdrop
 
                 cursor.Emit(OpCodes.Call, m_ParseTags);
 
                 matches++;
+            }
+            if (matches != 2) {
+                throw new Exception($"Too few matches for HasAttr(\"tag\"): {matches}");
             }
         }
 

--- a/Celeste.Mod.mm/Patches/MapData.cs
+++ b/Celeste.Mod.mm/Patches/MapData.cs
@@ -208,6 +208,11 @@ namespace Celeste {
             return null;
         }
 
+        public static void ParseTags(BinaryPacker.Element child, Backdrop backdrop) {
+            foreach (string tag in child.Attr("tag").Split(',')) {
+                backdrop.Tags.Add(tag);
+            }
+        }
     }
     public static class MapDataExt {
 


### PR DESCRIPTION
Closes #417 
Parses Backdrop Tags as a comma separated list. Since `Backdrop.Tags` is `HashSet<string>` already, this is really simple to implement. This is really beneficial for any sort of advanced backdrop manipulation, like what Windowpane Helper does (in fact, that mod manually implements this exact change)

This is the change in `MapData.ParseBackdrop`:
```cs
if (child.HasAttr("tag")) {
    //backdrop.Tags.Add(child.Attr("tag"));
    MapData.ParseTags(child, backdrop);
}
if (above != null && above.HasAttr("tag")) {
    //backdrop.Tags.Add(above.Attr("tag"));
    MapData.ParseTags(above, backdrop);
}
```