### PR TITLE
add missing decal registry options

### DIFF
--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistry.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistry.cs
@@ -18,9 +18,9 @@ namespace Celeste.Mod {
                 ((patch_Decal)decal).MakeParallax(float.Parse(attrs["amount"].Value));
             }},
             { "scale", delegate(Decal decal, XmlAttributeCollection attrs) {
-                float scalex = attrs["multiplyX"] != null ? float.Parse(attrs["multiplyX"].Value) : 1f;
-                float scaley = attrs["multiplyY"] != null ? float.Parse(attrs["multiplyY"].Value) : 1f;
-                ((patch_Decal)decal).Scale *= new Vector2(scalex, scaley);
+                float scaleX = attrs["multiplyX"] != null ? float.Parse(attrs["multiplyX"].Value) : 1f;
+                float scaleY = attrs["multiplyY"] != null ? float.Parse(attrs["multiplyY"].Value) : 1f;
+                ((patch_Decal)decal).Scale *= new Vector2(scaleX, scaleY);
             }},
             { "smoke", delegate(Decal decal, XmlAttributeCollection attrs) {
                 float offx = attrs["offsetX"] != null ? float.Parse(attrs["offsetX"].Value) : 0f;

--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistry.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistry.cs
@@ -17,6 +17,11 @@ namespace Celeste.Mod {
             { "parallax", delegate(Decal decal, XmlAttributeCollection attrs) {
                 ((patch_Decal)decal).MakeParallax(float.Parse(attrs["amount"].Value));
             }},
+            { "scale", delegate(Decal decal, XmlAttributeCollection attrs) {
+                float scalex = attrs["multiplierX"] != null ? float.Parse(attrs["multiplierX"].Value) : 1f;
+                float scaley = attrs["multiplierY"] != null ? float.Parse(attrs["multiplierY"].Value) : 1f;
+                ((patch_Decal)decal).Scale *= new Vector2(scalex, scaley);
+            }},
             { "smoke", delegate(Decal decal, XmlAttributeCollection attrs) {
                 float offx = attrs["offsetX"] != null ? float.Parse(attrs["offsetX"].Value) : 0f;
                 float offy = attrs["offsetY"] != null ? float.Parse(attrs["offsetY"].Value) : 0f;
@@ -129,6 +134,9 @@ namespace Celeste.Mod {
                 int[] idleFrames = Calc.ReadCSVIntWithTricks(attrs["idleFrames"]?.Value ?? "0");
                 int[] hiddenFrames = Calc.ReadCSVIntWithTricks(attrs["hiddenFrames"]?.Value ?? "0");
                 ((patch_Decal)decal).MakeScaredAnimation(hideRange, showRange, idleFrames, hiddenFrames, showFrames, hideFrames);
+            }},
+            { "randomiseAnimationOffset", delegate(Decal decal, XmlAttributeCollection attrs) {
+                ((patch_Decal)decal).MakeRandomAnimationOffset();
             }},
             { "light", delegate(Decal decal, XmlAttributeCollection attrs) {
                 float offx = attrs["offsetX"] != null ? float.Parse(attrs["offsetX"].Value) : 0f;

--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistry.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistry.cs
@@ -103,7 +103,8 @@ namespace Celeste.Mod {
                 if (attrs["index"] != null)
                     index = int.Parse(attrs["index"].Value);
                 bool blockWaterfalls = attrs["blockWaterfalls"] != null ? bool.Parse(attrs["blockWaterfalls"].Value) : true;
-                ((patch_Decal)decal).MakeSolid(x, y, width, height, index, blockWaterfalls);
+                bool safe = attrs["safe"] != null ? bool.Parse(attrs["safe"].Value) : true;
+                ((patch_Decal)decal).MakeSolid(x, y, width, height, index, blockWaterfalls, safe);
             }},
             { "staticMover", delegate(Decal decal, XmlAttributeCollection attrs) {
                 int x = 0;

--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistry.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistry.cs
@@ -18,8 +18,8 @@ namespace Celeste.Mod {
                 ((patch_Decal)decal).MakeParallax(float.Parse(attrs["amount"].Value));
             }},
             { "scale", delegate(Decal decal, XmlAttributeCollection attrs) {
-                float scalex = attrs["multiplierX"] != null ? float.Parse(attrs["multiplierX"].Value) : 1f;
-                float scaley = attrs["multiplierY"] != null ? float.Parse(attrs["multiplierY"].Value) : 1f;
+                float scalex = attrs["multiplyX"] != null ? float.Parse(attrs["multiplyX"].Value) : 1f;
+                float scaley = attrs["multiplyY"] != null ? float.Parse(attrs["multiplyY"].Value) : 1f;
                 ((patch_Decal)decal).Scale *= new Vector2(scalex, scaley);
             }},
             { "smoke", delegate(Decal decal, XmlAttributeCollection attrs) {
@@ -135,8 +135,8 @@ namespace Celeste.Mod {
                 int[] hiddenFrames = Calc.ReadCSVIntWithTricks(attrs["hiddenFrames"]?.Value ?? "0");
                 ((patch_Decal)decal).MakeScaredAnimation(hideRange, showRange, idleFrames, hiddenFrames, showFrames, hideFrames);
             }},
-            { "randomiseAnimationOffset", delegate(Decal decal, XmlAttributeCollection attrs) {
-                ((patch_Decal)decal).MakeRandomAnimationOffset();
+            { "randomizeFrame", delegate(Decal decal, XmlAttributeCollection attrs) {
+                ((patch_Decal)decal).RandomizeStartingFrame();
             }},
             { "light", delegate(Decal decal, XmlAttributeCollection attrs) {
                 float offx = attrs["offsetX"] != null ? float.Parse(attrs["offsetX"].Value) : 0f;

--- a/Celeste.Mod.mm/Patches/Decal.cs
+++ b/Celeste.Mod.mm/Patches/Decal.cs
@@ -28,6 +28,8 @@ namespace Celeste {
         private float hideRange;
         private float showRange;
 
+        private float frame;
+
         public bool Overlay { get; private set; }
 
         public patch_Decal(string texture, Vector2 position, Vector2 scale, int depth)
@@ -97,7 +99,7 @@ namespace Celeste {
                 OnShake = v => { X += v.X; Y += v.Y; },
             };
             if (jumpThrus)
-                sm.JumpThruChecker = s => s.CollideRect(new Rectangle((int)X + x, (int)X + y, w, h));
+                sm.JumpThruChecker = s => s.CollideRect(new Rectangle((int) X + x, (int) X + y, w, h));
             Add(sm);
         }
 
@@ -116,10 +118,7 @@ namespace Celeste {
             scaredAnimal = true;
         }
 
-        [MonoModIgnore]
-        private float frame;
-
-        public void MakeRandomAnimationOffset() {
+        public void RandomizeStartingFrame() {
             this.frame = Calc.Random.NextFloat(textures.Count);
         }
 

--- a/Celeste.Mod.mm/Patches/Decal.cs
+++ b/Celeste.Mod.mm/Patches/Decal.cs
@@ -31,7 +31,7 @@ namespace Celeste {
         private float frame;
 
         private Solid solid;
-        
+
         private StaticMover staticMover;
 
         public bool Overlay { get; private set; }
@@ -97,6 +97,13 @@ namespace Celeste {
             Scene.Add(solid);
         }
 
+        public void MakeSolid(float x, float y, float w, float h, int surfaceSoundIndex, bool blockWaterfalls = true, bool safe = true) {
+            solid = new Solid(Position + new Vector2(x, y), w, h, safe);
+            solid.BlockWaterfalls = blockWaterfalls;
+            solid.SurfaceSoundIndex = surfaceSoundIndex;
+            Scene.Add(solid);
+        }
+
         public void MakeCoreSwap(string coldPath, string hotPath) {
             Add(image = new CoreSwapImage(GFX.Game[coldPath], GFX.Game[hotPath]));
         }
@@ -110,8 +117,8 @@ namespace Celeste {
                 },
                 OnDisable = () => {
                     Active = Visible = Collidable = false;
-                    if (solid != null) 
-                        solid.Collidable = false; 
+                    if (solid != null)
+                        solid.Collidable = false;
                 },
                 OnEnable = () => {
                     Active = Visible = Collidable = true;

--- a/Celeste.Mod.mm/Patches/Decal.cs
+++ b/Celeste.Mod.mm/Patches/Decal.cs
@@ -116,6 +116,13 @@ namespace Celeste {
             scaredAnimal = true;
         }
 
+        [MonoModIgnore]
+        private float frame;
+
+        public void MakeRandomAnimationOffset() {
+            this.frame = Calc.Random.NextFloat(textures.Count);
+        }
+
         public void MakeOverlay() {
             Overlay = true;
         }


### PR DESCRIPTION
adds a scale property (with independent x and y scaling factors), and an animation offset randomisation one (like how glitch decals work)

closes #462 