### PR TITLE
Draw parallax stylegrounds using single Draw call

### DIFF
--- a/Celeste.Mod.mm/Patches/BackdropRenderer.cs
+++ b/Celeste.Mod.mm/Patches/BackdropRenderer.cs
@@ -1,5 +1,4 @@
-﻿using Celeste;
-using Microsoft.Xna.Framework.Graphics;
+﻿using Microsoft.Xna.Framework.Graphics;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Monocle;

--- a/Celeste.Mod.mm/Patches/BackdropRenderer.cs
+++ b/Celeste.Mod.mm/Patches/BackdropRenderer.cs
@@ -1,75 +1,72 @@
 ﻿using Microsoft.Xna.Framework.Graphics;
-using Mono.Cecil;
-using Mono.Cecil.Cil;
 using Monocle;
 using MonoMod;
-using MonoMod.Cil;
-using MonoMod.Utils;
-using System;
 
 namespace Celeste {
     class patch_BackdropRenderer : BackdropRenderer {
         private bool usingSpritebatch;
+        private bool usingLoopingSpritebatch;
         
+        /// <summary>
+        /// Start a new spritebatch for backdrop rendering that uses SamplerState.PointWrap, but is otherwise identical to the one started by StartSpritebatch.
+        /// </summary>
+        /// <param name="blendState">the blend state for the new spritebatch</param>
         public void StartSpritebatchLooping(BlendState blendState) {
             if (!usingSpritebatch) {
                 Draw.SpriteBatch.Begin(SpriteSortMode.Deferred, blendState, SamplerState.PointWrap, DepthStencilState.None, RasterizerState.CullNone, null, Matrix);
             }
             usingSpritebatch = true;
+            usingLoopingSpritebatch = true;
         }
 
-        [MonoModIgnore]
-        [PatchBackdropRendererRender]
-        public override extern void Render(Scene scene);
-    }
-}
+        [MonoModReplace]
+        public new void EndSpritebatch() {
+            if (usingSpritebatch)
+            {
+                Draw.SpriteBatch.End();
+            }
+            usingSpritebatch = false;
+            usingLoopingSpritebatch = false;
+        }
 
