### PR TITLE
Make "solid" and "staticMover" Decal Registry attributes compatible

### DIFF
--- a/Celeste.Mod.mm/MonoModRules.cs
+++ b/Celeste.Mod.mm/MonoModRules.cs
@@ -2559,13 +2559,18 @@ namespace MonoMod {
                 break;
             }
 
-            // Goal is to flip these two commands by swapping the Move call to after the Disable call.
-            // this.MoveStaticMovers(this.startPosition - this.Position);
-            // this.DisableStaticMovers();
+            // From:
+            //     this.MoveStaticMovers(this.startPosition - this.Position);
+            //     this.DisableStaticMovers();
+            // To:
+            //     this.DisableStaticMovers();
+            //     this.MoveStaticMovers(this.startPosition - this.Position);
             ILCursor cursor = new ILCursor(new ILContext(method));
             cursor.GotoNext(MoveType.Before, instr => instr.MatchCallvirt("Celeste.Platform", "MoveStaticMovers"));
             cursor.Remove();
             cursor.GotoNext(MoveType.After, instr => instr.MatchCallvirt("Celeste.Platform", "DisableStaticMovers"));
+
+            // The argument order happens to let us emit the two function calls adjacent to each other
             cursor.Emit(OpCodes.Callvirt, m_Platform_MoveStaticMovers);
         }
 

--- a/Celeste.Mod.mm/MonoModRules.cs
+++ b/Celeste.Mod.mm/MonoModRules.cs
@@ -2563,8 +2563,9 @@ namespace MonoMod {
             //     this.MoveStaticMovers(this.startPosition - this.Position);
             //     this.DisableStaticMovers();
             // To:
+            //     Vector2 amount = this.startPosition - this.Position;
             //     this.DisableStaticMovers();
-            //     this.MoveStaticMovers(this.startPosition - this.Position);
+            //     this.MoveStaticMovers(amount);
             ILCursor cursor = new ILCursor(new ILContext(method));
             cursor.GotoNext(MoveType.Before, instr => instr.MatchCallvirt("Celeste.Platform", "MoveStaticMovers"));
             cursor.Remove();

--- a/Celeste.Mod.mm/Patches/Decal.cs
+++ b/Celeste.Mod.mm/Patches/Decal.cs
@@ -118,10 +118,12 @@ namespace Celeste {
                 },
                 OnMove = v => {
                     Position += v;
-                    if (staticMover.Platform != null) 
-                        solid.LiftSpeed = staticMover.Platform.LiftSpeed;
-                    solid?.MoveHExact((int) v.X);
-                    solid?.MoveVExact((int) v.Y);
+                    if (solid != null) {
+                        if (staticMover.Platform != null)
+                            solid.LiftSpeed = staticMover.Platform.LiftSpeed;
+                        solid.MoveHExact((int) v.X);
+                        solid.MoveVExact((int) v.Y);
+                    }
                 },
                 OnShake = v => { Position += v; },
             };

