### PR TITLE
Fix crash when comments included in AnimatedTiles.xml

### DIFF
--- a/Celeste.Mod.mm/Patches/LevelLoader.cs
+++ b/Celeste.Mod.mm/Patches/LevelLoader.cs
@@ -84,7 +84,7 @@ namespace Celeste {
             if (string.IsNullOrEmpty(path))
                 path = Path.Combine("Graphics", "AnimatedTiles.xml");
             GFX.AnimatedTilesBank = new AnimatedTilesBank();
-            XmlElement animatedData = Calc.LoadContentXML(path)["Data"];
+            XmlNodeList animatedData = Calc.LoadContentXML(path).GetElementsByTagName("sprite");
             foreach (XmlElement el in animatedData)
                 if (el != null)
                     GFX.AnimatedTilesBank.Add(


### PR DESCRIPTION
Currently maps crash on load if comments are included in AnimatedTiles.xml. Changed it so it only sorts through the actual sprite tags.