-namespace MonoMod {
-    /// <summary>
-    /// Patches the method to render parallaxes using a wrapping SamplerState.
-    /// </summary>
-    [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchBackdropRendererRender))]
-    class PatchBackdropRendererRenderAttribute : Attribute { }
-
-    static partial class MonoModRules {
-
-        public static void PatchBackdropRendererRender(ILContext context, CustomAttribute attrib) {
-            MethodReference m_BackDropRenderer_StartSpritebatchLooping = context.Method.DeclaringType.FindMethod("StartSpritebatchLooping");
-            TypeReference t_Parallax = context.Module.GetType("Celeste.Parallax");
-            MethodReference m_Parallax_ImprovedRender = t_Parallax.Resolve().FindMethod("ImprovedRender");
-
-            ILCursor cursor = new ILCursor(context);
-
-            /* Change: StartSpritebatch(blendState);
-               to: backdrop is Parallax ? StartSpritebatchLooping(blendState) : StartSpritebatch(blendState); */
-            cursor.GotoNext(instr => instr.MatchCallvirt("Celeste.BackdropRenderer", "StartSpritebatch"));
-            ILLabel beforeStartSpritebatch = cursor.MarkLabel();
-            cursor.MoveBeforeLabels();
-            cursor.Emit(OpCodes.Ldloc_2); // load backdrop
-            cursor.Emit(OpCodes.Isinst, t_Parallax);
-            cursor.Emit(OpCodes.Brfalse_S, beforeStartSpritebatch);
-            cursor.Emit(OpCodes.Callvirt, m_BackDropRenderer_StartSpritebatchLooping);
-            ILLabel nextIf = cursor.DefineLabel();
-            cursor.GotoNext(MoveType.After, instr => instr.MatchCallvirt("Celeste.BackdropRenderer", "StartSpritebatch"));
-            cursor.MarkLabel(nextIf);
-            cursor.Index--;
-            cursor.Emit(OpCodes.Br, nextIf);
-
-            // call ImprovedRender instead of Render for Parallax
-            cursor.GotoNext(instr => instr.MatchLdarg(1), instr => instr.MatchCallvirt("Celeste.Backdrop", "Render"));
-            cursor.Emit(OpCodes.Isinst, t_Parallax);
-            cursor.Emit(OpCodes.Dup);
-            ILLabel parallaxRender = cursor.DefineLabel();
-            cursor.Emit(OpCodes.Brtrue_S, parallaxRender);
-            cursor.Emit(OpCodes.Pop);
-            cursor.Emit(OpCodes.Ldloc_2);
-            cursor.Index += 2;
-            ILLabel continueLoop = cursor.DefineLabel();
-            cursor.Emit(OpCodes.Br, continueLoop);
-            cursor.MarkLabel(parallaxRender);
-            cursor.Emit(OpCodes.Ldarg_1);
-            cursor.Emit(OpCodes.Callvirt, m_Parallax_ImprovedRender);
-            cursor.MarkLabel(continueLoop);
+        [MonoModReplace]
+        public override void Render(Scene scene) {
+            BlendState blendState = BlendState.AlphaBlend;
+            foreach (Backdrop backdrop in Backdrops)
+            {
+                if (backdrop.Visible)
+                {
+                    if (backdrop is Parallax parallax && (!usingLoopingSpritebatch || parallax.BlendState != blendState))
+                    {
+                        EndSpritebatch();
+                        blendState = parallax.BlendState;
+                    }
+                    if (backdrop is not Parallax && backdrop.UseSpritebatch && usingLoopingSpritebatch) { // make sure non-Parallax backdrops are drawn with the normal spritebatch parameters
+                        EndSpritebatch();
+                    }
+                    if (backdrop.UseSpritebatch && !usingSpritebatch)
+                    {
+                        if (backdrop is Parallax)
+                        {
+                            StartSpritebatchLooping(blendState);
+                        }
+                        else
+                        {
+                            StartSpritebatch(blendState);
+                        }
+                    }
+                    if (!backdrop.UseSpritebatch && usingSpritebatch)
+                    {
+                        EndSpritebatch();
+                    }
+                    backdrop.Render(scene);
+                }
+            }
+            if (Fade > 0f)
+            {
+                Draw.Rect(-10f, -10f, 340f, 200f, FadeColor * Fade);
+            }
+            EndSpritebatch();
         }
     }
 }

