### PR TITLE
Add flagSwap decal registry attribute

### DIFF
--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistry.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistry.cs
@@ -60,8 +60,7 @@ namespace Celeste.Mod {
                 decal.Add(new BloomPoint(offset, alpha, radius));
             }},
             { "coreSwap", delegate(Decal decal, XmlAttributeCollection attrs) {
-                if (attrs["coldPath"] != null && attrs["hotPath"] != null)
-                    ((patch_Decal)decal).MakeCoreSwap(attrs["coldPath"].Value, attrs["hotPath"].Value);
+                ((patch_Decal)decal).MakeFlagSwap("cold", attrs["hotPath"]?.Value, attrs["coldPath"]?.Value);
             }},
             { "mirror", delegate(Decal decal, XmlAttributeCollection attrs) {
                 string text = decal.Name.ToLower();

--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistry.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistry.cs
@@ -157,6 +157,10 @@ namespace Celeste.Mod {
             { "overlay", delegate(Decal decal, XmlAttributeCollection attrs) {
                 ((patch_Decal)decal).MakeOverlay();
             }},
+            { "flagSwap", delegate(Decal decal, XmlAttributeCollection attrs) {
+                if (attrs["flag"] != null)
+                    ((patch_Decal)decal).MakeFlagSwap(attrs["flag"].Value, attrs["offPath"]?.Value, attrs["onPath"]?.Value);
+            }},
         };
 
         public static Vector2 ScaleOffset(Vector2 scale, float x, float y) {

--- a/Celeste.Mod.mm/Patches/Decal.cs
+++ b/Celeste.Mod.mm/Patches/Decal.cs
@@ -59,6 +59,33 @@ namespace Celeste {
             }
         }
 
+        private class FlagSwapImage : Component {
+
+            private string flag;
+            private List<MTexture> off;
+            private List<MTexture> on;
+            private List<MTexture> activeTextures => (Scene as Level).Session.GetFlag(flag) ? on : off;
+            private int loopCount;
+            private float frame;
+            public patch_Decal Decal => (patch_Decal) Entity;
+
+            public FlagSwapImage(string flag, List<MTexture> off, List<MTexture> on) : base(active: true, visible: true) {
+                this.flag = flag;
+                this.off = off;
+                this.on = on;
+                loopCount = (Math.Max(off.Count, 1)) * (Math.Max(on.Count, 1));
+            }
+
+            public override void Update() {
+                frame = (frame + Decal.AnimationSpeed * Engine.DeltaTime) % loopCount;
+            }
+
+            public override void Render() {
+                if (activeTextures.Count > 0)
+                    activeTextures[(int) frame % activeTextures.Count].DrawCentered(Decal.Position, Color.White, Decal.scale);
+            }
+        }
+
         public extern void orig_ctor(string texture, Vector2 position, Vector2 scale, int depth);
         [MonoModConstructor]
         public void ctor(string texture, Vector2 position, Vector2 scale, int depth) {
@@ -110,6 +137,11 @@ namespace Celeste {
 
         public void MakeCoreSwap(string coldPath, string hotPath) {
             Add(image = new CoreSwapImage(GFX.Game[coldPath], GFX.Game[hotPath]));
+        }
+
+        public void MakeFlagSwap(string flag, string offPath, string onPath) {
+            Add(image = new FlagSwapImage(flag, offPath != null ? GFX.Game.GetAtlasSubtextures(offPath) : new List<MTexture>(),
+                                                onPath != null ? GFX.Game.GetAtlasSubtextures(onPath) : new List<MTexture>()));
         }
 
         public void MakeStaticMover(int x, int y, int w, int h, bool jumpThrus = false) {

--- a/Celeste.Mod.mm/Patches/Decal.cs
+++ b/Celeste.Mod.mm/Patches/Decal.cs
@@ -73,7 +73,7 @@ namespace Celeste {
                 this.flag = flag;
                 this.off = off;
                 this.on = on;
-                loopCount = (Math.Max(off.Count, 1)) * (Math.Max(on.Count, 1));
+                loopCount = Math.Max(off.Count, 1) * Math.Max(on.Count, 1);
             }
 
             public override void Update() {
@@ -135,6 +135,7 @@ namespace Celeste {
             Scene.Add(solid);
         }
 
+        [Obsolete("Use MakeFlagSwap with the cold flag instead.")]
         public void MakeCoreSwap(string coldPath, string hotPath) {
             Add(image = new CoreSwapImage(GFX.Game[coldPath], GFX.Game[hotPath]));
         }


### PR DESCRIPTION
This adds a decal registry attribute that allows swapping decal textures based on a flag. It mostly works analogously to the `coreSwap` attribute, except it uses a flag instead of core mode and it can handle animations as well as omitting one of the paths to make a decal only visible on one flag state. It's worth considering making those changes to the `coreSwap` attribute as well, which would probably just mean calling `MakeFlagSwap` with the `cold` flag and retiring `MakeCoreSwap`.