### PR TITLE
Disable unnecessary build warnings in patch classes

### DIFF
--- a/Celeste.Mod.mm/Patches/Lookout.cs
+++ b/Celeste.Mod.mm/Patches/Lookout.cs
@@ -1,5 +1,4 @@
 ﻿#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
-#pragma warning disable CS0169 // Field is never used
 
 using Microsoft.Xna.Framework;
 using Monocle;
@@ -7,8 +6,6 @@ using MonoMod;
 
 namespace Celeste {
     class patch_Lookout : Lookout {
-
-        private bool interacting;
 
         public patch_Lookout(EntityData data, Vector2 offset)
             : base(data, offset) {

--- a/Celeste.Mod.mm/Patches/Lookout.cs
+++ b/Celeste.Mod.mm/Patches/Lookout.cs
@@ -1,4 +1,5 @@
 ﻿#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
+#pragma warning disable CS0169 // Field is never used
 
 using Microsoft.Xna.Framework;
 using Monocle;

--- a/Celeste.Mod.mm/Patches/Settings.cs
+++ b/Celeste.Mod.mm/Patches/Settings.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Xna.Framework.Input;
+﻿#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
+
+using Microsoft.Xna.Framework.Input;
 using MonoMod;
 using System.Collections.Generic;
 using System.Linq;

--- a/Celeste.Mod.mm/Patches/Settings.cs
+++ b/Celeste.Mod.mm/Patches/Settings.cs
@@ -1,6 +1,4 @@
-﻿#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
-
-using Microsoft.Xna.Framework.Input;
+﻿using Microsoft.Xna.Framework.Input;
 using MonoMod;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,9 +6,6 @@ using System.Xml.Serialization;
 
 namespace Celeste {
     class patch_Settings : Settings {
-
-        [MonoModIgnore]
-        public static new patch_Settings Instance;
 
         [MonoModIgnore]
         [PatchSettingsDoNotTranslateKeys]


### PR DESCRIPTION
Building Everest had two warnings caused by fields in patch classes whose usage the compiler couldn't recognize properly. This PR adds pragmas to disable those warnings.