### PR TITLE
Allow suppressing error log opening on crash

### DIFF
--- a/Celeste.Mod.mm/Mod/Core/CoreModuleSettings.cs
+++ b/Celeste.Mod.mm/Mod/Core/CoreModuleSettings.cs
@@ -210,6 +210,10 @@ namespace Celeste.Mod.Core {
         [SettingIgnore] // TODO: Show as advanced setting.
         public bool? WhitelistFullOverride { get; set; } = null;
 
+        [SettingInGame(false)]
+        [SettingIgnore] // TODO: Show as advanced setting.
+        public bool OpenErrorLogOnCrash { get; set; } = true;
+
         public string InputGui { get; set; } = "";
 
         private string _MainMenuMode = "";

--- a/Celeste.Mod.mm/Patches/Monocle/ErrorLog.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/ErrorLog.cs
@@ -1,6 +1,7 @@
 ﻿#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
 
 using Celeste.Mod;
+using Celeste.Mod.Core;
 using MonoMod;
 using MonoMod.Utils;
 using System;
@@ -18,6 +19,12 @@ namespace Monocle {
         [MonoModIgnore] // We don't want to change anything about the method...
         [PatchErrorLogWrite] // ... except for manually manipulating the method via MonoModRules
         public static extern void Write(string str);
+
+        public static extern void orig_Open();
+        public static void Open() {
+            if (Environment.GetEnvironmentVariable("EVEREST_NO_ERRORLOG") != "1" && CoreModule.Settings.OpenErrorLogOnCrash)
+                orig_Open();
+        }
 
     }
 }

--- a/Celeste.Mod.mm/Patches/Monocle/ErrorLog.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/ErrorLog.cs
@@ -22,7 +22,7 @@ namespace Monocle {
 
         public static extern void orig_Open();
         public static void Open() {
-            if (Environment.GetEnvironmentVariable("EVEREST_NO_ERRORLOG") != "1" && CoreModule.Settings.OpenErrorLogOnCrash)
+            if (Environment.GetEnvironmentVariable("EVEREST_NO_ERRORLOG_ON_CRASH") != "1" && CoreModule.Settings.OpenErrorLogOnCrash)
                 orig_Open();
         }
 


### PR DESCRIPTION
Changing `OpenErrorLogOnCrash` to `false` in `modsettings-Everest.celeste` or setting the environment variable `EVEREST_NO_ERRORLOG_ON_CRASH` to `1` will prevent the error log from being automatically opened upon crashing.

The env var is more reliable than the setting, because if the game crashes before settings are read, `OpenErrorLogOnCrash` defaults to `true`.

Open to suggestions for better/other names.