### PR TITLE
Make CoreModeTrigger toggle effects optional

### DIFF
--- a/Celeste.Mod.mm/Mod/Entities/CoreModeTrigger.cs
+++ b/Celeste.Mod.mm/Mod/Entities/CoreModeTrigger.cs
@@ -4,10 +4,12 @@ namespace Celeste.Mod.Entities {
     [CustomEntity("everest/coreModeTrigger", "cavern/coremodetrigger")]
     public class CoreModeTrigger : Trigger {
         private readonly Session.CoreModes mode;
+        private readonly bool playEffects;
 
         public CoreModeTrigger(EntityData data, Vector2 offset) 
             : base(data, offset) {
             mode = data.Enum("mode", Session.CoreModes.None);
+            playEffects = data.Bool("playEffects", true);
         }
 
         public override void OnEnter(Player player) {
@@ -15,9 +17,11 @@ namespace Celeste.Mod.Entities {
             if (level.CoreMode == mode)
                 return;
             level.CoreMode = mode;
-            Input.Rumble(RumbleStrength.Medium, RumbleLength.Medium);
-            level.Flash(Color.White * 0.15f, true);
-            Celeste.Freeze(0.05f);
+            if (playEffects) {
+                Input.Rumble(RumbleStrength.Medium, RumbleLength.Medium);
+                level.Flash(Color.White * 0.15f, true);
+                Celeste.Freeze(0.05f);
+            }
         }
     }
 }


### PR DESCRIPTION
I have heard a lot of people request this option so there's a way to silently change the core mode. Value is default true for backwards compatibility. Would require an Ahorn/Lonn update as well.