### PR TITLE
Fix cutscenes not ending Chapter timer on enter/talk if set to end level

### DIFF
--- a/Celeste.Mod.mm/Mod/Entities/CustomNPC.cs
+++ b/Celeste.Mod.mm/Mod/Entities/CustomNPC.cs
@@ -114,6 +114,9 @@ namespace Celeste.Mod.Entities {
             if (onlyOnce && (dialogs.Length == 1 || Session.GetCounter(id + "DialogCounter") > dialogs.Length - 2)) {
                 (Scene as Level).Session.SetFlag("DoNotTalk" + id, true); // Sets flag to not load
             }
+            if (endLevel) {
+                (Scene as Level).RegisterAreaComplete();
+            }
             player.StateMachine.State = Player.StDummy;
             OnStart?.Invoke(Session.GetCounter(id + "DialogCounter"));
             Level.StartCutscene(OnTalkEnd);

--- a/Celeste.Mod.mm/Mod/Entities/DialogCutscene.cs
+++ b/Celeste.Mod.mm/Mod/Entities/DialogCutscene.cs
@@ -15,6 +15,9 @@ namespace Celeste.Mod.Entities {
         }
 
         public override void OnBegin(Level level) {
+            if (endLevel) {
+                level.RegisterAreaComplete();
+            }
             Add(new Coroutine(Cutscene(level)));
         }
 


### PR DESCRIPTION
Dialog Cutscenes and Custom NPCs implemented by Everest for use in custom maps were not ending the Chapter timer on entering the trigger/talking to the NPC as you'd expect from cutscenes that end levels (reported by me [here](https://discord.com/channels/403698615446536203/429775320720211968/958641030268321822), probably should've used github issues oops). 
This PR rectifies that by calling RegisterAreaComplete in OnBegin/OnTalk if endLevel is set to true, the same method used by all vanilla level-end cutscenes. 

To test: setup a map with a Dialog Cutscene/Custom NPC that has End Level ticked, turn on Chapter timer, interact with the trigger/NPC. The timer should now stop and turn green/gold (or remain grey if debug features were used), instead of continuing to run and only ending if all the dialogue is cleared.
Tested myself locally:
- Before: https://youtu.be/yBBdXunmqw0
- Fixed: https://youtu.be/4u5TppWkyh8

This pretty much only affects custom map speedrunning, but I'd hope that me submitting this PR is indicative of this being okay 😅 there are no maps on speedrun.com that would be affected by this change, and even if there were, this would only make their runs faster (even an immediate cutscene skip with the old behaviour would still lose time on the fade to black) and more consistent with expected vanilla behaviour, so no qualms on that front.