### PR TITLE
Implement Custom Backdrops through custom attribute

### DIFF
--- a/Celeste.Mod.mm/Mod/Backdrops/CustomBackdropAttribute.cs
+++ b/Celeste.Mod.mm/Mod/Backdrops/CustomBackdropAttribute.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace Celeste.Mod.Backdrops {
+    /// <summary>
+    /// Marks this backdrop as a Custom <see cref="Backdrop"/>.
+    /// <br></br>
+    /// This Backdrop will be loaded when a matching ID is detected.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public class CustomBackdropAttribute : Attribute {
+        /// <summary>
+        /// A list of unique identifiers for this Backdrop.
+        /// </summary>
+        public string[] IDs { get; }
+
+        /// <summary>
+        /// Marks this backdrop as a Custom <see cref="Backdrop"/>.
+        /// </summary>
+        /// <param name="ids">A list of unique identifiers for this Backdrop.</param>
+        public CustomBackdropAttribute(params string[] ids) {
+            IDs = ids;
+        }
+    }
+}

--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -728,7 +728,6 @@ namespace Celeste.Mod {
                             continue;
                         }
                         patch_MapData.BackdropLoaders[id] = loader;
-                        Console.WriteLine(patch_MapData.BackdropLoaders.Count);
                     }
                 }
             }

--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -653,7 +653,7 @@ namespace Celeste.Mod {
                         genName = genName.Trim();
 
                         patch_EventTrigger.CutsceneLoader loader = null;
-                        
+
                         ConstructorInfo ctor;
                         MethodInfo gen;
 

--- a/Celeste.Mod.mm/Patches/MapData.cs
+++ b/Celeste.Mod.mm/Patches/MapData.cs
@@ -201,6 +201,12 @@ namespace Celeste {
             if (backdropFromMod != null)
                 return backdropFromMod;
 
+            if (BackdropLoaders.TryGetValue(child.Name, out BackdropLoader loader)) {
+                Backdrop loaded = loader(child);
+                if (loaded != null)
+                    return loaded;
+            }
+
             if (child.Name.Equals("rain", StringComparison.OrdinalIgnoreCase)) {
                 patch_RainFG rain = new patch_RainFG();
                 if (child.HasAttr("color"))

--- a/Celeste.Mod.mm/Patches/MapData.cs
+++ b/Celeste.Mod.mm/Patches/MapData.cs
@@ -16,6 +16,9 @@ namespace Celeste {
         public int DetectedStrawberriesIncludingUntracked;
         public List<EntityData> DashlessGoldenberries = new List<EntityData>();
 
+        public delegate Backdrop BackdropLoader(BinaryPacker.Element data);
+        public static readonly Dictionary<string, BackdropLoader> BackdropLoaders = new Dictionary<string, BackdropLoader>();
+
         public MapMetaModeProperties Meta {
             get {
                 MapMeta metaAll = AreaData.Get(Area).GetMeta();


### PR DESCRIPTION
This adds a `CustomBackdropAttribute` attribute class under the `Celeste.Mod.Backdrops` namespace. You can use it instead of subscribing to an everest provides when custom backdrops are loaded. This makes registering custom backdrops much easier, and could have its own section in the wiki, for those who are looking for implementing their own backdrops.

When an Everest module is registered, after looking for custom entities and events, it will, in the same manner, look for custom backdrops. IDs are associated with a loader delegate, and stored in a dictionary in `patch_MapData`.

For loading custom backdrops, the `patch_MapData.LoadCustomBackdrop` will now:
* attempt to load any custom backdrop through the `Everest.Events.Level.OnLoadBackdrop` event, which thus have priority over any other custom backdrop
* search for a matching ID in the dictionary that contains the registered custom backdrops, and invoke the associated loader delegate if found
* do the rest, notably, perform the custom loading of the `rain` backdrop, or return `null`.

Example:
```cs
[CustomBackdrop("CustomBackdrops/Test")]
public class CustomBackdrop : Backdrop {
    public CustomBackdrop (BinaryPacker.Element data)
        : base() {
        int valueA = data.AttrInt("a", defaultValue: 3);
        bool valueB = data.AttrBool("b");
        // etc...
    }

    public override void Update(Scene scene) { ... }
    public override void Render(Scene scene) { ... }
}
```

Similarly to custom entities, instead of having a constructor which takes in a `BinaryPacker.Element`, you can have a static method which takes it in, and returns a `Backdrop`. By default, the method's name must be `Load`, but it can be changed by appending `=Name` at the end of the custom backdrop ID to set it to `Name`, for instance.

```cs
[CustomBackdrop("CustomBackdrops/Test=CreateBackdrop")]
public class CustomBackdrop : Backdrop {
    // ...
    public static Backdrop CreateBackdrop(BinaryPacker.Element data) => new();
}
```


Closes #461.