### PR TITLE
Minor Decal Registry cleanup

### DIFF
--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistry.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistry.cs
@@ -29,7 +29,7 @@ namespace Celeste.Mod {
                 float offY = attrs["offsetY"] != null ? float.Parse(attrs["offsetY"].Value) : 0f;
                 bool inbg = attrs["inbg"] != null ? bool.Parse(attrs["inbg"].Value) : false;
 
-                Vector2 offset = ScaleOffset(((patch_Decal)decal).Scale, offX, offY);
+                Vector2 offset = decal.GetScaledOffset(offX, offY);
 
                 ((patch_Decal)decal).CreateSmoke(offset, inbg);
             }},
@@ -54,8 +54,8 @@ namespace Celeste.Mod {
                 float alpha = attrs["alpha"] != null ? float.Parse(attrs["alpha"].Value) : 1f;
                 float radius = attrs["radius"] != null ? float.Parse(attrs["radius"].Value) : 1f;
 
-                Vector2 offset = ScaleOffset(((patch_Decal)decal).Scale, offX, offY);
-                radius = ScaleRadius(((patch_Decal)decal).Scale, radius);
+                Vector2 offset = decal.GetScaledOffset(offX, offY);
+                radius = decal.GetScaledRadius(radius);
 
                 decal.Add(new BloomPoint(offset, alpha, radius));
             }},
@@ -93,7 +93,7 @@ namespace Celeste.Mod {
                 bool blockWaterfalls = attrs["blockWaterfalls"] != null ? bool.Parse(attrs["blockWaterfalls"].Value) : true;
                 bool safe = attrs["safe"] != null ? bool.Parse(attrs["safe"].Value) : true;
 
-                ScaleRectangle(((patch_Decal)decal).Scale, ref x, ref y, ref width, ref height);
+                decal.ScaleRectangle(ref x, ref y, ref width, ref height);
 
                 ((patch_Decal)decal).MakeSolid(x, y, width, height, index, blockWaterfalls, safe);
             }},
@@ -103,7 +103,7 @@ namespace Celeste.Mod {
                 int width = attrs["width"] != null ? int.Parse(attrs["width"].Value) : 16;
                 int height = attrs["height"] != null ? int.Parse(attrs["height"].Value) : 16;
 
-                ScaleRectangle(((patch_Decal)decal).Scale, ref x, ref y, ref width, ref height);
+                decal.ScaleRectangle(ref x, ref y, ref width, ref height);
 
                 ((patch_Decal)decal).MakeStaticMover(x, y, width, height);
             }},
@@ -121,8 +121,8 @@ namespace Celeste.Mod {
                 int[] hideFrames = Calc.ReadCSVIntWithTricks(attrs["hideFrames"]?.Value ?? "0");
                 int[] showFrames = Calc.ReadCSVIntWithTricks(attrs["showFrames"]?.Value ?? "0");
 
-                hideRange = (int) ScaleRadius(((patch_Decal)decal).Scale, hideRange);
-                showRange = (int) ScaleRadius(((patch_Decal)decal).Scale, showRange);
+                hideRange = (int) decal.GetScaledRadius(hideRange);
+                showRange = (int) decal.GetScaledRadius(showRange);
 
                 ((patch_Decal)decal).MakeScaredAnimation(hideRange, showRange, idleFrames, hiddenFrames, showFrames, hideFrames);
             }},
@@ -137,9 +137,9 @@ namespace Celeste.Mod {
                 int startFade = attrs["startFade"] != null ? int.Parse(attrs["startFade"].Value) : 16;
                 int endFade = attrs["endFade"] != null ? int.Parse(attrs["endFade"].Value) : 24;
 
-                Vector2 offset = ScaleOffset(((patch_Decal)decal).Scale, offX, offY);
-                startFade = (int) ScaleRadius(((patch_Decal)decal).Scale, startFade);
-                endFade = (int) ScaleRadius(((patch_Decal)decal).Scale, endFade);
+                Vector2 offset = decal.GetScaledOffset(offX, offY);
+                startFade = (int) decal.GetScaledRadius(startFade);
+                endFade = (int) decal.GetScaledRadius(endFade);
 
                 decal.Add(new VertexLight(offset, color, alpha, startFade, endFade));
             }},
