### PR TITLE
Allow localizing the Granny ch9 easter egg

### DIFF
--- a/Celeste.Mod.mm/Patches/NPC07X_Granny_Ending.cs
+++ b/Celeste.Mod.mm/Patches/NPC07X_Granny_Ending.cs
@@ -44,10 +44,7 @@ namespace MonoMod {
             new ILContext(routine).Invoke(ctx => {
                 ILCursor cursor = new ILCursor(ctx);
 
-                if (!cursor.TryGotoNext(MoveType.After, instr => instr.MatchLdstr("{portrait GRANNY right mock} I see you have discovered Debug Mode."))) {
-                    return;
-                }
-
+                cursor.GotoNext(MoveType.After, instr => instr.MatchLdstr("{portrait GRANNY right mock} I see you have discovered Debug Mode."));
                 cursor.Emit(OpCodes.Call, method.DeclaringType.FindMethod("System.String _GetDebugModeDialog(System.String)"));
             });
         }

--- a/Celeste.Mod.mm/Patches/NPC07X_Granny_Ending.cs
+++ b/Celeste.Mod.mm/Patches/NPC07X_Granny_Ending.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.Xna.Framework;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using MonoMod;
+using MonoMod.Cil;
+using MonoMod.Utils;
+using System;
+using System.Collections;
+
+namespace Celeste {
+    public class patch_NPC07X_Granny_Ending : NPC07X_Granny_Ending {
+        public patch_NPC07X_Granny_Ending(EntityData data, Vector2 offset, bool ch9EasterEgg = false)
+            : base(data, offset, ch9EasterEgg) {
+            // no-op. MonoMod ignores this - we only need this to make the compiler shut up.
+        }
+
+        [MonoModIgnore]
+        [PatchCh9EasterEggText]
+        private extern IEnumerator TalkRoutine(Player player);
+
+        private static string _GetDebugModeDialog(string vanillaDialog) {
+            if (Dialog.Has("CH10_GRANNY_EASTEREGG")) {
+                // dialog key defined by a mod => use this one
+                return Dialog.Get("CH10_GRANNY_EASTEREGG");
+            }
+
+            // dialog key not defined, like vanilla => use the hardcoded one
+            return vanillaDialog;
+        }
+    }
+}
+
+namespace MonoMod {
+    /// <summary>
+    /// Allow a mod to replace the easter egg text by defining it in the language file.
+    /// </summary>
+    [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchCh9EasterEggText))]
+    class PatchCh9EasterEggText : Attribute { }
+
+    static partial class MonoModRules {
+        public static void PatchCh9EasterEggText(MethodDefinition method, CustomAttribute attrib) {
+            MethodDefinition routine = method.GetEnumeratorMoveNext();
+
+            new ILContext(routine).Invoke(ctx => {
+                ILCursor cursor = new ILCursor(ctx);
+
+                if (!cursor.TryGotoNext(MoveType.After, instr => instr.MatchLdstr("{portrait GRANNY right mock} I see you have discovered Debug Mode."))) {
+                    return;
+                }
+
+                cursor.Emit(OpCodes.Call, method.DeclaringType.FindMethod("System.String _GetDebugModeDialog(System.String)"));
+            });
+        }
+    }
+}


### PR DESCRIPTION
I have got a request from someone wanting to translate the "I see you have discovered Debug Mode" line from Granny in the chapter 9 easter egg... except it is added to the game's dialogue through code, rather than through a dialog txt file like the rest of dialogue, probably to hide it away.

**If a mod defines the `CH10_GRANNY_EASTEREGG` key, it is overwritten and therefore doesn't show up in-game.** This PR changes this in order to only use the hardcoded value if no value is already defined for this dialog key.