### PR TITLE
Add lightOcclude property to DecalRegistry

### DIFF
--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistry.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistry.cs
@@ -140,6 +140,14 @@ namespace Celeste.Mod {
                 int endFade = attrs["endFade"] != null ? int.Parse(attrs["endFade"].Value) : 24;
                 decal.Add(new VertexLight(offset, color, alpha, startFade, endFade));
             }},
+            { "lightOcclude", delegate(Decal decal, XmlAttributeCollection attrs) {
+                int x = attrs["x"] != null ? int.Parse(attrs["x"].Value) : 0;
+                int y = attrs["y"] != null ? int.Parse(attrs["y"].Value) : 0;
+                int width = attrs["width"] != null ? int.Parse(attrs["width"].Value) : 16;
+                int height = attrs["height"] != null ? int.Parse(attrs["height"].Value) : 16;
+                float alpha = attrs["alpha"] != null ? float.Parse(attrs["alpha"].Value) : 1f;
+                decal.Add(new LightOcclude(new Rectangle(x, y, width, height), alpha));
+            }},
         };
 
         public static Dictionary<string, DecalInfo> RegisteredDecals = new Dictionary<string, DecalInfo>();


### PR DESCRIPTION
Closes #291 

LightOcclude already accounts for the decal/entity's position when setting its bounds if you give it a Rectangle, so didn't need to do it when initially setting the Rectangle's dimensions. Can confirm that the bounds of the occluder will line up if the same values for e.g. a `solid` property's dimensions are used, which should satisfy the primary use-case expressed in the request.

I will update the [documentation](https://github.com/EverestAPI/Resources/wiki/Decal-Registry) with this new property and its attributes when this gets merged (feel free to yell at me if I forget)