--- a/Celeste.Mod.mm/Patches/BackdropRenderer.cs
+++ b/Celeste.Mod.mm/Patches/BackdropRenderer.cs
@@ -36,8 +36,8 @@ namespace MonoMod {
         public static void PatchBackdropRendererRender(ILContext context, CustomAttribute attrib) {
             MethodReference m_BackDropRenderer_StartSpritebatchLooping = context.Method.DeclaringType.FindMethod("StartSpritebatchLooping");
             TypeReference t_Parallax = context.Module.GetType("Celeste.Parallax");
-            MethodReference n_Parallax_ImprovedRender = t_Parallax.Resolve().FindMethod("ImprovedRender");
-            
+            MethodReference m_Parallax_ImprovedRender = t_Parallax.Resolve().FindMethod("ImprovedRender");
+
             ILCursor cursor = new ILCursor(context);
 
             /* Change: StartSpritebatch(blendState);
@@ -68,7 +68,7 @@ namespace MonoMod {
             cursor.Emit(OpCodes.Br, continueLoop);
             cursor.MarkLabel(parallaxRender);
             cursor.Emit(OpCodes.Ldarg_1);
-            cursor.Emit(OpCodes.Callvirt, n_Parallax_ImprovedRender);
+            cursor.Emit(OpCodes.Callvirt, m_Parallax_ImprovedRender);
             cursor.MarkLabel(continueLoop);
         }
     }

--- a/Celeste.Mod.mm/Patches/BackdropRenderer.cs
+++ b/Celeste.Mod.mm/Patches/BackdropRenderer.cs
@@ -1,0 +1,59 @@
+﻿using Celeste;
+using Microsoft.Xna.Framework.Graphics;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Monocle;
+using MonoMod;
+using MonoMod.Cil;
+using MonoMod.Utils;
+using System;
+
+namespace Celeste {
+    class patch_BackdropRenderer : BackdropRenderer {
+        private bool usingSpritebatch;
+        
+        public void StartSpritebatchLooping(BlendState blendState) {
+            if (!usingSpritebatch) {
+                Draw.SpriteBatch.Begin(SpriteSortMode.Deferred, blendState, SamplerState.PointWrap, DepthStencilState.None, RasterizerState.CullNone, null, Matrix);
+            }
+            usingSpritebatch = true;
+        }
+
+        [MonoModIgnore]
+        [PatchBackdropRendererRender]
+        public override extern void Render(Scene scene);
+    }
+}
+
+namespace MonoMod {
+    /// <summary>
+    /// Patches the method to begin a wrapping spritebatch for parallaxes.
+    /// </summary>
+    [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchBackdropRendererRender))]
+    class PatchBackdropRendererRenderAttribute : Attribute { }
+
+    static partial class MonoModRules {
+
+        public static void PatchBackdropRendererRender(ILContext context, CustomAttribute attrib) {
+            MethodReference m_BackDropRenderer_StartSpritebatchLooping = context.Method.DeclaringType.FindMethod("StartSpritebatchLooping");
+            TypeReference t_Parallax = context.Module.GetType("Celeste.Parallax");
+            
+            ILCursor cursor = new ILCursor(context);
+
+            /* Change: StartSpritebatch(blendState);
+               to: backdrop is Parallax ? StartSpritebatchLooping(blendState) : StartSpritebatch(blendState); */
+            cursor.GotoNext(instr => instr.MatchCallvirt("Celeste.BackdropRenderer", "StartSpritebatch"));
+            ILLabel beforeStartSpritebatch = cursor.MarkLabel();
+            cursor.MoveBeforeLabels();
+            cursor.Emit(OpCodes.Ldloc_2); // load backdrop
+            cursor.Emit(OpCodes.Isinst, t_Parallax);
+            cursor.Emit(OpCodes.Brfalse_S, beforeStartSpritebatch);
+            cursor.Emit(OpCodes.Callvirt, m_BackDropRenderer_StartSpritebatchLooping);
+            ILLabel nextIf = cursor.DefineLabel();
+            cursor.GotoNext(MoveType.After, instr => instr.MatchCallvirt("Celeste.BackdropRenderer", "StartSpritebatch"));
+            cursor.MarkLabel(nextIf);
+            cursor.Index--;
+            cursor.Emit(OpCodes.Br, nextIf);
+        }
+    }
+}

--- a/Celeste.Mod.mm/Patches/Monocle/MTexture.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/MTexture.cs
@@ -213,6 +213,8 @@ namespace Monocle {
             return new Rectangle(x, y, w, h);
         }
 
