### PR TITLE
Alter whitelist behaviour to override blacklist (in some or all cases)

### DIFF
--- a/Celeste.Mod.mm/Mod/Core/CoreModuleSettings.cs
+++ b/Celeste.Mod.mm/Mod/Core/CoreModuleSettings.cs
@@ -206,6 +206,10 @@ namespace Celeste.Mod.Core {
         [SettingIgnore] // TODO: Show as advanced setting.
         public bool? SaveDataFlush { get; set; } = null;
 
+        [SettingInGame(false)]
+        [SettingIgnore] // TODO: Show as advanced setting.
+        public bool? WhitelistFullOverride { get; set; } = null;
+
         public string InputGui { get; set; } = "";
 
         private string _MainMenuMode = "";

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
@@ -40,9 +40,10 @@ namespace Celeste.Mod {
             internal static string NameTemporaryBlacklist;
             internal static List<string> _TemporaryBlacklist;
             /// <summary>
-            /// The currently loaded mod whitelist.
+            /// The currently loaded mod temporary blacklist.
             /// </summary>
             public static ReadOnlyCollection<string> TemporaryBlacklist => _TemporaryBlacklist?.AsReadOnly();
+
             /// <summary>
             /// The path to the Everest /Mods/whitelist.txt file.
             /// </summary>
@@ -119,8 +120,13 @@ namespace Celeste.Mod {
 
             public static bool AutoLoadNewMods { get; internal set; }
 
-            public static bool ShouldLoadFile(string file)
-                => !Blacklist.Contains(file) && (TemporaryBlacklist == null || !TemporaryBlacklist.Contains(file)) && (Whitelist == null || Whitelist.Contains(file));
+            public static bool ShouldLoadFile(string file) {
+                if (CoreModule.Settings.WhitelistFullOverride ?? false) {
+                    return Whitelist != null ? Whitelist.Contains(file) : (!Blacklist.Contains(file) && (TemporaryBlacklist == null || !TemporaryBlacklist.Contains(file)));
+                } else {
+                    return (Whitelist != null && Whitelist.Contains(file)) || (!Blacklist.Contains(file) && (TemporaryBlacklist == null || !TemporaryBlacklist.Contains(file)));
+                }
+            }
 
             internal static void LoadAuto() {
                 Directory.CreateDirectory(PathMods = Path.Combine(PathEverest, "Mods"));


### PR DESCRIPTION
Previously, if a mod was disabled in the base blacklist (or temporary blacklist I guess), then even if a provided whitelist explicitly allowed it to load, `ShouldLoadFile()` still returned false because it had to be enabled in both the blacklist _and_ whitelist in order for it to return true. From a brief discussion (plus [this comment](https://github.com/EverestAPI/Everest/issues/320#issuecomment-890322061) and other mentions of it on Discord), it was agreed that this didn't align with expectations for general whitelist behaviour and for Everest in particular (since you need to go out of your way to create a whitelist txt file and enable it via launch args). So this PR alters the loading behaviour to always enable a mod if it is present in a given whitelist.

This also adds an "advanced" setting (i.e. only accessible via `modsettings-Everest.celeste`) to override the blacklist if it enables a particular mod, but that mod is implicitly disabled in a given whitelist (i.e. not present in the file). Basically if a whitelist is provided under this setting, ignore the blacklist(s) entirely, and only use the whitelist to determine what mods should load.
Consensus wasn't as clear on whether this extension of the whitelist behaviour from the first change was ideal, so implementing it via a setting seemed like the most reasonable option. I've defaulted it to false for now so the full override is opt-in, but that should(?) easily be changed if opinions change.

Also cleaned up comments/whitespace at the beginning of the file.