### PR TITLE
Fix dreaming bonfire lighting animation

### DIFF
--- a/Celeste.Mod.mm/Patches/Bonfire.cs
+++ b/Celeste.Mod.mm/Patches/Bonfire.cs
@@ -1,0 +1,26 @@
+﻿#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
+#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
+
+using Microsoft.Xna.Framework;
+using Monocle;
+using MonoMod;
+
+namespace Celeste {
+    class patch_Bonfire : Bonfire {
+
+        private Sprite sprite;
+
+        public patch_Bonfire(EntityData data, Vector2 offset) : base(data, offset) {
+            //no-op, ignored by MonoMod
+        }
+
+        public extern void orig_ctor(Vector2 position, Mode mode);
+
+        [MonoModConstructor]
+        public void ctor(Vector2 position, Mode mode) {
+            orig_ctor(position, mode);
+
+            ((patch_Sprite) sprite).Animations["startDream"].Goto = new Chooser<string>("burnDream"); // replace non-existent goto animation "dreamy" with correct animation
+        }
+    }
+}

--- a/Celeste.Mod.mm/Patches/Bonfire.cs
+++ b/Celeste.Mod.mm/Patches/Bonfire.cs
@@ -22,7 +22,7 @@ namespace Celeste {
             orig_ctor(position, mode);
 
             Dictionary<string, patch_Sprite.Animation> animations = ((patch_Sprite) sprite).Animations;
-            if (animations.ContainsKey("startDream") && animations["startDream"].Goto[0].Equals("dreamy") && !animations.ContainsKey("dreamy"))
+            if (animations.ContainsKey("startDream") && (animations["startDream"].Goto?[0].Equals("dreamy") ?? false) && !animations.ContainsKey("dreamy"))
                 animations["startDream"].Goto = new Chooser<string>("burnDream"); // replace non-existent goto animation "dreamy" with correct animation
         }
     }

--- a/Celeste.Mod.mm/Patches/Bonfire.cs
+++ b/Celeste.Mod.mm/Patches/Bonfire.cs
@@ -4,6 +4,7 @@
 using Microsoft.Xna.Framework;
 using Monocle;
 using MonoMod;
+using System.Collections.Generic;
 
 namespace Celeste {
     class patch_Bonfire : Bonfire {
@@ -20,7 +21,9 @@ namespace Celeste {
         public void ctor(Vector2 position, Mode mode) {
             orig_ctor(position, mode);
 
-            ((patch_Sprite) sprite).Animations["startDream"].Goto = new Chooser<string>("burnDream"); // replace non-existent goto animation "dreamy" with correct animation
+            Dictionary<string, patch_Sprite.Animation> animations = ((patch_Sprite) sprite).Animations;
+            if (animations.ContainsKey("startDream") && animations["startDream"].Goto[0].Equals("dreamy") && !animations.ContainsKey("dreamy"))
+                animations["startDream"].Goto = new Chooser<string>("burnDream"); // replace non-existent goto animation "dreamy" with correct animation
         }
     }
 }


### PR DESCRIPTION
The `startDream` animation, which is used when lighting a bonfire in a map with the Dreaming metadata option, is specified in the vanilla Sprites.xml as `<Anim id="startDream" path="fire" delay="0.1" frames="0-6" goto="dreamy"/>`. However, the `dreamy` animation does not exist, leading to a crash when this animation is played, such as in a custom animation or in a Randomizer map (as reported by sese müller on Discord). This patches the `Bonfire` constructor to set that animation's goto to the `burnDream` animation instead, which seems like the intended behavior.
While this does not fix cases where mod code creates the `campfire` sprite manually, I was not able to find any kind of custom bonfire entity on the modded entity list, and any sort of deeper fix would have to be very invasive into the sprite creation code and would have to interpret whether the animation is being used intentionally or unintentionally.