### PR TITLE
Add support for non-looping complete screen animations

### DIFF
--- a/Celeste.Mod.mm/Mod/Meta/MapMeta.cs
+++ b/Celeste.Mod.mm/Mod/Meta/MapMeta.cs
@@ -498,6 +498,7 @@ namespace Celeste.Mod.Meta {
         [YamlIgnore] public Vector2 Speed => SpeedArray.ToVector2() ?? Vector2.Zero;
         [YamlMember(Alias = "Speed")] public float[] SpeedArray { get; set; }
         public float Scale { get; set; } = 1f;
+        public bool Loop { get; set; } = true;
     }
 
     public class MapMetaCompleteScreenTitle {

--- a/Celeste.Mod.mm/MonoModRules.cs
+++ b/Celeste.Mod.mm/MonoModRules.cs
@@ -427,6 +427,12 @@ namespace MonoMod {
     /// </summary>
     [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchPlayerStarFlyReturnToNormalHitbox))]
     class PatchPlayerStarFlyReturnToNormalHitboxAttribute : Attribute { }
+    
+    /// <summary>
+    /// Patches the method to support non-looping complete screen layers.
+    /// </summary>
+    [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchCompleteRendererImageLayerRender))]
+    class PatchCompleteRendererImageLayerRenderAttribute : Attribute { }
 
 
     static class MonoModRules {
@@ -2471,6 +2477,17 @@ namespace MonoMod {
             cursor.Emit(OpCodes.Callvirt, m_Player_Die);
             cursor.Emit(OpCodes.Pop);
             cursor.RemoveRange(3);
+        }
+
+        public static void PatchCompleteRendererImageLayerRender(ILContext context, CustomAttribute attrib) {
+            MethodReference m_ImageLayer_Render = MonoModRule.Modder.FindType("Celeste.CompleteRenderer/ImageLayer")
+                .Resolve().FindProperty("ImageIndex").GetMethod;
+            
+            ILCursor cursor = new(context);
+            cursor.GotoNext(MoveType.After, instr => instr.MatchLdfld("Celeste.CompleteRenderer/ImageLayer", "Images"));
+            cursor.Emit(OpCodes.Ldarg_0);
+            cursor.Emit(OpCodes.Callvirt, m_ImageLayer_Render);
+            cursor.RemoveRange(8);
         }
 
         public static void PostProcessor(MonoModder modder) {

--- a/Celeste.Mod.mm/MonoModRules.cs
+++ b/Celeste.Mod.mm/MonoModRules.cs
@@ -2480,8 +2480,7 @@ namespace MonoMod {
         }
 
         public static void PatchCompleteRendererImageLayerRender(ILContext context, CustomAttribute attrib) {
-            MethodReference m_ImageLayer_Render = MonoModRule.Modder.FindType("Celeste.CompleteRenderer/ImageLayer")
-                .Resolve().FindProperty("ImageIndex").GetMethod;
+            MethodReference m_ImageLayer_Render = context.Method.DeclaringType.FindProperty("ImageIndex").GetMethod;
             
             ILCursor cursor = new(context);
             cursor.GotoNext(MoveType.After, instr => instr.MatchLdfld("Celeste.CompleteRenderer/ImageLayer", "Images"));

--- a/Celeste.Mod.mm/MonoModRules.cs
+++ b/Celeste.Mod.mm/MonoModRules.cs
@@ -2494,7 +2494,7 @@ namespace MonoMod {
         public static void PatchCompleteRendererImageLayerRender(ILContext context, CustomAttribute attrib) {
             MethodReference m_ImageLayer_Render = context.Method.DeclaringType.FindProperty("ImageIndex").GetMethod;
             
-            ILCursor cursor = new(context);
+            ILCursor cursor = new ILCursor(context);
             cursor.GotoNext(MoveType.After, instr => instr.MatchLdfld("Celeste.CompleteRenderer/ImageLayer", "Images"));
             cursor.Emit(OpCodes.Ldarg_0);
             cursor.Emit(OpCodes.Callvirt, m_ImageLayer_Render);

--- a/Celeste.Mod.mm/MonoModRules.cs
+++ b/Celeste.Mod.mm/MonoModRules.cs
@@ -2498,12 +2498,16 @@ namespace MonoMod {
         }
 
         public static void PatchCompleteRendererImageLayerRender(ILContext context, CustomAttribute attrib) {
-            MethodReference m_ImageLayer_Render = context.Method.DeclaringType.FindProperty("ImageIndex").GetMethod;
+            MethodReference m_ImageLayer_get_ImageIndex = context.Method.DeclaringType.FindProperty("ImageIndex").GetMethod;
             
             ILCursor cursor = new ILCursor(context);
+            
+            // change: MTexture mTexture = Images[(int)(Frame % (float)Images.Count)];
+            // to:     MTexture mTexture = Images[ImageIndex];
+            // for new property ImageIndex
             cursor.GotoNext(MoveType.After, instr => instr.MatchLdfld("Celeste.CompleteRenderer/ImageLayer", "Images"));
             cursor.Emit(OpCodes.Ldarg_0);
-            cursor.Emit(OpCodes.Callvirt, m_ImageLayer_Render);
+            cursor.Emit(OpCodes.Callvirt, m_ImageLayer_get_ImageIndex);
             cursor.RemoveRange(8);
         }
         

--- a/Celeste.Mod.mm/Patches/CompleteRenderer.cs
+++ b/Celeste.Mod.mm/Patches/CompleteRenderer.cs
@@ -113,6 +113,29 @@ namespace Celeste {
 
                 Loop = xml.AttrBool("loop", true);
             }
+
+            private bool loopDone;
+            public int ImageIndex {
+                get {
+                    if (Loop) {
+                        return (int) (Frame % (float) Images.Count); // as in vanilla
+                    } else {
+                        if (loopDone) {
+                            return Images.Count - 1;
+                        } else {
+                            int index = (int) (Frame % (float) Images.Count);
+                            if (index == Images.Count - 1) {
+                                loopDone = true;
+                            }
+                            return index;
+                        }
+                    }
+                }
+            }
+
+            [MonoModIgnore]
+            [PatchCompleteRendererImageLayerRender]
+            public new extern void Render(Vector2 scroll);
         }
 
         public class ImageLayerNoXML : patch_ImageLayer {

--- a/Celeste.Mod.mm/Patches/CompleteRenderer.cs
+++ b/Celeste.Mod.mm/Patches/CompleteRenderer.cs
@@ -101,7 +101,8 @@ namespace Celeste {
         public class patch_ImageLayer : ImageLayer {
 
             public bool Loop;
-            public patch_ImageLayer(Vector2 offset, Atlas atlas, XmlElement xml) : base(offset, atlas, xml) {
+            public patch_ImageLayer(Vector2 offset, Atlas atlas, XmlElement xml)
+                : base(offset, atlas, xml) {
                 //no-op
             }
 

--- a/Celeste.Mod.mm/Patches/CompleteRenderer.cs
+++ b/Celeste.Mod.mm/Patches/CompleteRenderer.cs
@@ -102,6 +102,8 @@ namespace Celeste {
         public class patch_ImageLayer : ImageLayer {
 
             public bool Loop;
+            private bool loopDone;
+            
             public patch_ImageLayer(Vector2 offset, Atlas atlas, XmlElement xml)
                 : base(offset, atlas, xml) {
                 //no-op
@@ -115,8 +117,7 @@ namespace Celeste {
 
                 Loop = xml.AttrBool("loop", true);
             }
-
-            private bool loopDone;
+            
             public int ImageIndex {
                 get {
                     if (Loop) {

--- a/Celeste.Mod.mm/Patches/CompleteRenderer.cs
+++ b/Celeste.Mod.mm/Patches/CompleteRenderer.cs
@@ -117,8 +117,6 @@ namespace Celeste {
 
         public class ImageLayerNoXML : ImageLayer {
 
-            public bool Loop;
-
             public ImageLayerNoXML(Vector2 offset, Atlas atlas, MapMetaCompleteScreenLayer meta)
                 : base(offset, atlas, FakeXML) {
                 Position = meta.Position;
@@ -137,7 +135,7 @@ namespace Celeste {
                 Alpha = meta.Alpha;
                 Speed = meta.Speed;
                 Scale = meta.Scale;
-                Loop = meta.Loop;
+                ((patch_ImageLayer) (ImageLayer) this).Loop = meta.Loop;
             }
         }
 

--- a/Celeste.Mod.mm/Patches/CompleteRenderer.cs
+++ b/Celeste.Mod.mm/Patches/CompleteRenderer.cs
@@ -115,7 +115,7 @@ namespace Celeste {
             }
         }
 
-        public class ImageLayerNoXML : ImageLayer {
+        public class ImageLayerNoXML : patch_ImageLayer {
 
             public ImageLayerNoXML(Vector2 offset, Atlas atlas, MapMetaCompleteScreenLayer meta)
                 : base(offset, atlas, FakeXML) {
@@ -135,7 +135,7 @@ namespace Celeste {
                 Alpha = meta.Alpha;
                 Speed = meta.Speed;
                 Scale = meta.Scale;
-                ((patch_ImageLayer) (ImageLayer) this).Loop = meta.Loop;
+                Loop = meta.Loop;
             }
         }
 

--- a/Celeste.Mod.mm/Patches/CompleteRenderer.cs
+++ b/Celeste.Mod.mm/Patches/CompleteRenderer.cs
@@ -1,4 +1,5 @@
 #pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
+#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
 
 
 using Celeste.Mod.Meta;
@@ -97,7 +98,26 @@ namespace Celeste {
 
         }
 
+        public class patch_ImageLayer : ImageLayer {
+
+            public bool Loop;
+            public patch_ImageLayer(Vector2 offset, Atlas atlas, XmlElement xml) : base(offset, atlas, xml) {
+                //no-op
+            }
+
+            public extern void orig_ctor(Vector2 offset, Atlas atlas, XmlElement xml);
+
+            [MonoModConstructor]
+            public void ctor(Vector2 offset, Atlas atlas, XmlElement xml) {
+                orig_ctor(offset, atlas, xml);
+
+                Loop = xml.AttrBool("loop", true);
+            }
+        }
+
         public class ImageLayerNoXML : ImageLayer {
+
+            public bool Loop;
 
             public ImageLayerNoXML(Vector2 offset, Atlas atlas, MapMetaCompleteScreenLayer meta)
                 : base(offset, atlas, FakeXML) {
@@ -117,6 +137,7 @@ namespace Celeste {
                 Alpha = meta.Alpha;
                 Speed = meta.Speed;
                 Scale = meta.Scale;
+                Loop = meta.Loop;
             }
         }
 


### PR DESCRIPTION
Currently, any animation on complete screens except for the parallax must loop indefinitely. This PR implements support for non-looping layers by adding a new meta attribute Loop to complete screen layers, true by default, that causes the animation to stay on the last frame if set to false. This is implemented both for .meta.yaml and .xml so that it can be used both for custom maps and global skinmods.