+        public bool IsPacked => Width != Texture.Width || Height != Texture.Height;
+
         private static Texture2D CreateUnpackedTexture(Texture2D src, Rectangle rect)
         {
             Texture2D tex = new Texture2D(src.GraphicsDevice, rect.Width, rect.Height);
@@ -309,6 +311,11 @@ namespace Monocle {
         public new void Draw(Vector2 position, Vector2 origin, Color color, Vector2 scale, float rotation, Rectangle clip) {
             float scaleFix = ScaleFix;
             Monocle.Draw.SpriteBatch.Draw(Texture.Texture, position, GetRelativeRect(clip), color, rotation, (origin - DrawOffset) / scaleFix, scale * scaleFix, SpriteEffects.None, 0f);
+        }
+
+        public void Draw(Vector2 position, Vector2 origin, Color color, float scale, float rotation, SpriteEffects flip, Rectangle absoluteClip) {
+            float scaleFix = ScaleFix;
+            Monocle.Draw.SpriteBatch.Draw(Texture.Texture, position, absoluteClip, color, rotation, (origin - DrawOffset) / scaleFix, scale * scaleFix, flip, 0f);
         }
 
         #endregion
@@ -818,16 +825,6 @@ namespace Monocle {
                 }
             }
             Monocle.Draw.SpriteBatch.Draw(Texture.Texture, position, clip, color, rotation, offset, scale, flip, 0f);
-        }
-
-        #endregion
-
-        #region DrawWithWrappingSupport
-
-        public void DrawWithWrappingSupport(Vector2 position, Vector2 origin, Color color, float scale, float rotation, SpriteEffects flip, Rectangle absoluteClip) {
-            float scaleFix = ScaleFix;
-            // TODO does this have to use reflection?
-            Monocle.Draw.SpriteBatch.Draw(typeof(SpriteBatch).GetField("samplerState", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(Monocle.Draw.SpriteBatch) != SamplerState.PointWrap ? Texture.Texture : Unpacked, position, absoluteClip, color, rotation, (origin - DrawOffset) / scaleFix, scale * scaleFix, flip, 0f);
         }
 
         #endregion

--- a/Celeste.Mod.mm/Patches/Monocle/MTexture.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/MTexture.cs
@@ -225,7 +225,7 @@ namespace Monocle {
 
         private Texture2D Unpacked {
             get {
-                unpacked ??= CreateUnpackedTexture(Texture.Texture, ClipRect);
+                unpacked ??= Width == Texture.Width && Height == Texture.Height ? Texture.Texture : CreateUnpackedTexture(Texture.Texture, ClipRect);
                 return unpacked;
             }
         }

--- a/Celeste.Mod.mm/Patches/Monocle/MTexture.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/MTexture.cs
@@ -7,7 +7,6 @@ using Microsoft.Xna.Framework.Graphics;
 using MonoMod;
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 
 namespace Monocle {
     class patch_MTexture : MTexture {
@@ -44,8 +43,6 @@ namespace Monocle {
         private int _OrigHeight;
 
         private List<ModAsset> _ModAssets;
-
-        private Texture2D unpacked;
 
         // Patching constructors is ugly.
         public extern void orig_ctor(patch_MTexture parent, int x, int y, int width, int height);
@@ -214,23 +211,6 @@ namespace Monocle {
         }
 
         public bool IsPacked => Width != Texture.Width || Height != Texture.Height;
-
-        private static Texture2D CreateUnpackedTexture(Texture2D src, Rectangle rect)
-        {
-            Texture2D tex = new Texture2D(src.GraphicsDevice, rect.Width, rect.Height);
-            int count = rect.Width * rect.Height;
-            Color[] data = new Color[count];
-            src.GetData(0, rect, data, 0, count);
-            tex.SetData(data);
-            return tex;
-        }
-
-        private Texture2D Unpacked {
-            get {
-                unpacked ??= Width == Texture.Width && Height == Texture.Height ? Texture.Texture : CreateUnpackedTexture(Texture.Texture, ClipRect);
-                return unpacked;
-            }
-        }
 
         #region Drawing Methods
 

--- a/Celeste.Mod.mm/Patches/Monocle/MTexture.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/MTexture.cs
@@ -68,7 +68,7 @@ namespace Monocle {
         }
 
         /// <summary>
-        /// Override the given MTexutre with the given VirtualTexture and parameters.
+        /// Override the given MTexture with the given VirtualTexture and parameters.
         /// </summary>
         public void SetOverride(VirtualTexture texture, Vector2 drawOffset, int frameWidth, int frameHeight) {
             if (!_HasOrig) {
@@ -89,7 +89,7 @@ namespace Monocle {
         }
 
         /// <summary>
-        /// Override the given MTexutre with the given mod asset.
+        /// Override the given MTexture with the given mod asset.
         /// </summary>
         public void SetOverride(ModAsset asset) {
             if (!_HasOrig && Texture.GetMetadata() == asset) {
@@ -289,6 +289,11 @@ namespace Monocle {
         public new void Draw(Vector2 position, Vector2 origin, Color color, Vector2 scale, float rotation, Rectangle clip) {
             float scaleFix = ScaleFix;
             Monocle.Draw.SpriteBatch.Draw(Texture.Texture, position, GetRelativeRect(clip), color, rotation, (origin - DrawOffset) / scaleFix, scale * scaleFix, SpriteEffects.None, 0f);
+        }
+
+        public void Draw(Vector2 position, Vector2 origin, Color color, float scale, float rotation, SpriteEffects flip, Rectangle absoluteClip) {
+            float scaleFix = ScaleFix;
+            Monocle.Draw.SpriteBatch.Draw(Texture.Texture, position, absoluteClip, color, rotation, (origin - DrawOffset) / scaleFix, scale * scaleFix, flip, 0f);
         }
 
         #endregion

--- a/Celeste.Mod.mm/Patches/Parallax.cs
+++ b/Celeste.Mod.mm/Patches/Parallax.cs
@@ -52,7 +52,9 @@ namespace Celeste {
             if (FlipY) {
                 flip |= SpriteEffects.FlipVertically;
             }
-            Rectangle rect = new Rectangle(0, 0, LoopX ? (int) Math.Ceiling(Celeste.GameWidth - position.X) : Texture.Width, LoopY ? (int) Math.Ceiling(Celeste.GameHeight - position.Y) : Texture.Height);
+            Rectangle rect = new Rectangle(0, 0,
+                                           LoopX ? (int) Math.Ceiling(Celeste.GameWidth - position.X) : Texture.Width,
+                                           LoopY ? (int) Math.Ceiling(Celeste.GameHeight - position.Y) : Texture.Height);
             ((patch_MTexture) Texture).Draw(position, Vector2.Zero, color, 1f, 0f, flip, rect);
         }
     }

--- a/Celeste.Mod.mm/Patches/Parallax.cs
+++ b/Celeste.Mod.mm/Patches/Parallax.cs
@@ -19,6 +19,10 @@ namespace Celeste {
         /// </summary>
         /// <param name="scene">The Level to render the Parallax to.</param>
         public void ImprovedRender(Scene scene) {
+            if (((patch_MTexture) Texture).IsPacked) {
+                Render(scene);
+                return;
+            }
             Vector2 camera = ((scene as Level).Camera.Position + CameraOffset).Floor();
             Vector2 position = (Position - camera * Scroll).Floor();
             float alpha = fadeIn * Alpha * FadeAlphaMultiplier;
@@ -49,7 +53,7 @@ namespace Celeste {
                 flip |= SpriteEffects.FlipVertically;
             }
             Rectangle rect = new Rectangle(0, 0, LoopX ? (int) Math.Ceiling(Celeste.GameWidth - position.X) : Texture.Width, LoopY ? (int) Math.Ceiling(Celeste.GameHeight - position.Y) : Texture.Height);
-            ((patch_MTexture) Texture).DrawWithWrappingSupport(position, Vector2.Zero, color, 1f, 0f, flip, rect);
+            ((patch_MTexture) Texture).Draw(position, Vector2.Zero, color, 1f, 0f, flip, rect);
         }
     }
 }

--- a/Celeste.Mod.mm/Patches/Parallax.cs
+++ b/Celeste.Mod.mm/Patches/Parallax.cs
@@ -17,7 +17,7 @@ namespace Celeste {
 
         private void DrawParallax(Vector2 position, Color color, SpriteEffects flip) {
             Rectangle rect = new Rectangle(0, 0, LoopX ? Celeste.GameWidth : Texture.Width, LoopY ? Celeste.GameHeight : Texture.Height);
-            ((patch_MTexture) Texture).Draw(position, Vector2.Zero, color, 1f, 0f, flip, rect);
+            ((patch_MTexture) Texture).DrawWithWrappingSupport(position, Vector2.Zero, color, 1f, 0f, flip, rect);
         }
 
         [MonoModIgnore]

--- a/Celeste.Mod.mm/Patches/Parallax.cs
+++ b/Celeste.Mod.mm/Patches/Parallax.cs
@@ -1,9 +1,11 @@
 ﻿#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
+#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
 
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Monocle;
 using System;
+using System.Reflection;
 
 namespace Celeste {
     class patch_Parallax : Parallax {
@@ -14,13 +16,15 @@ namespace Celeste {
             // no-op, ignored by MonoMod
         }
 
-        /// <summary>
-        /// An optimized version of the vanilla Render method. Only works if the SamplerState is set to PointWrap.
-        /// </summary>
-        /// <param name="scene">The Level to render the Parallax to.</param>
-        public void ImprovedRender(Scene scene) {
-            if (((patch_MTexture) Texture).IsPacked) {
-                Render(scene);
+        public extern void orig_Render(Scene scene);
+
+        // not pretty, but because of SpriteSortMode.Deferred, we can't just check Draw.SpriteBatch.GraphicsDevice.SamplerStates[0], so we need reflection since we can't patch XNA
+        private static readonly FieldInfo spriteBatchSamplerState = typeof(SpriteBatch).GetField("samplerState", BindingFlags.Instance | BindingFlags.NonPublic);
+        public override void Render(Scene scene) {
+            if (((patch_MTexture) Texture).IsPacked // atlas-packed textures do not support wrapping spritebatches and are therefore drawn normally
+                || spriteBatchSamplerState.GetValue(Draw.SpriteBatch) != SamplerState.PointWrap) { // if Parallax.Render is called from outside BackdropRenderer.Render, it might use a different SamplerState
+                // in either case, fall back to vanilla rendering
+                orig_Render(scene);
                 return;
             }
             Vector2 camera = ((scene as Level).Camera.Position + CameraOffset).Floor();
@@ -39,6 +43,7 @@ namespace Celeste {
             if (color.A <= 1) {
                 return;
             }
+            // use modulo instead of vanilla's loops, which might be very inefficient for a small looping styleground far offscreen
             if (LoopX) {
                 position.X = (position.X % Texture.Width - Texture.Width) % Texture.Width;
             }
@@ -55,7 +60,7 @@ namespace Celeste {
             Rectangle rect = new Rectangle(0, 0,
                                            LoopX ? (int) Math.Ceiling(Celeste.GameWidth - position.X) : Texture.Width,
                                            LoopY ? (int) Math.Ceiling(Celeste.GameHeight - position.Y) : Texture.Height);
-            ((patch_MTexture) Texture).Draw(position, Vector2.Zero, color, 1f, 0f, flip, rect);
+            ((patch_MTexture) Texture).Draw(position, Vector2.Zero, color, 1f, 0f, flip, rect); // take advantage of the PointWrap sampler state to draw in a single draw call
         }
     }
 }

--- a/Celeste.Mod.mm/Patches/Parallax.cs
+++ b/Celeste.Mod.mm/Patches/Parallax.cs
@@ -1,0 +1,60 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Monocle;
+using MonoMod;
+using MonoMod.Cil;
+using MonoMod.Utils;
+using System;
+
+namespace Celeste {
+    class patch_Parallax : Parallax {
+        
+        public patch_Parallax(MTexture texture) : base(texture) {
+            // no-op, ignored by MonoMod
+        }
+
+        private void DrawParallax(Vector2 position, Color color, SpriteEffects flip) {
+            Rectangle rect = new Rectangle(0, 0, LoopX ? Celeste.GameWidth : Texture.Width, LoopY ? Celeste.GameHeight : Texture.Height);
+            ((patch_MTexture) Texture).Draw(position, Vector2.Zero, color, 1f, 0f, flip, rect);
+        }
+
+        [MonoModIgnore]
+        [PatchParallaxRender]
+        public override extern void Render(Scene scene);
+    }
+}
+
+namespace MonoMod {
+    /// <summary>
+    /// Patches the method to replace looped Draw calls with single call.
+    /// </summary>
+    [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchParallaxRender))]
+    class PatchParallaxRenderAttribute : Attribute { }
+
+    static partial class MonoModRules {
+
+        public static void PatchParallaxRender(ILContext context, CustomAttribute attrib) {
+            MethodDefinition m_Parallax_DrawParallax = context.Method.DeclaringType.FindMethod("DrawParallax");
+
+            ILCursor cursor = new ILCursor(context);
+
+            cursor.GotoNext(MoveType.After, instr => instr.MatchLdfld("Celeste.Backdrop", "FlipY"),
+                                            instr => instr.MatchBrfalse(out _),
+                                            instr => instr.MatchLdcI4(2),
+                                            instr => instr.MatchStloc(4),
+                                            instr => instr.MatchLdloc(1),
+                                            instr => instr.MatchLdfld("Microsoft.Xna.Framework.Vector2", "X"));
+            cursor.Index -= 2;
+            cursor.MoveAfterLabels();
+            cursor.RemoveRange(cursor.Instrs.Count - cursor.Index - 1); // delete rest of method except ret instruction
+            cursor.MoveAfterLabels();
+            cursor.Emit(OpCodes.Ldarg_0);
+            cursor.Emit(OpCodes.Ldloc_1); // position
+            cursor.Emit(OpCodes.Ldloc_3); // color
+            cursor.Emit(OpCodes.Ldloc_S, (byte) 4); // flip
+            cursor.Emit(OpCodes.Callvirt, m_Parallax_DrawParallax);
+        }
+    }
+}

--- a/Celeste.Mod.mm/Patches/Parallax.cs
+++ b/Celeste.Mod.mm/Patches/Parallax.cs
@@ -3,7 +3,6 @@
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Monocle;
-using MonoMod;
 using System;
 
 namespace Celeste {
@@ -15,8 +14,11 @@ namespace Celeste {
             // no-op, ignored by MonoMod
         }
 
-        [MonoModReplace]
-        public override void Render(Scene scene) {
+        /// <summary>
+        /// An optimized version of the vanilla Render method. Only works if the SamplerState is set to PointWrap.
+        /// </summary>
+        /// <param name="scene">The Level to render the Parallax to.</param>
+        public void ImprovedRender(Scene scene) {
             Vector2 camera = ((scene as Level).Camera.Position + CameraOffset).Floor();
             Vector2 position = (Position - camera * Scroll).Floor();
             float alpha = fadeIn * Alpha * FadeAlphaMultiplier;


### PR DESCRIPTION
Previously, looping Parallax stylegrounds were drawn using a nested loop of Draw calls, leading to poor performance especially for small stylegrounds. This PR instead creates a `PointWrap` spritebatch for parallaxes so they can be drawn using a single Draw call. This fixes #464 .
Profiling results for a 1x1 pixel styleground looping on both axes:
Before:
![image](https://user-images.githubusercontent.com/46748261/182223205-f33d1c00-0ec4-4a12-8bc9-b702cdc3d2db.png)
After:
![image](https://user-images.githubusercontent.com/46748261/182223261-f71c7fbb-e401-4447-bcde-07b5aea26421.png)
The time spent in `Parallax.Draw()` has been reduced from 4% to <0.01%.

Submitted as draft because I have done very limited testing so far. Needs to be tested in actual maps and with scroll, flip etc. attributes to make sure it always produces the same result as previously. Other necessary test: `HeatWave.Render` directly calls `Parallax.Render`, but currently does not have the looping spritebatch. It needs to be checked whether that still works or requires additional changes.
Also the IL patches need to be commented more.