### PR TITLE
Regenerate LevelData cache after reload correctly

### DIFF
--- a/Celeste.Mod.mm/Patches/MapData.cs
+++ b/Celeste.Mod.mm/Patches/MapData.cs
@@ -50,10 +50,10 @@ namespace Celeste {
             DetectedCassette = false;
             DetectedStrawberriesIncludingUntracked = 0;
 
-            RegenerateLevelsByNameCache();
-
             try {
                 orig_Load();
+
+                RegenerateLevelsByNameCache();
 
                 foreach (LevelData level in Levels) {
                     foreach (EntityData entity in level.Entities) {


### PR DESCRIPTION
We were calling `RegenerateLevelsByNameCache` before the levels were actually (re)loaded, which means it was using old/empty data to initialize the cache each time.