--- a/Celeste.Mod.mm/Patches/Decal.cs
+++ b/Celeste.Mod.mm/Patches/Decal.cs
@@ -104,8 +104,7 @@ namespace Celeste {
                 SolidChecker = s => s.CollideRect(new Rectangle((int) X + x, (int) Y + y, w, h)),
                 OnDestroy = () => {
                     RemoveSelf();
-                    if (solid != null) 
-                        solid.RemoveSelf(); 
+                    solid?.RemoveSelf();
                 },
                 OnDisable = () => {
                     Active = Visible = Collidable = false;
@@ -119,12 +118,10 @@ namespace Celeste {
                 },
                 OnMove = v => {
                     Position += v;
-                    if (solid != null) {
-                        if (staticMover.Platform != null) 
-                            solid.LiftSpeed = staticMover.Platform.LiftSpeed;
-                        solid.MoveHExact((int) v.X);
-                        solid.MoveVExact((int) v.Y);
-                    }
+                    if (staticMover.Platform != null) 
+                        solid.LiftSpeed = staticMover.Platform.LiftSpeed;
+                    solid?.MoveHExact((int) v.X);
+                    solid?.MoveVExact((int) v.Y);
                 },
                 OnShake = v => { Position += v; },
             };

--- a/Celeste.Mod.mm/Patches/Decal.cs
+++ b/Celeste.Mod.mm/Patches/Decal.cs
@@ -27,6 +27,9 @@ namespace Celeste {
         private float hideRange;
         private float showRange;
 
+        private Solid solid;
+        private StaticMover staticMover;
+
         public patch_Decal(string texture, Vector2 position, Vector2 scale, int depth)
             : base(texture, position, scale, depth) {
             // no-op. MonoMod ignores this - we only need this to make the compiler shut up.
@@ -79,23 +82,51 @@ namespace Celeste {
         [MakeMethodPublic]
         public extern void MakeBanner(float speed, float amplitude, int sliceSize, float sliceSinIncrement, bool easeDown, float offset = 0f, bool onlyIfWindy = false);
 
-        [MonoModIgnore]
+        [MonoModReplace]
         [MakeMethodPublic]
-        public extern void MakeSolid(float x, float y, float w, float h, int surfaceSoundIndex, bool blockWaterfalls = true);
+        public void MakeSolid(float x, float y, float w, float h, int surfaceSoundIndex, bool blockWaterfalls = true) {
+            solid = new Solid(Position + new Vector2(x, y), w, h, true);
+            solid.BlockWaterfalls = blockWaterfalls;
+            solid.SurfaceSoundIndex = surfaceSoundIndex;
+            Scene.Add(solid);
+        }
 
         public void MakeCoreSwap(string coldPath, string hotPath) {
             Add(image = new CoreSwapImage(GFX.Game[coldPath], GFX.Game[hotPath]));
         }
 
         public void MakeStaticMover(int x, int y, int w, int h, bool jumpThrus = false) {
-            StaticMover sm = new StaticMover {
+            staticMover = new StaticMover {
                 SolidChecker = s => s.CollideRect(new Rectangle((int) X + x, (int) Y + y, w, h)),
-                OnMove = v => { X += v.X; Y += v.Y; },
-                OnShake = v => { X += v.X; Y += v.Y; },
+                OnDestroy = () => {
+                    RemoveSelf();
+                    if (solid != null) 
+                        solid.RemoveSelf(); 
+                },
+                OnDisable = () => {
+                    Active = Visible = Collidable = false;
+                    if (solid != null) 
+                        solid.Collidable = false; 
+                },
+                OnEnable = () => {
+                    Active = Visible = Collidable = true;
+                    if (solid != null)
+                        solid.Collidable = true;
+                },
+                OnMove = v => {
+                    Position += v;
+                    if (solid != null) {
+                        if (staticMover.Platform != null) 
+                            solid.LiftSpeed = staticMover.Platform.LiftSpeed;
+                        solid.MoveHExact((int) v.X);
+                        solid.MoveVExact((int) v.Y);
+                    }
+                },
+                OnShake = v => { Position += v; },
             };
             if (jumpThrus)
-                sm.JumpThruChecker = s => s.CollideRect(new Rectangle((int)X + x, (int)X + y, w, h));
-            Add(sm);
+                staticMover.JumpThruChecker = s => s.CollideRect(new Rectangle((int) X + x, (int) X + y, w, h));
+            Add(staticMover);
         }
 
         public void MakeScaredAnimation(int hideRange, int showRange, int[] idleFrames, int[] hiddenFrames, int[] showFrames, int[] hideFrames) {

--- a/Celeste.Mod.mm/Patches/MoveBlock.cs
+++ b/Celeste.Mod.mm/Patches/MoveBlock.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.Xna.Framework;
+using MonoMod;
+using System.Collections;
+
+namespace Celeste {
+    class patch_MoveBlock : MoveBlock {
+
+        public patch_MoveBlock(Vector2 position, int width, int height, MoveBlock.Directions direction, bool canSteer, bool fast)
+            : base(position, width, height, direction, canSteer, fast) {
+            // no-op. MonoMod ignores this - we only need this to make the compiler shut up.
+        }
+
+        [MonoModIgnore]
+        [PatchMoveBlockController]
+        private extern IEnumerator Controller();
+    }
+}


### PR DESCRIPTION
- Updates staticMover commands to update the added solid as well
- Patches MoveBlock to disable static movers before resetting their position. Non-solid movers behave the same either way, but moving a solid static mover while it's still collidable teleports any actors on it

I checked other solids as well and didn't find any major compatibility issues besides the usual funkiness from combing two solids (e.g. Kevins getting stuck).