### PR TITLE
Fix tileset sounds

### DIFF
--- a/Celeste.Mod.mm/Patches/Autotiler.cs
+++ b/Celeste.Mod.mm/Patches/Autotiler.cs
@@ -75,7 +75,7 @@ namespace Celeste {
             } else if (xml.HasAttr("sound")) {
                 SurfaceIndex.TileToIndex[xml.AttrChar("id")] = xml.AttrInt("sound");
             } else if (!SurfaceIndex.TileToIndex.ContainsKey(xml.AttrChar("id"))) {
-                SurfaceIndex.TileToIndex[xml.AttrChar("id")] = SurfaceIndex.Brick; // 8 as fallback instead of 0 to match vanilla's default index
+                SurfaceIndex.TileToIndex[xml.AttrChar("id")] = 0; // fall back to no sound
             }
 
             if (xml.HasAttr("debris"))

--- a/Celeste.Mod.mm/Patches/Autotiler.cs
+++ b/Celeste.Mod.mm/Patches/Autotiler.cs
@@ -75,7 +75,7 @@ namespace Celeste {
             } else if (xml.HasAttr("sound")) {
                 SurfaceIndex.TileToIndex[xml.AttrChar("id")] = xml.AttrInt("sound");
             } else if (!SurfaceIndex.TileToIndex.ContainsKey(xml.AttrChar("id"))) {
-                SurfaceIndex.TileToIndex[xml.AttrChar("id")] = 8; // 8 as fallback instead of 0 to match vanilla's default index
+                SurfaceIndex.TileToIndex[xml.AttrChar("id")] = SurfaceIndex.Brick; // 8 as fallback instead of 0 to match vanilla's default index
             }
 
             if (xml.HasAttr("debris"))

--- a/Celeste.Mod.mm/Patches/Autotiler.cs
+++ b/Celeste.Mod.mm/Patches/Autotiler.cs
@@ -72,8 +72,10 @@ namespace Celeste {
             if (xml.HasAttr("soundPath") && xml.HasAttr("sound")) { // Could accommodate for no sound attr, but requiring it should improve clarity on user's end 
                 SurfaceIndex.TileToIndex[xml.AttrChar("id")] = xml.AttrInt("sound");
                 patch_SurfaceIndex.IndexToCustomPath[xml.AttrInt("sound")] = (xml.Attr("soundPath").StartsWith("event:/") ? "" : "event:/") + xml.Attr("soundPath");
-            } else if (!SurfaceIndex.TileToIndex.ContainsKey(xml.AttrChar("id")) || xml.AttrChar("id") == 'o') { // Backwards-compat: some existing mods use 'o' and overwrite its sound
-                SurfaceIndex.TileToIndex[xml.AttrChar("id")] = xml.HasAttr("sound") ? xml.AttrInt("sound") : 8; // 8 as fallback instead of 0 to match vanilla's default index
+            } else if (xml.HasAttr("sound")) {
+                SurfaceIndex.TileToIndex[xml.AttrChar("id")] = xml.AttrInt("sound");
+            } else if (!SurfaceIndex.TileToIndex.ContainsKey(xml.AttrChar("id"))) {
+                SurfaceIndex.TileToIndex[xml.AttrChar("id")] = 8; // 8 as fallback instead of 0 to match vanilla's default index
             }
 
             if (xml.HasAttr("debris"))


### PR DESCRIPTION
Fix the way tileset sounds are determined. This fixes two related issues introduced by #445 : Foreground tilesets using the same ID as a background tileset would have their sound ID set to the default (reported by tobyaaa on Discord), and tilesets using a vanilla tileset ID would be forced to use the vanilla sound. Now the order of preference goes: explicit sound attribute > hardcoded sound index for vanilla tileset ID > fallback 8 for non-vanilla tileset ID.