### PR TITLE
Added extra mod blacklist commandline argument

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Content.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Content.cs
@@ -321,9 +321,7 @@ namespace Celeste.Mod {
             for (int i = 0; i < files.Length; i++) {
                 string file = files[i];
                 string name = file.Substring(Path.Length + 1);
-                if (!file.EndsWith(".bin") || Everest.Loader._Blacklist.Contains(name))
-                    continue;
-                if (Everest.Loader._Whitelist != null && !Everest.Loader._Whitelist.Contains(name))
+                if (!file.EndsWith(".bin") || !Everest.Loader.ShouldLoadFile(name))
                     continue;
                 Add("Maps/" + file.Substring(Path.Length + 1), new MapBinsInModsModAsset(this, file));
             }

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
@@ -36,13 +36,13 @@ namespace Celeste.Mod {
             /// <summary>
             /// The path to the Everest /Mods/temperalblacklist.txt file.
             /// </summary>
-            public static string PathTemperalBlacklist { get; internal set; }
-            internal static string NameTemperalBlacklist;
-            internal static List<string> _TemperalBlacklist;
+            public static string PathTemporaryBlacklist { get; internal set; }
+            internal static string NameTemporaryBlacklist;
+            internal static List<string> _TemporaryBlacklist;
             /// <summary>
             /// The currently loaded mod whitelist.
             /// </summary>
-            public static ReadOnlyCollection<string> TemperalBlacklist => _TemperalBlacklist?.AsReadOnly();
+            public static ReadOnlyCollection<string> TemporaryBlacklist => _TemporaryBlacklist?.AsReadOnly();
             /// <summary>
             /// The path to the Everest /Mods/whitelist.txt file.
             /// </summary>
@@ -120,7 +120,7 @@ namespace Celeste.Mod {
             public static bool AutoLoadNewMods { get; internal set; }
 
             public static bool ShouldLoadFile(string file)
-                => !Blacklist.Contains(file) && (TemperalBlacklist == null || !TemperalBlacklist.Contains(file)) && (Whitelist == null || Whitelist.Contains(file));
+                => !Blacklist.Contains(file) && (TemporaryBlacklist == null || !TemporaryBlacklist.Contains(file)) && (Whitelist == null || Whitelist.Contains(file));
 
             internal static void LoadAuto() {
                 Directory.CreateDirectory(PathMods = Path.Combine(PathEverest, "Mods"));
@@ -136,10 +136,10 @@ namespace Celeste.Mod {
                         writer.WriteLine("SomeMod.zip");
                     }
                 }
-                if (!string.IsNullOrEmpty(NameTemperalBlacklist)) {
-                    PathTemperalBlacklist = Path.Combine(PathMods, NameTemperalBlacklist);
-                    if (File.Exists(PathTemperalBlacklist)) {
-                        _TemperalBlacklist = File.ReadAllLines(PathTemperalBlacklist).Select(l => (l.StartsWith("#") ? "" : l).Trim()).ToList();
+                if (!string.IsNullOrEmpty(NameTemporaryBlacklist)) {
+                    PathTemporaryBlacklist = Path.Combine(PathMods, NameTemporaryBlacklist);
+                    if (File.Exists(PathTemporaryBlacklist)) {
+                        _TemporaryBlacklist = File.ReadAllLines(PathTemporaryBlacklist).Select(l => (l.StartsWith("#") ? "" : l).Trim()).ToList();
                     }
                 }
 

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
@@ -120,7 +120,7 @@ namespace Celeste.Mod {
             public static bool AutoLoadNewMods { get; internal set; }
 
             public static bool ShouldLoadFile(string file)
-                => !Blacklist.Contains(file) && !TemperalBlacklist.Contains(file) && (Whitelist == null || Whitelist.Contains(file));
+                => !Blacklist.Contains(file) && (TemperalBlacklist == null || !TemperalBlacklist.Contains(file)) && (Whitelist == null || Whitelist.Contains(file));
 
             internal static void LoadAuto() {
                 Directory.CreateDirectory(PathMods = Path.Combine(PathEverest, "Mods"));

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
@@ -34,7 +34,7 @@ namespace Celeste.Mod {
             public static ReadOnlyCollection<string> Blacklist => _Blacklist?.AsReadOnly();
 
             /// <summary>
-            /// The path to the Everest /Mods/temperalblacklist.txt file.
+            /// The path to the Everest /Mods/temporaryblacklist.txt file.
             /// </summary>
             public static string PathTemporaryBlacklist { get; internal set; }
             internal static string NameTemporaryBlacklist;

--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -303,7 +303,7 @@ namespace Celeste.Mod {
                     Loader.NameWhitelist = queue.Dequeue();
 
                 else if (arg == "--blacklist" && queue.Count >= 1)
-                    Loader.NameTemperalBlacklist = queue.Dequeue();
+                    Loader.NameTemporaryBlacklist = queue.Dequeue();
 
             }
         }

--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -302,6 +302,9 @@ namespace Celeste.Mod {
                 else if (arg == "--whitelist" && queue.Count >= 1)
                     Loader.NameWhitelist = queue.Dequeue();
 
+                else if (arg == "--blacklist" && queue.Count >= 1)
+                    Loader.NameTemperalBlacklist = queue.Dequeue();
+
             }
         }
 

--- a/Celeste.Mod.mm/Mod/UI/OuiDependencyDownloader.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiDependencyDownloader.cs
@@ -196,9 +196,7 @@ namespace Celeste.Mod.UI {
                             LogLine(string.Format(Dialog.Get("DEPENDENCYDOWNLOADER_MOD_UNBLACKLIST"), modFilename));
 
                             // remove the mod from the loaded blacklist
-                            while (Everest.Loader._Blacklist.Contains(modFilename)) {
-                                Everest.Loader._Blacklist.Remove(modFilename);
-                            }
+                            Everest.Loader._Blacklist.RemoveAll(item => item == modFilename);
 
                             // hot load the mod
                             if (modFilename.EndsWith(".zip")) {

--- a/Celeste.Mod.mm/Mod/UI/OuiModToggler.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiModToggler.cs
@@ -191,8 +191,8 @@ namespace Celeste.Mod.UI {
                     // remove the "loading..." message
                     menu.Remove(loading);
 
-                    // if there is a whitelist or temperal blacklist, warn the user that it will break those settings.
-                    if (Everest.Loader.Whitelist != null || Everest.Loader.TemperalBlacklist != null) {
+                    // if there is a whitelist or temporary blacklist, warn the user that it will break those settings.
+                    if (Everest.Loader.Whitelist != null || Everest.Loader.TemporaryBlacklist != null) {
                         menu.Add(restartMessage1 = new TextMenuExt.SubHeaderExt(Dialog.Clean("MODOPTIONS_MODTOGGLE_WHITELISTWARN")) { TextColor = Color.OrangeRed });
                     }
 
@@ -202,7 +202,7 @@ namespace Celeste.Mod.UI {
                     menu.Add(new TextMenuExt.SubHeaderExt(Dialog.Clean("MODOPTIONS_MODTOGGLE_MESSAGE_3")) { HeightExtra = 20f, TextColor = Color.Goldenrod });
 
                     // reduce spacing between the whitelist warning and the blacklist overwrite warning
-                    if (Everest.Loader.Whitelist != null || Everest.Loader.TemperalBlacklist != null) {
+                    if (Everest.Loader.Whitelist != null || Everest.Loader.TemporaryBlacklist != null) {
                         restartMessage1.HeightExtra = 30f;
                     }
 

--- a/Celeste.Mod.mm/Mod/UI/OuiModToggler.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiModToggler.cs
@@ -191,8 +191,8 @@ namespace Celeste.Mod.UI {
                     // remove the "loading..." message
                     menu.Remove(loading);
 
-                    // if there is a whitelist, warn the user that it will break those settings.
-                    if (Everest.Loader.Whitelist != null) {
+                    // if there is a whitelist or temperal blacklist, warn the user that it will break those settings.
+                    if (Everest.Loader.Whitelist != null || Everest.Loader.TemperalBlacklist != null) {
                         menu.Add(restartMessage1 = new TextMenuExt.SubHeaderExt(Dialog.Clean("MODOPTIONS_MODTOGGLE_WHITELISTWARN")) { TextColor = Color.OrangeRed });
                     }
 
@@ -202,7 +202,7 @@ namespace Celeste.Mod.UI {
                     menu.Add(new TextMenuExt.SubHeaderExt(Dialog.Clean("MODOPTIONS_MODTOGGLE_MESSAGE_3")) { HeightExtra = 20f, TextColor = Color.Goldenrod });
 
                     // reduce spacing between the whitelist warning and the blacklist overwrite warning
-                    if (Everest.Loader.Whitelist != null) {
+                    if (Everest.Loader.Whitelist != null || Everest.Loader.TemperalBlacklist != null) {
                         restartMessage1.HeightExtra = 30f;
                     }
 
@@ -315,7 +315,7 @@ namespace Celeste.Mod.UI {
         private void addFileToMenu(TextMenu menu, string file) {
             TextMenu.OnOff option;
 
-            bool enabled = !Everest.Loader._Blacklist.Contains(file);
+            bool enabled = !Everest.Loader.Blacklist.Contains(file);
             menu.Add(option = (TextMenu.OnOff) new TextMenu.OnOff(file.Length > 40 ? file.Substring(0, 40) + "..." : file, enabled)
                 .Change(b => {
                     if (b) {


### PR DESCRIPTION
Allow for setting an extra blacklist file with commandline argument `--blacklist <filename>.`
It works similarly to the current whitelist file as it is ignored when toggeling mods in-game. 
Maybe should change the dialog `MODOPTIONS_MODTOGGLE_WHITELISTWARN` since this dialog is now also shown when an extra blacklist is active.