@@ -150,7 +150,7 @@ namespace Celeste.Mod {
                 int height = attrs["height"] != null ? int.Parse(attrs["height"].Value) : 16;
                 float alpha = attrs["alpha"] != null ? float.Parse(attrs["alpha"].Value) : 1f;
 
-                ScaleRectangle(((patch_Decal)decal).Scale, ref x, ref y, ref width, ref height);
+                decal.ScaleRectangle(ref x, ref y, ref width, ref height);
 
                 decal.Add(new LightOcclude(new Rectangle(x, y, width, height), alpha));
             }},
@@ -158,34 +158,6 @@ namespace Celeste.Mod {
                 ((patch_Decal)decal).MakeOverlay();
             }},
         };
-
-        public static Vector2 ScaleOffset(Vector2 scale, float x, float y) {
-            return new Vector2(x * scale.X, y * scale.Y);
-        }
-
-        public static float ScaleRadius(Vector2 scale, float radius) { 
-            return radius * ((Math.Abs(scale.X) + Math.Abs(scale.Y)) / 2f);
-        }
-
-        public static void ScaleRectangle(Vector2 scale, ref float x, ref float y, ref float width, ref float height) {
-            x *= Math.Abs(scale.X);
-            y *= Math.Abs(scale.Y);
-            width *= Math.Abs(scale.X);
-            height *= Math.Abs(scale.Y);
-
-            x = (scale.X < 0) ? -x - width : x;
-            y = (scale.Y < 0) ? -y - height : y;
-        }
-
-        public static void ScaleRectangle(Vector2 scale, ref int x, ref int y, ref int width, ref int height) {
-            x = (int) (x * Math.Abs(scale.X));
-            y = (int) (y * Math.Abs(scale.Y));
-            width = (int) (width * Math.Abs(scale.X));
-            height = (int) (height * Math.Abs(scale.Y));
-
-            x = (scale.X < 0) ? -x - width : x;
-            y = (scale.Y < 0) ? -y - height : y;
-        }
 
         public static Dictionary<string, DecalInfo> RegisteredDecals = new Dictionary<string, DecalInfo>();
 

--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistry.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistry.cs
@@ -159,6 +159,37 @@ namespace Celeste.Mod {
             }},
         };
 
+        // Helper functions for scaling Decal Registry fields
+        public static Vector2 GetScaledOffset(this Decal self, float x, float y) {
+            return new Vector2(x * ((patch_Decal) self).Scale.X, y * ((patch_Decal) self).Scale.Y);
+        }
+
+        public static float GetScaledRadius(this Decal self, float radius) {
+            return radius * ((Math.Abs(((patch_Decal) self).Scale.X) + Math.Abs(((patch_Decal) self).Scale.Y)) / 2f);
+        }
+
+        public static void ScaleRectangle(this Decal self, ref float x, ref float y, ref float width, ref float height) {
+            Vector2 scale = ((patch_Decal) self).Scale;
+            x *= Math.Abs(scale.X);
+            y *= Math.Abs(scale.Y);
+            width *= Math.Abs(scale.X);
+            height *= Math.Abs(scale.Y);
+
+            x = (scale.X < 0) ? -x - width : x;
+            y = (scale.Y < 0) ? -y - height : y;
+        }
+
+        public static void ScaleRectangle(this Decal self, ref int x, ref int y, ref int width, ref int height) {
+            Vector2 scale = ((patch_Decal) self).Scale;
+            x = (int) (x * Math.Abs(scale.X));
+            y = (int) (y * Math.Abs(scale.Y));
+            width = (int) (width * Math.Abs(scale.X));
+            height = (int) (height * Math.Abs(scale.Y));
+
+            x = (scale.X < 0) ? -x - width : x;
+            y = (scale.Y < 0) ? -y - height : y;
+        }
+
         public static Dictionary<string, DecalInfo> RegisteredDecals = new Dictionary<string, DecalInfo>();
 
         public static void AddPropertyHandler(string propertyName, Action<Decal, XmlAttributeCollection> action) {

--- a/Celeste.Mod.mm/Patches/Decal.cs
+++ b/Celeste.Mod.mm/Patches/Decal.cs
@@ -233,6 +233,36 @@ namespace Celeste {
             => ((patch_Decal) self).Scale;
         public static void SetScale(this Decal self, Vector2 value)
             => ((patch_Decal) self).Scale = value;
+
+        public static Vector2 GetScaledOffset(this Decal self, float x, float y) {
+            return new Vector2(x * ((patch_Decal) self).Scale.X, y * ((patch_Decal) self).Scale.Y);
+        }
+
+        public static float GetScaledRadius(this Decal self, float radius) {
+            return radius * ((Math.Abs(((patch_Decal) self).Scale.X) + Math.Abs(((patch_Decal) self).Scale.Y)) / 2f);
+        }
+
+        public static void ScaleRectangle(this Decal self, ref float x, ref float y, ref float width, ref float height) {
+            Vector2 scale = ((patch_Decal) self).Scale;
+            x *= Math.Abs(scale.X);
+            y *= Math.Abs(scale.Y);
+            width *= Math.Abs(scale.X);
+            height *= Math.Abs(scale.Y);
+
+            x = (scale.X < 0) ? -x - width : x;
+            y = (scale.Y < 0) ? -y - height : y;
+        }
+
+        public static void ScaleRectangle(this Decal self, ref int x, ref int y, ref int width, ref int height) {
+            Vector2 scale = ((patch_Decal) self).Scale;
+            x = (int) (x * Math.Abs(scale.X));
+            y = (int) (y * Math.Abs(scale.Y));
+            width = (int) (width * Math.Abs(scale.X));
+            height = (int) (height * Math.Abs(scale.Y));
+
+            x = (scale.X < 0) ? -x - width : x;
+            y = (scale.Y < 0) ? -y - height : y;
+        }
     }
 }
 

