### PR TITLE
Consume enter press for "q" command

### DIFF
--- a/Celeste.Mod.mm/Mod/Helpers/Commands.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/Commands.cs
@@ -1,10 +1,12 @@
-﻿using Monocle;
+﻿using Microsoft.Xna.Framework.Input;
+using Monocle;
 
 namespace Celeste.Mod.Helpers {
     internal static class Commands {
 
         [Command("q", "hides the command line")]
         public static void Hide() {
+            MInput.Keyboard.CurrentState = new KeyboardState(Keys.Enter);
             Engine.Commands.Open = false;
         }
 

--- a/Celeste.Mod.mm/Mod/Helpers/Commands.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/Commands.cs
@@ -6,7 +6,7 @@ namespace Celeste.Mod.Helpers {
 
         [Command("q", "hides the command line")]
         public static void Hide() {
-            MInput.Keyboard.CurrentState = new KeyboardState(Keys.Enter);
+            MInput.Keyboard.CurrentState = new KeyboardState(Keys.Enter); // trick MInput into thinking Enter was already pressed on previous frame to prevent registering new press
             Engine.Commands.Open = false;
         }
 


### PR DESCRIPTION
This prevents the Enter press when executing the `q` command from being recognized as a new keypress by `MInput`. This fixes the first point of #314 .
Explanation: While the console is open, `MInput` is made to believe that no buttons are pressed. By marking Enter as pressed before closing the console, `MInput` thinks that Enter was already pressed on the previous frame and therefore does not register a new button press.