### PR TITLE
Add Logging for missing CompleteScreen texture

### DIFF
--- a/Celeste.Mod.mm/Patches/CompleteRenderer.cs
+++ b/Celeste.Mod.mm/Patches/CompleteRenderer.cs
@@ -1,6 +1,7 @@
 #pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
 
 
+using Celeste.Mod;
 using Celeste.Mod.Meta;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
@@ -109,6 +110,7 @@ namespace Celeste {
                     if (atlas.Has(img)) {
                         Images.Add(atlas[img]);
                     } else {
+                        Logger.Log(LogLevel.Warn, "Atlas", $"Requested CompleteScreen texture that does not exist: {atlas.GetDataPath().Substring(17)}/{img}");
                         Images.Add(null);
                     }
                 }


### PR DESCRIPTION
Closes #347 

Example output:
- meta.yaml:
```
CompleteScreen:
    Atlas: "Endscreens/caeyo_test"
    Start: [ 0.0, 0.0 ]
    Center: [ 0.0, 0.0 ]
    Offset: [ 0.0, 0.0 ]
    Layers:
      - Type: "layer"
        Images: [ "static" ]
        Position: [ 0.0, 0.0 ]
        Scroll: [ 0.0 ]
```
- Log line:

```
(05/21/2022 16:59:29) [Everest] [Warn] [Atlas] Requested CompleteScreen texture that does not exist: Endscreens/caeyo_test/static   
```

The `Substring(17)` is to remove the `Graphics\Atlases` part of the path that gets returned - if this can cause an issue that I'm not aware of then let me know and I can remove it.