--- a/Celeste.Mod.mm/Patches/Decal.cs
+++ b/Celeste.Mod.mm/Patches/Decal.cs
@@ -132,10 +132,9 @@ namespace Celeste {
                 OnMove = v => {
                     Position += v;
                     if (solid != null) {
-                        if (staticMover.Platform != null)
-                            solid.LiftSpeed = staticMover.Platform.LiftSpeed;
-                        solid.MoveHExact((int) v.X);
-                        solid.MoveVExact((int) v.Y);
+                        Vector2 liftSpeed = (staticMover.Platform != null) ? staticMover.Platform.LiftSpeed : Vector2.Zero;
+                        solid.MoveH(v.X, liftSpeed.X);
+                        solid.MoveV(v.Y, liftSpeed.Y);
                     }
                 },
                 OnShake = v => { Position += v; },

--- a/Celeste.Mod.mm/Patches/Decal.cs
+++ b/Celeste.Mod.mm/Patches/Decal.cs
@@ -227,42 +227,13 @@ namespace Celeste {
             RemoveSelf();
         }
     }
+
     public static class DecalExt {
 
         public static Vector2 GetScale(this Decal self)
             => ((patch_Decal) self).Scale;
         public static void SetScale(this Decal self, Vector2 value)
             => ((patch_Decal) self).Scale = value;
-
-        public static Vector2 GetScaledOffset(this Decal self, float x, float y) {
-            return new Vector2(x * ((patch_Decal) self).Scale.X, y * ((patch_Decal) self).Scale.Y);
-        }
-
-        public static float GetScaledRadius(this Decal self, float radius) {
-            return radius * ((Math.Abs(((patch_Decal) self).Scale.X) + Math.Abs(((patch_Decal) self).Scale.Y)) / 2f);
-        }
-
-        public static void ScaleRectangle(this Decal self, ref float x, ref float y, ref float width, ref float height) {
-            Vector2 scale = ((patch_Decal) self).Scale;
-            x *= Math.Abs(scale.X);
-            y *= Math.Abs(scale.Y);
-            width *= Math.Abs(scale.X);
-            height *= Math.Abs(scale.Y);
-
-            x = (scale.X < 0) ? -x - width : x;
-            y = (scale.Y < 0) ? -y - height : y;
-        }
-
-        public static void ScaleRectangle(this Decal self, ref int x, ref int y, ref int width, ref int height) {
-            Vector2 scale = ((patch_Decal) self).Scale;
-            x = (int) (x * Math.Abs(scale.X));
-            y = (int) (y * Math.Abs(scale.Y));
-            width = (int) (width * Math.Abs(scale.X));
-            height = (int) (height * Math.Abs(scale.Y));
-
-            x = (scale.X < 0) ? -x - width : x;
-            y = (scale.Y < 0) ? -y - height : y;
-        }
     }
 }
 


### PR DESCRIPTION
1. In some situations, MoveStaticMovers is called with subpixel amounts. Could potentially cause issues over time so might as well use MoveH/V instead
2. Moved the scaling functions to DecalExt so they're a bit more visible/intuitive to use. Will edit wiki as well