### PR TITLE
Fix crash when exiting feather state while inside a solid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -252,3 +252,6 @@ result
 
 # Olympus temporary build files
 tmp-olympus/
+
+# JetBrains Rider files
+.idea/

--- a/Celeste.Mod.mm/Patches/Player.cs
+++ b/Celeste.Mod.mm/Patches/Player.cs
@@ -201,6 +201,10 @@ namespace Celeste {
         [MonoModIgnore]
         [PatchPlayerBeforeUpTransition]
         public new extern void BeforeUpTransition();
+
+        [MonoModIgnore]
+        [PatchPlayerStarFlyReturnToNormalHitbox]
+        private extern void StarFlyReturnToNormalHitbox();
     }
     public static class PlayerExt {
 


### PR DESCRIPTION
When the player exits the StStarFly (feather) state while inside a solid, the vanilla game deliberately throws an exception in the Player.StarFlyReturnToNormalHitbox() method, crashing the game. This PR replaces that exception throw with killing the player, which is the expected behavior for ending up inside a solid.

To test: place a solid two tiles above the ground and a feather under it, then jump into the feather while crouched, causing the player to uncrouch into the ceiling. When the feather ends, the game will now kill the player instead of crashing.