### PR TITLE
Nearly double Logger.Log performance

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Logger.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Logger.cs
@@ -97,8 +97,8 @@ namespace Celeste.Mod {
         /// <param name="str">The string / message to log.</param>
         public static void Log(LogLevel level, string tag, string str) {
             if (shouldLog(tag, level)) {
-                // desprite what your IDE might be telling you, DO NOT omit the manual .ToString() call, as this will cause unnecessary boxing
-                // On modern runtimes string interpolation is much smarter and omiting that call reduces allocations, but not on Framework
+                // Despite what your IDE might be telling you, DO NOT omit the manual .ToString() call, as this will cause unnecessary boxing.
+                // On modern runtimes string interpolation is much smarter and omitting that call reduces allocations, but not on Framework.
                 Console.WriteLine($"({DateTime.Now.ToString()}) [Everest] [{level.FastToString()}] [{tag}] {str}");
             }
         }

--- a/Celeste.Mod.mm/Mod/Everest/Logger.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Logger.cs
@@ -97,14 +97,9 @@ namespace Celeste.Mod {
         /// <param name="str">The string / message to log.</param>
         public static void Log(LogLevel level, string tag, string str) {
             if (shouldLog(tag, level)) {
-                Console.Write("(");
-                Console.Write(DateTime.Now);
-                Console.Write(") [Everest] [");
-                Console.Write(level.ToString());
-                Console.Write("] [");
-                Console.Write(tag);
-                Console.Write("] ");
-                Console.WriteLine(str);
+                // desprite what your IDE might be telling you, DO NOT omit the manual .ToString() call, as this will cause unnecessary boxing
+                // On modern runtimes string interpolation is much smarter and omiting that call reduces allocations, but not on Framework
+                Console.WriteLine($"({DateTime.Now.ToString()}) [Everest] [{level.FastToString()}] [{tag}] {str}");
             }
         }
 
@@ -165,5 +160,21 @@ namespace Celeste.Mod {
         Info,
         Warn,
         Error
+    }
+
+    public static class LogLevelExtensions {
+        /// <summary>
+        /// Converts this <see cref="LogLevel"/> to its string representation, in a way more performant than <see cref="Enum.ToString()"/>
+        /// </summary>
+        public static string FastToString(this LogLevel level) {
+            return level switch {
+                LogLevel.Verbose => nameof(LogLevel.Verbose),
+                LogLevel.Debug => nameof(LogLevel.Debug),
+                LogLevel.Info => nameof(LogLevel.Info),
+                LogLevel.Warn => nameof(LogLevel.Warn),
+                LogLevel.Error => nameof(LogLevel.Error),
+                _ => level.ToString(),
+            };
+        }
     }
 }


### PR DESCRIPTION
Logging is one of the slowest actions during startup, in my case it takes 20% of startup! Of course, this is related to #336, but the `Logger.Log` function implementation itself is really sub-optimal, as it does tons of `Console.Write` calls, which all flush immediately.

This PR improves the performance of `Logger.Log`, by merging all the `Console.Write` calls into one call with string interpolation. While this does cause extra allocations, making use of allocation-free methods such as using a shared `char[]` buffer didn't seem to provide a significant increase in performance, and IMO it's not worth it, as IO is still ~99% of the cost.

Other minor optimisations:
- Avoiding boxing of the `DateTime` struct by explicitly calling `.ToString()`, despite IDE suggestions.
- Using a custom `.FastToString()` method for converting the `LogLevel` enum to a `string`, a well-known enum performance trick.

```
old:
DONE LOADING (in 13169ms), 2724 spent in Logger.Log (20,6%)
new:
DONE LOADING (in 12544ms), 1521 spent in Logger.Log (12.1%)
```