### PR TITLE
Improve GenerateModAssemblyResolver performance

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -362,7 +362,7 @@ namespace Celeste.Mod {
                     return null;
 
                 foreach (ModContent mod in Content.Mods) {
-                    if (mod is not ZipModContent or FileSystemModContent)
+                    if (mod is not (ZipModContent or FileSystemModContent))
                         continue;
 
                     EverestModuleMetadata meta = mod.Mod;

--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -362,18 +362,15 @@ namespace Celeste.Mod {
                     return null;
 
                 foreach (ModContent mod in Content.Mods) {
-                    if (mod is not (ZipModContent or FileSystemModContent))
-                        continue;
-
                     EverestModuleMetadata meta = mod.Mod;
                     if (meta == null)
                         continue;
 
                     string path = name.Name + ".dll";
                     if (!string.IsNullOrEmpty(meta.DLL)) {
-                        path = Path.Combine(Path.GetDirectoryName(meta.DLL), path);
+                        path = Path.Combine(Path.GetDirectoryName(meta.DLL), path).Replace('\\', '/');
                         if (!string.IsNullOrEmpty(meta.PathDirectory))
-                            path = path.Substring(meta.PathDirectory.Length + 1).Replace(Path.DirectorySeparatorChar, '/');
+                            path = path.Substring(meta.PathDirectory.Length + 1);
                     }
 
                     if (mod.Map.TryGetValue(path, out ModAsset asm) && asm.Type == typeof(AssetTypeAssembly)) {

--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -358,16 +358,15 @@ namespace Celeste.Mod {
             // Handle failed resolution for unregistered assemblies
             AppDomain.CurrentDomain.AssemblyResolve += (asmSender, asmArgs) => {
                 AssemblyName name = asmArgs?.Name == null ? null : new AssemblyName(asmArgs.Name);
-
                 if (string.IsNullOrEmpty(name?.Name))
                     return null;
 
-                string path = name.Name + ".dll";
                 foreach (ModContent mod in Content.Mods) {
                     EverestModuleMetadata meta = mod.Mod;
                     if (meta == null)
                         continue;
-                    
+
+                    string path = name.Name + ".dll";
                     if (!string.IsNullOrEmpty(meta.DLL)) {
                         path = Path.Combine(Path.GetDirectoryName(meta.DLL), path);
                     }
@@ -390,7 +389,6 @@ namespace Celeste.Mod {
                             if (stream != null)
                                 return Relinker.GetRelinkedAssembly(meta, Path.GetFileNameWithoutExtension(filePath), stream);
                         }
-                            
                     }
                 }
 


### PR DESCRIPTION
Alternate implementation of Ja's assembly resolver fix in #424 that checks the content map for the assembly instead of re-crawling already loaded mods. Should maintain current mod loading order, while still removing the performance hit from unzipping archives.

EDIT: one part of the discussion that didn't get posted in Ja's PR is that anything that uses `FakeAssembly.GetTypes[Safe]` also triggers the assembly resolver for each missing type. So anything that re-initializes the tracker like hot reloading, unblacklisting installed dependencies, etc. can cause a massive load spike. Can also occur with CU2 chapter panels and Eevee Helper on room transitions.