### PR TITLE
Remove staticMover decals if their Platform is removed

### DIFF
--- a/Celeste.Mod.mm/Mod/Core/CoreModuleSession.cs
+++ b/Celeste.Mod.mm/Mod/Core/CoreModuleSession.cs
@@ -1,7 +1,11 @@
-﻿namespace Celeste.Mod.Core {
+﻿using System.Collections.Generic;
+
+namespace Celeste.Mod.Core {
     public class CoreModuleSession : EverestModuleSession {
 
         public int WhateverElseCount { get; set; } = 1337;
+
+        public HashSet<string> AttachedDecals { get; set; } = new HashSet<string>();
 
     }
 }

--- a/Celeste.Mod.mm/Mod/Entities/EntityRemovedListener.cs
+++ b/Celeste.Mod.mm/Mod/Entities/EntityRemovedListener.cs
@@ -1,0 +1,30 @@
+﻿using Monocle;
+using System;
+
+namespace Celeste.Mod.Entities {
+    /// <summary>
+    /// Allows for defining an Action to take when an Entity is removed.
+    /// </summary>
+    public class EntityRemovedListener : Component {
+
+        /// <summary>
+        /// Called when this Entity is removed from the scene.
+        /// </summary>
+        public Action OnEntityRemoved;
+
+        /// <summary>
+        /// Create a new EntityRemovedListener component.
+        /// </summary>
+        /// <param name="onEntityRemoved">Called when this Entity is removed from the scene.</param>
+        public EntityRemovedListener(Action onEntityRemoved) 
+            : base(false, false) {
+            OnEntityRemoved = onEntityRemoved;
+        }
+
+        public override void EntityRemoved(Scene scene) {
+            base.EntityRemoved(scene);
+            OnEntityRemoved?.Invoke();
+        }
+
+    }
+}

--- a/Celeste.Mod.mm/Patches/Decal.cs
+++ b/Celeste.Mod.mm/Patches/Decal.cs
@@ -29,8 +29,6 @@ namespace Celeste {
         private float showRange;
 
         private StaticMover staticMover;
-        private Vector2 position;
-        private string texture;
 
         public patch_Decal(string texture, Vector2 position, Vector2 scale, int depth)
             : base(texture, position, scale, depth) {
@@ -60,8 +58,6 @@ namespace Celeste {
             }
             hideRange = 32f;
             showRange = 48f;
-            this.texture = texture;
-            this.position = position;
 
             orig_ctor(texture, position, scale, depth);
         }
@@ -101,7 +97,7 @@ namespace Celeste {
                 OnShake = v => { X += v.X; Y += v.Y; },
                 OnAttach = p => {
                     p.Add(new EntityRemovedListener(() => RemoveSelf()));
-                    (Scene as Level).Session.SetFlag($"Everest_Decal_texture:{texture}_X:{position.X}_Y:{position.Y}_WasAttached");
+                    (Scene as Level).Session.SetFlag($"Everest_Decal_texture:{Name}_X:{Position.X}_Y:{Position.Y}_WasAttached");
                 }
             };
             if (jumpThrus)
@@ -131,7 +127,7 @@ namespace Celeste {
 
         public override void Awake(Scene scene) {
             base.Awake(scene);
-            if (staticMover?.Platform == null && (scene as Level).Session.GetFlag($"Everest_Decal_texture:{texture}_X:{position.X}_Y:{position.Y}_WasAttached"))
+            if (staticMover?.Platform == null && (scene as Level).Session.GetFlag($"Everest_Decal_texture:{Name}_X:{Position.X}_Y:{Position.Y}_WasAttached"))
                 RemoveSelf();
         }
 

--- a/Celeste.Mod.mm/Patches/Decal.cs
+++ b/Celeste.Mod.mm/Patches/Decal.cs
@@ -2,6 +2,7 @@
 #pragma warning disable CS0414 // The field is assigned but its value is never used
 
 using Celeste.Mod;
+using Celeste.Mod.Core;
 using Celeste.Mod.Entities;
 using Microsoft.Xna.Framework;
 using Monocle;
@@ -97,7 +98,7 @@ namespace Celeste {
                 OnShake = v => { X += v.X; Y += v.Y; },
                 OnAttach = p => {
                     p.Add(new EntityRemovedListener(() => RemoveSelf()));
-                    (Scene as Level).Session.SetFlag($"Everest_Decal_texture:{Name}_X:{Position.X}_Y:{Position.Y}_WasAttached");
+                    CoreModule.Session.AttachedDecals.Add($"{Name}||{Position.X}||{Position.Y}");
                 }
             };
             if (jumpThrus)
@@ -127,8 +128,9 @@ namespace Celeste {
 
         public override void Awake(Scene scene) {
             base.Awake(scene);
-            if (staticMover?.Platform == null && (scene as Level).Session.GetFlag($"Everest_Decal_texture:{Name}_X:{Position.X}_Y:{Position.Y}_WasAttached"))
+            if (staticMover?.Platform == null && CoreModule.Session.AttachedDecals.Contains($"{Name}||{Position.X}||{Position.Y}")) {
                 RemoveSelf();
+            }
         }
 
         public extern void orig_Added(Scene scene);


### PR DESCRIPTION
Closes #329 

If a decal with a staticMover attribute successfully attaches to a Platform, remove the decal whenever that Platform is removed. Also immediately remove the decal if it was attached to a Platform at some point in time (tracked through Session flags based on the decal's texture (i.e. the path to the image from the `decals` Atlas) and position) and is now not attached to any Platform.

Thanks to @bigkahuna443 for input and help on this - this is tangentially related to his open PR #448 but was submitted separately since it serves a different purpose and should probably be assessed outside of his. 

I opted to put together the EntityRemovedListener to make this as non-invasive as possible (hardly any vanilla entities actually call DestroyStaticMovers and this avoids having to patch them), to make it easily extend to modded entities, and to avoid janky issues with other approaches like having the decal removal lag behind by a frame or the removal of large amounts of decals being visually staggered. I also tried to make it more generalised instead of a "DecalAttacherComponent" in case any future Everest features/other mods want to make use of it. Hopefully an addition like this is okay, this was really the best option 😅 
The session flags are probably the ugliest part of this but we couldn't think of a better way to globally track whether a decal should be immediately removed - happy to hear/implement any cleaner alternatives to this.
If desired, I can make this behaviour optional via a parameter in the staticMover attribute.