### PR TITLE
Fix tile entity SoundIndex issues

### DIFF
--- a/Celeste.Mod.mm/Patches/Autotiler.cs
+++ b/Celeste.Mod.mm/Patches/Autotiler.cs
@@ -69,8 +69,8 @@ namespace Celeste {
                 ReadIntoCustomTemplate(data, tileset, xml);
             }
 
-            if (!SurfaceIndex.TileToIndex.ContainsKey(xml.AttrChar("id"))) {
-                SurfaceIndex.TileToIndex[xml.AttrChar("id")] = xml.HasAttr("sound") ? xml.AttrInt("sound") : 8; // '8' as fallback instead of '0' to match vanilla's default index
+            if (!SurfaceIndex.TileToIndex.ContainsKey(xml.AttrChar("id")) || xml.AttrChar("id") == 'o') { // Backwards-compat: some existing mods (e.g. Into the Jungle) use 'o' and overwrite its sound
+                SurfaceIndex.TileToIndex[xml.AttrChar("id")] = xml.HasAttr("sound") ? xml.AttrInt("sound") : 8; // 8 as fallback instead of 0 to match vanilla's default index
             }
 
             if (xml.HasAttr("debris"))

--- a/Celeste.Mod.mm/Patches/Autotiler.cs
+++ b/Celeste.Mod.mm/Patches/Autotiler.cs
@@ -69,8 +69,9 @@ namespace Celeste {
                 ReadIntoCustomTemplate(data, tileset, xml);
             }
 
-            if (xml.HasAttr("sound"))
-                SurfaceIndex.TileToIndex[xml.AttrChar("id")] = xml.AttrInt("sound");
+            if (!SurfaceIndex.TileToIndex.ContainsKey(xml.AttrChar("id"))) {
+                SurfaceIndex.TileToIndex[xml.AttrChar("id")] = xml.HasAttr("sound") ? xml.AttrInt("sound") : 8; // '8' as fallback instead of '0' to match vanilla's default index
+            }
 
             if (xml.HasAttr("debris"))
                 data.Debris = xml.Attr("debris");

--- a/Celeste.Mod.mm/Patches/IntroCrusher.cs
+++ b/Celeste.Mod.mm/Patches/IntroCrusher.cs
@@ -26,6 +26,7 @@ namespace Celeste {
             levelFlags = data.Attr("flags");
 
             string tiletype = data.Attr("tiletype");
+            SurfaceSoundIndex = SurfaceIndex.TileToIndex[tiletype[0]];
             if (!string.IsNullOrEmpty(tiletype)) {
                 Remove(tilegrid);
                 Add(tilegrid = GFX.FGAutotiler.GenerateBox(tiletype[0], data.Width / 8, data.Height / 8).TileGrid);


### PR DESCRIPTION
Closes #311 

Went with `8` (in FMOD this is the `brick` sound) as the fallback SurfaceIndex instead of `0` (no sound) since that seems to be vanilla's default index, and colours and I agreed that it was appropriate to match that.

Needed the `SurfaceIndex.TileToIndex.ContainsKey` check to avoid overwriting the hardcoded vanilla values, as I think the vast majority of existing maps include the vanilla tileset definitions in their XMLs (since the recommended practice is to copy-paste the vanilla ForegroundTiles.xml into your mod) and vanilla tilesets don't define a `sound` attribute. 
Wasn't sure if there was a faster or cleaner way to do this - didn't have access to `TryAdd`, didn't want to use `Add` for fear of some epic exception being thrown, and couldn't find anything else that would easily slot in here. Let me know if there is.