### PR TITLE
Add Decal Registry "overlay" tag

### DIFF
--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistry.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistry.cs
@@ -140,6 +140,9 @@ namespace Celeste.Mod {
                 int endFade = attrs["endFade"] != null ? int.Parse(attrs["endFade"].Value) : 24;
                 decal.Add(new VertexLight(offset, color, alpha, startFade, endFade));
             }},
+            { "overlay", delegate(Decal decal, XmlAttributeCollection attrs) {
+                ((patch_Decal)decal).MakeOverlay();
+            }},
         };
 
         public static Dictionary<string, DecalInfo> RegisteredDecals = new Dictionary<string, DecalInfo>();

--- a/Celeste.Mod.mm/Patches/Decal.cs
+++ b/Celeste.Mod.mm/Patches/Decal.cs
@@ -5,6 +5,7 @@ using Celeste.Mod;
 using Microsoft.Xna.Framework;
 using Monocle;
 using MonoMod;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -152,21 +153,19 @@ namespace Celeste {
                 }
 
             }
+            if (Overlay) {
+                Add(new BeforeRenderHook(new Action(CreateOverlay)));
+            }
         }
 
-        [PatchDecalUpdate]
-        public extern void orig_Update();
-        public override void Update() {
-            if (Overlay) {
-                Tileset tileset = new Tileset(textures[0], 8, 8);
-                for (int i = 0; i < textures[0].Width / 8; i++) {
-                    for (int j = 0; j < textures[0].Height / 8; j++) {
-                        TileInterceptor.TileCheck(Scene, tileset[i, j], new Vector2(Position.X - textures[0].Center.X + i * 8, Position.Y - textures[0].Center.Y + j * 8));
-                    }
+        private void CreateOverlay() {
+            Tileset tileset = new Tileset(textures[0], 8, 8);
+            for (int i = 0; i < textures[0].Width / 8; i++) {
+                for (int j = 0; j < textures[0].Height / 8; j++) {
+                    TileInterceptor.TileCheck(Scene, tileset[i, j], new Vector2(Position.X - textures[0].Center.X + i * 8, Position.Y - textures[0].Center.Y + j * 8));
                 }
-                RemoveSelf();
             }
-            orig_Update();
+            RemoveSelf();
         }
     }
     public static class DecalExt {

--- a/Celeste.Mod.mm/Patches/Decal.cs
+++ b/Celeste.Mod.mm/Patches/Decal.cs
@@ -27,6 +27,8 @@ namespace Celeste {
         private float hideRange;
         private float showRange;
 
+        public bool Overlay { get; private set; }
+
         public patch_Decal(string texture, Vector2 position, Vector2 scale, int depth)
             : base(texture, position, scale, depth) {
             // no-op. MonoMod ignores this - we only need this to make the compiler shut up.
@@ -113,6 +115,10 @@ namespace Celeste {
             scaredAnimal = true;
         }
 
+        public void MakeOverlay() {
+            Overlay = true;
+        }
+
         [MonoModIgnore]
         private Component image;
 
@@ -148,9 +154,20 @@ namespace Celeste {
             }
         }
 
-        [MonoModIgnore]
         [PatchDecalUpdate]
-        public extern override void Update();
+        public extern void orig_Update();
+        public override void Update() {
+            if (Overlay) {
+                Tileset tileset = new Tileset(textures[0], 8, 8);
+                for (int i = 0; i < textures[0].Width / 8; i++) {
+                    for (int j = 0; j < textures[0].Height / 8; j++) {
+                        TileInterceptor.TileCheck(Scene, tileset[i, j], new Vector2(Position.X - textures[0].Center.X + i * 8, Position.Y - textures[0].Center.Y + j * 8));
+                    }
+                }
+                RemoveSelf();
+            }
+            orig_Update();
+        }
     }
     public static class DecalExt {
 

--- a/Celeste.Mod.mm/Patches/IntroCrusher.cs
+++ b/Celeste.Mod.mm/Patches/IntroCrusher.cs
@@ -30,6 +30,7 @@ namespace Celeste {
                 Remove(tilegrid);
                 Add(tilegrid = GFX.FGAutotiler.GenerateBox(tiletype[0], data.Width / 8, data.Height / 8).TileGrid);
             }
+            Add(new TileInterceptor(tilegrid, highPriority: false));
         }
 
         [MonoModLinkTo("Monocle.Entity", "Added")]


### PR DESCRIPTION
Implements a more approachable version of objtiles. Basic functionality is:
1. Add an "overlay" tag to a decal in the DecalRegistry.xml (excludes all other tags).
2. Layer the decal over a supported tile entity (will include list in docs).
3. For every tile the decal overlaps, the tile texture of the entity will be replaced by that of the "tile" of the decal.

Other implementations were considered, e.g. supporting a custom tilesets/scenery.png image, but this implementation is pretty flexible, easy to work with, and won't require any extra editor support. It also allows users to work with segments larger than a single tile and not have to artificially break them up and piece them together.

The overlay happens in a BeforeRender hook since some tile entities don't set up their TileInterceptors until Awake.