### PR TITLE
Reduce the width of the map list and mod options with a new width calculation mode

### DIFF
--- a/Celeste.Mod.mm/Mod/UI/OuiMapList.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiMapList.cs
@@ -30,6 +30,7 @@ namespace Celeste.Mod.UI {
 
         private TextMenu CreateMenu(bool inGame, EventInstance snapshot) {
             menu = new TextMenu();
+            ((patch_TextMenu) menu).CompactWidthMode = true;
             items.Clear();
 
             menu.Add(new TextMenu.Header(Dialog.Clean("maplist_title")));

--- a/Celeste.Mod.mm/Mod/UI/OuiModOptions.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiModOptions.cs
@@ -33,6 +33,7 @@ namespace Celeste.Mod.UI {
 
         public static TextMenu CreateMenu(bool inGame, EventInstance snapshot) {
             TextMenu menu = new TextMenu();
+            ((patch_TextMenu) menu).CompactWidthMode = true;
             ((patch_TextMenu) menu).BatchMode = true;
 
             menu.Add(new TextMenuExt.HeaderImage("menu/everest") {

--- a/Celeste.Mod.mm/Patches/TextMenu.cs
+++ b/Celeste.Mod.mm/Patches/TextMenu.cs
@@ -28,6 +28,11 @@ namespace Celeste {
         public List<Item> Items => items;
 
         /// <summary>
+        /// If enabled, the menu will be made narrower by adapting the size of the two "columns" for each menu section instead of for the entire menu.
+        /// </summary>
+        public bool CompactWidthMode { get; set; } = false;
+
+        /// <summary>
         /// When a menu is in batch mode, adding / removing items will not recalculate its size to improve performance.
         /// Size is recalculated immediately after batch mode is disabled.
         /// </summary>
@@ -229,8 +234,7 @@ namespace Celeste {
 
         /// <inheritdoc cref="TextMenu.Add(TextMenu.Item)"/>
         [MonoModReplace]
-        public new TextMenu Add(Item item)
-        {
+        public new TextMenu Add(Item item) {
             items.Add(item);
             item.Container = this;
             Add(item.ValueWiggler = Wiggler.Create(0.25f, 3f));
@@ -254,10 +258,48 @@ namespace Celeste {
             if (BatchMode) {
                 recalculatingSizeInBatchMode = true;
             }
-            orig_RecalculateSize();
+
+            if (CompactWidthMode) {
+                recalculateSizeForCompactWidthMode();
+            } else {
+                orig_RecalculateSize();
+            }
+
             if (BatchMode) {
                 recalculatingSizeInBatchMode = false;
             }
+        }
+
+        private void recalculateSizeForCompactWidthMode() {
+            LeftColumnWidth = RightColumnWidth = Height = 0f;
+
+            float leftColumnWidthSoFar = 0f;
+            float rightColumnWidthSoFar = 0f;
+
+            foreach (Item item in items) {
+                if (item is SubHeader && item is not TextMenuExt.EaseInSubHeaderExt) {
+                    // starting new section, save the new maximum and reset the column sizes
+                    LeftColumnWidth = Math.Max(LeftColumnWidth, leftColumnWidthSoFar + rightColumnWidthSoFar);
+                    leftColumnWidthSoFar = rightColumnWidthSoFar = 0f;
+                }
+
+                // take height into account
+                if (item.Visible) {
+                    Height += item.Height() + ItemSpacing;
+                }
+
+                // take width into account
+                if (item.IncludeWidthInMeasurement) {
+                    leftColumnWidthSoFar = Math.Max(leftColumnWidthSoFar, item.LeftWidth());
+                    rightColumnWidthSoFar = Math.Max(rightColumnWidthSoFar, item.RightWidth());
+                }
+            }
+
+            Height -= ItemSpacing;
+
+            // take the last section into account by saving the maximum one last time
+            LeftColumnWidth = Math.Max(LeftColumnWidth, leftColumnWidthSoFar + rightColumnWidthSoFar);
+            Width = Math.Max(MinWidth, LeftColumnWidth);
         }
 
         public class patch_LanguageButton : LanguageButton {


### PR DESCRIPTION
That new `CompactWidthMode` option (feel free to suggest better names 😅) aims to replace the width calculation with one that leads to narrower menus, that are less likely to be wider than the screen. This was made for the map list, but it was brought up that applying that to mod options could also help with some options being large.

Basically, instead of having 2 big columns, the width of each section of the menu is calculated, and the largest one determines the width of the menu.

Before:

https://user-images.githubusercontent.com/52103563/173672741-e94bdc2e-85cf-47a5-b475-c7547c29cb5d.mp4

The menu overflows because Death Tracker has a big value in the right column, and Jackal Helper a big one in the left column.

After:

https://user-images.githubusercontent.com/52103563/173672788-06cf6ad6-2ee9-46cc-bf88-6b700e96b4c3.mp4

The entire menu took the width of the Jackal Helper section, which is the widest of the menu.
