### PR TITLE
Drastically improve GenerateModAssemblyResolver performance

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
@@ -493,7 +493,7 @@ namespace Celeste.Mod {
                                 if (entryName == meta.DLL)
                                     using (MemoryStream stream = entry.ExtractStream())
                                         asm = Relinker.GetRelinkedAssembly(meta, Path.GetFileNameWithoutExtension(meta.DLL), stream);
-                                else if (entryName.StartsWith(dllDirectory)) // immediately load any other libraries to avoid reading zip files over and over again later
+                                else if (Path.GetDirectoryName(entryName) == dllDirectory) // immediately load any other libraries to avoid reading zip files over and over again later
                                     using (MemoryStream stream = entry.ExtractStream())
                                         Relinker.GetRelinkedAssembly(meta, Path.GetFileNameWithoutExtension(entryName), stream);
                             }

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
@@ -484,6 +484,7 @@ namespace Celeste.Mod {
                 Assembly asm = null;
                 if (!string.IsNullOrEmpty(meta.PathArchive)) {
                     bool returnEarly = false;
+                    string dllDirectory = Path.GetDirectoryName(meta.DLL);
                     using (ZipFile zip = new ZipFile(meta.PathArchive)) {
                         foreach (ZipEntry entry in zip.Entries) {
                             string entryName = entry.FileName.Replace('\\', '/');
@@ -492,7 +493,7 @@ namespace Celeste.Mod {
                                 using MemoryStream stream = entry.ExtractStream();
                                 if (entryName == meta.DLL)
                                     asm = Relinker.GetRelinkedAssembly(meta, Path.GetFileNameWithoutExtension(meta.DLL), stream);
-                                else // immediately load any other libraries to avoid reading zip files over and over again later
+                                else if (entryName.StartsWith(dllDirectory)) // immediately load any other libraries to avoid reading zip files over and over again later
                                     Relinker.GetRelinkedAssembly(meta, Path.GetFileNameWithoutExtension(entryName), stream);
                             }
 

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
@@ -745,6 +745,10 @@ namespace Celeste.Mod {
 
             private static ResolveEventHandler GenerateModAssemblyResolver(EverestModuleMetadata meta)
                 => (sender, args) => {
+                    EverestModule module = _Modules.FirstOrDefault(module => module.Metadata.Name == meta.Name);
+                    if (module is not null)
+                        return module.GetType().Assembly;
+
                     AssemblyName name = args?.Name == null ? null : new AssemblyName(args.Name);
                     if (string.IsNullOrEmpty(name?.Name))
                         return null;


### PR DESCRIPTION
I just looked into loading times, and realized that the Tracker takes 26 seconds to initialize for me with quite a few mods installed. Weirdly, `FakeAssembly.GetTypesSafe` spent tons of time reading zip files to resolve mod assemblies for no reason:
![image](https://user-images.githubusercontent.com/50085307/157344073-9d108458-a375-42bb-8865-369ed1b83037.png)

Furthermore, I had lag issues when opening Collab Utils 2 Chapter Panels, and it turns out it was caused by this exact same function.

[Explanation of changes](https://github.com/EverestAPI/Everest/pull/424#issuecomment-1062773514)