### PR TITLE
Add support for custom tileset sounds

### DIFF
--- a/Celeste.Mod.mm/MonoModRules.cs
+++ b/Celeste.Mod.mm/MonoModRules.cs
@@ -2549,12 +2549,12 @@ namespace MonoMod {
             ILCursor cursor = new ILCursor(context);
 
             /*  Move cursor to after IL_040d in
-                    // num2 = platformByPriority.GetLandSoundIndex(this)
-                    IL_040a: ldloc.s 4
+                   // num2 = platformByPriority.GetLandSoundIndex(this)
+                   IL_040a: ldloc.s 4
 	                IL_040c: ldarg.0
 	                IL_040d: callvirt instance int32 Celeste.Platform::GetLandSoundIndex(class Monocle.Entity)
 	                IL_0412: stloc.s 5
-               and get the variable index of num2  
+                and get the variable index of num2  
             */
             int num2VariableIndex = 0;
             cursor.GotoNext(MoveType.After, instr => instr.MatchCallvirt("Celeste.Platform", "System.Int32 GetLandSoundIndex(Monocle.Entity)"),
@@ -2646,7 +2646,7 @@ namespace MonoMod {
                     Audio.Play("event:/char/madeline/footstep", base.Center, "surface_index", platformByPriority.GetStepSoundIndex(this));
                 to:
                     Audio.Play(SurfaceIndex.GetPathFromIndex(platformByPriority.GetStepSoundIndex(this)) + "/footstep", base.Center, "surface_index", 
-                         platformByPriority.GetStepSoundIndex(this));
+                               platformByPriority.GetStepSoundIndex(this));
             */
             cursor.Emit(OpCodes.Ldloc_1);
             cursor.Emit(OpCodes.Ldarg_0);
@@ -2663,7 +2663,7 @@ namespace MonoMod {
             // Patch Player::ctor's OnFrameChange delegate manually because see above
             PatchPlayerCtorOnFrameChange(modder.Module.GetType("Celeste.Player").FindMethod("<.ctor>b__280_1"));
             // Patch NPC::SetupTheoSpriteSounds's OnFrameChange delegate manually because see above
-            // We can also re-use the same patch code for NPC::SetupGrannySpriteSounds
+            // We can also re-use the same patch code for NPC::SetupGrannySpriteSounds's OnFrameChange delegate
             PatchNPCSetupSpriteSoundsOnFrameChange(modder.Module.GetType("Celeste.NPC").FindMethod("<SetupTheoSpriteSounds>b__19_0"));
             PatchNPCSetupSpriteSoundsOnFrameChange(modder.Module.GetType("Celeste.NPC").FindMethod("<SetupGrannySpriteSounds>b__20_0"));
 

--- a/Celeste.Mod.mm/MonoModRules.cs
+++ b/Celeste.Mod.mm/MonoModRules.cs
@@ -2545,8 +2545,10 @@ namespace MonoMod {
 
         public static void PatchPlayerOnCollideV(ILContext context, CustomAttribute attrib) {
             MethodDefinition m_SurfaceIndex_GetPathFromIndex = context.Module.GetType("Celeste.SurfaceIndex").FindMethod("System.String GetPathFromIndex(System.Int32)");
-            TypeDefinition t_String = MonoModRule.Modder.FindType("System.String").Resolve();
-            MethodReference m_String_Concat = MonoModRule.Modder.Module.ImportReference(t_String.FindMethod("System.String Concat(System.String,System.String)"));
+            MethodReference m_String_Concat = MonoModRule.Modder.Module.ImportReference(
+                MonoModRule.Modder.FindType("System.String").Resolve()
+                    .FindMethod("System.String Concat(System.String,System.String)")
+            );
 
             ILCursor cursor = new ILCursor(context);
 
@@ -2587,8 +2589,10 @@ namespace MonoMod {
             // Doesn't use PatchPlaySurfaceIndex because index, not platform, is stored in the local variable
 
             MethodDefinition m_SurfaceIndex_GetPathFromIndex = context.Module.GetType("Celeste.SurfaceIndex").FindMethod("System.String GetPathFromIndex(System.Int32)");
-            TypeDefinition t_String = MonoModRule.Modder.FindType("System.String").Resolve();
-            MethodReference m_String_Concat = MonoModRule.Modder.Module.ImportReference(t_String.FindMethod("System.String Concat(System.String,System.String)"));
+            MethodReference m_String_Concat = MonoModRule.Modder.Module.ImportReference(
+                MonoModRule.Modder.FindType("System.String").Resolve()
+                    .FindMethod("System.String Concat(System.String,System.String)")
+            );
             
             ILCursor cursor = new ILCursor(context);
 

--- a/Celeste.Mod.mm/MonoModRules.cs
+++ b/Celeste.Mod.mm/MonoModRules.cs
@@ -2549,8 +2549,8 @@ namespace MonoMod {
             ILCursor cursor = new ILCursor(context);
 
             /*  Move cursor to after IL_040d in
-                   // num2 = platformByPriority.GetLandSoundIndex(this)
-                   IL_040a: ldloc.s 4
+                    // num2 = platformByPriority.GetLandSoundIndex(this)
+                    IL_040a: ldloc.s 4
 	                IL_040c: ldarg.0
 	                IL_040d: callvirt instance int32 Celeste.Platform::GetLandSoundIndex(class Monocle.Entity)
 	                IL_0412: stloc.s 5

--- a/Celeste.Mod.mm/Patches/Autotiler.cs
+++ b/Celeste.Mod.mm/Patches/Autotiler.cs
@@ -69,8 +69,12 @@ namespace Celeste {
                 ReadIntoCustomTemplate(data, tileset, xml);
             }
 
-            if (xml.HasAttr("sound"))
+            if (xml.HasAttr("soundPath") && xml.HasAttr("sound")) { // Could accommodate for no sound attr, but requiring it should improve clarity on user's end 
                 SurfaceIndex.TileToIndex[xml.AttrChar("id")] = xml.AttrInt("sound");
+                patch_SurfaceIndex.IndexToCustomPath[xml.AttrInt("sound")] = (xml.Attr("soundPath").StartsWith("event:/") ? "" : "event:/") + xml.Attr("soundPath");
+            } else if (!SurfaceIndex.TileToIndex.ContainsKey(xml.AttrChar("id")) || xml.AttrChar("id") == 'o') { // Backwards-compat: some existing mods use 'o' and overwrite its sound
+                SurfaceIndex.TileToIndex[xml.AttrChar("id")] = xml.HasAttr("sound") ? xml.AttrInt("sound") : 8; // 8 as fallback instead of 0 to match vanilla's default index
+            }
 
             if (xml.HasAttr("debris"))
                 data.Debris = xml.Attr("debris");

--- a/Celeste.Mod.mm/Patches/LevelLoader.cs
+++ b/Celeste.Mod.mm/Patches/LevelLoader.cs
@@ -66,6 +66,9 @@ namespace Celeste {
                 { 'o', 43 }
             };
 
+            // Clear any custom tileset sound paths
+            patch_SurfaceIndex.IndexToCustomPath.Clear();
+
             AreaData area = AreaData.Get(session);
             MapMeta meta = area.GetMeta();
             string path;

--- a/Celeste.Mod.mm/Patches/Player.cs
+++ b/Celeste.Mod.mm/Patches/Player.cs
@@ -144,6 +144,16 @@ namespace Celeste {
                 orig_WindMove(move);
         }
 
+        [MonoModIgnore]
+        [PatchPlayerOnCollideV]
+        private extern void OnCollideV(CollisionData data);
+
+        [MonoModIgnore]
+        [PatchPlayerClimbBegin]
+        private extern void ClimbBegin();
+
+        [MonoModIgnore]
+        [PatchPlayerOrigWallJump]
         private extern void orig_WallJump(int dir);
         private void WallJump(int dir) {
             if ((Scene as Level).Session.Area.GetLevelSet() != "Celeste") {

--- a/Celeste.Mod.mm/Patches/SurfaceIndex.cs
+++ b/Celeste.Mod.mm/Patches/SurfaceIndex.cs
@@ -6,10 +6,10 @@ namespace Celeste {
         public static Dictionary<int, string> IndexToCustomPath = new Dictionary<int, string>(); 
 
         public static string GetPathFromIndex(int key) {
-            if (IndexToCustomPath.TryGetValue(key, out string path))
+            if (IndexToCustomPath.TryGetValue(key, out string path)) {
                 return path;
-            else
-                return "event:/char/madeline";
+            }
+            return "event:/char/madeline";
         }
 
     }

--- a/Celeste.Mod.mm/Patches/SurfaceIndex.cs
+++ b/Celeste.Mod.mm/Patches/SurfaceIndex.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+
+namespace Celeste {
+    class patch_SurfaceIndex: SurfaceIndex {
+
+        public static Dictionary<int, string> IndexToCustomPath = new Dictionary<int, string>(); 
+
+        public static string GetPathFromIndex(int key) {
+            if (IndexToCustomPath.TryGetValue(key, out string path))
+                return path;
+            else
+                return "event:/char/madeline";
+        }
+
+    }
+}


### PR DESCRIPTION
Tileset sounds are currently controlled by values fed to a `surface_index` parameter in one of four FMOD events (`footstep`, `handhold`, `grab`, and `landing`), which play a different sound based on that index. Vanilla tilesets have their own hardcoded list of IDs-to-indexes, and custom tilesets can specify their own indexes from the available ones in the vanilla FMOD project.
Rather than try match tileset IDs to FMOD event paths (which would get very messy and require a lot more patching/wouldn't support any existing mods), we can use these indexes that are already being assigned by existing entities, and that have existing methods to be retrieved when the sound is to be played, and match them against event paths instead.

We allow mappers to specify a `soundPath` parameter in their tileset XML, which should lead to the four necessary events for a unique tileset sound in FMOD: `footstep`, `handhold`, `grab`, and `landing`. 
- If they omit one or more of these, no sound will be played, and the missing event will be logged automatically. Unfortunately this could get a bit spammy since it'll get logged every time that action is called, but honestly if somebody's going as far as creating custom tileset sounds then I think it's fair to expect that they fill out all four events - if they put together sounds for one action but don't want unique sounds for the rest then it's as easy as copy-pasting the event and renaming it, and if they really want a certain action to be silent then adding an empty event also works. I will stress in the documentation that all four events should be present in some form.

Since each path needs its own index in order for this to work, we require that mappers also specify a `sound` param to make use of `soundPath`.
- We could assign indexes ourselves if they omit the `sound` param, but I figured requiring it should help the mapper to diagnose the source of any conflicts or overrides on their own - it's not hard to just assign an index, there'll be a list of what you should and shouldn't use in the accompanying documentation for this as well.
- The audio designer is free to decide whether they want to use this `sound` value to control a `surface_index` param (as done in vanilla) or not (setting the value of a param that doesn't exist in an event just won't do anything), but requiring `sound` to be specified should also help them understand how the game is interacting with their event.
- I didn't want to force this to be unique, as I wanted to allow for re-using the same index and path for multiple tilesets. It is possible to say "include the `soundPath` and `sound` pair in the tileset with the id that's going to get read first, then just re-use the `sound` value in later tilesets" but that felt way more jank to me than just allowing for existing indexes to be given new paths and asking the mapper/#modding_help to deal with any issues regarding unwanted overrides when they come up.

On Everest's end, we take these index:path pairs and store them in our `SurfaceIndex.IndexToCustomPath` dict. We then patch all the Player methods to use our `SurfaceIndex.GetPathFromIndex()` method to try get a custom path matching the Platform's SurfaceSoundIndex (which was already being retrieved for use with `surface_index`) when it tries to play the sound for whatever action is occurring. If we can't, we fall back to vanilla, which is a safe bet. We also patch the methods that handle the Theo and Granny NPC footstep sounds, which behave in a similar manner to Player, to respect custom tilesets too.
- If I screwed up anything in these patches then definitely let me hear it. I don't actually know enough about how delegate patching works to know for sure if I had to do all those patches in PostProcessor, but I think the MiniInstaller exceptions were pointing at doing the patching in there when I tried it the "normal" way, I tried doing it the same as coroutines to no avail, and it lined up with the CrushBlock::AttackSequence patch's circumstances - anonymous function, compiler-generated, all that

I tested this pretty extensively in vanilla, existing maps with custom tilesets not using this feature, and a couple test maps using this feature, and saw no issues. Tested some tile entities in helpers too and they all worked fine - couldn't test everything under the sun but provided they don't do anything unusual when handling tileset sounds, they should all have support for this by default. If there are any custom entities similar to the Theo and Granny NPCs that play sounds based on the current Platform, they will have to add this support on their own, but it's as easy as changing their code to call the new `SurfaceIndex.GetPathFromIndex()` method patched in here and passing it whatever int they were getting to determine what index to play. No existing uses of them will break either, just any future attempts to use them in conjunction with custom tilesets (which I can't see being all too common, this is a pretty niche feature as-is)

Closes #326 (character arc 😎)