### PR TITLE
Set explicit log levels

### DIFF
--- a/Celeste.Mod.mm/Mod/Core/CoreModule.cs
+++ b/Celeste.Mod.mm/Mod/Core/CoreModule.cs
@@ -77,7 +77,7 @@ namespace Celeste.Mod.Core {
                 files.Sort(new LogRotationHelper.OldestFirst());
                 int historyToDelete = files.Count - historyToKeep;
                 foreach (string file in files.Take(historyToDelete)) {
-                    Logger.Log("core", $"log.txt history: keeping {historyToKeep} file(s) of history, deleting {file}");
+                    Logger.Log(LogLevel.Verbose, "core", $"log.txt history: keeping {historyToKeep} file(s) of history, deleting {file}");
                     File.Delete(file);
                 }
             }
@@ -140,7 +140,7 @@ namespace Celeste.Mod.Core {
             ILCursor cursor = new ILCursor(il);
 
             while (cursor.TryGotoNext(instr => instr.MatchCallvirt<Assembly>("GetTypes"))) {
-                Logger.Log("core", $"Redirecting Assembly.GetTypes => Extensions.GetTypesSafe in {il.Method.FullName}, index {cursor.Index}");
+                Logger.Log(LogLevel.Verbose, "core", $"Redirecting Assembly.GetTypes => Extensions.GetTypesSafe in {il.Method.FullName}, index {cursor.Index}");
                 cursor.Next.OpCode = OpCodes.Call;
                 cursor.Next.Operand = typeof(Extensions).GetMethod("GetTypesSafe");
             }

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Content.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Content.cs
@@ -269,12 +269,12 @@ namespace Celeste.Mod {
             if (e.ChangeType == WatcherChangeTypes.Changed && Directory.Exists(e.FullPath))
                 return;
 
-            Logger.Log("content", $"File updated: {e.FullPath} - {e.ChangeType}");
+            Logger.Log(LogLevel.Verbose, "content", $"File updated: {e.FullPath} - {e.ChangeType}");
             QueuedTaskHelper.Do(e.FullPath, () => Update(e.FullPath, e.FullPath));
         }
 
         private void FileRenamed(object source, RenamedEventArgs e) {
-            Logger.Log("content", $"File renamed: {e.OldFullPath} - {e.FullPath}");
+            Logger.Log(LogLevel.Verbose, "content", $"File renamed: {e.OldFullPath} - {e.FullPath}");
             QueuedTaskHelper.Do(Tuple.Create(e.OldFullPath, e.FullPath), () => Update(e.OldFullPath, e.FullPath));
         }
 
@@ -721,7 +721,7 @@ namespace Celeste.Mod {
                     format = ".yml";
 
                 } else if (file == "DecalRegistry.xml") {
-                    Logger.Log("Decal Registry", "found DecalRegistry.xml");
+                    Logger.Log(LogLevel.Verbose, "Decal Registry", "found DecalRegistry.xml");
                     type = typeof(AssetTypeDecalRegistry);
                     file = file.Substring(0, file.Length - 4);
 
@@ -941,7 +941,7 @@ namespace Celeste.Mod {
 
                 if (_ContentLoaded) {
                     // We're late-loading this mod and thus need to manually ingest new assets.
-                    Logger.Log(LogLevel.Info, "content", $"Late ingest via update for {meta.Name}");
+                    Logger.Log(LogLevel.Verbose, "content", $"Late ingest via update for {meta.Name}");
 
                     Stopwatch loadTimerPrev = Celeste.LoadTimer; // Trick AssetReloadHelper into insta-running callbacks.
                     Stopwatch loadTimer = Stopwatch.StartNew();
@@ -1011,7 +1011,7 @@ namespace Celeste.Mod {
                     if (Emoji.IsInitialized()) {
                         if (refreshEmojis(mapping)) {
                             MainThreadHelper.Do(() => {
-                                Logger.Log("content", "Reloading fonts after late emoji registration");
+                                Logger.Log(LogLevel.Verbose, "content", "Reloading fonts after late emoji registration");
                                 Fonts.Reload();
                             });
                         }
@@ -1042,7 +1042,7 @@ namespace Celeste.Mod {
                     }
                 } else if (mapping.PathVirtual.StartsWith("Graphics/Atlases/Gui/emoji/")) {
                     string emojiName = mapping.PathVirtual.Substring(27);
-                    Logger.Log("content", $"Late registering emoji: {emojiName}");
+                    Logger.Log(LogLevel.Verbose, "content", $"Late registering emoji: {emojiName}");
                     Emoji.Register(emojiName, GFX.Gui["emoji/" + emojiName]);
                     return true;
                 }

--- a/Celeste.Mod.mm/Mod/Everest/Everest.DebugRC.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.DebugRC.cs
@@ -66,7 +66,7 @@ namespace Celeste.Mod {
                                 } catch (ThreadInterruptedException) {
                                     throw;
                                 } catch (Exception e) {
-                                    Logger.Log("debugrc", $"DebugRC failed responding: {e}");
+                                    Logger.Log(LogLevel.Error, "debugrc", $"DebugRC failed responding: {e}");
                                 }
                             }, Listener.GetContext());
                         }
@@ -79,10 +79,10 @@ namespace Celeste.Mod {
                         // 995 = I/O abort due to thread abort or application shutdown.
                         if (e.ErrorCode != 500 &&
                             e.ErrorCode != 995) {
-                            Logger.Log("debugrc", $"DebugRC failed listening ({e.ErrorCode}): {e}");
+                            Logger.Log(LogLevel.Error, "debugrc", $"DebugRC failed listening ({e.ErrorCode}): {e}");
                         }
                     } catch (Exception e) {
-                        Logger.Log("debugrc", $"DebugRC failed listening: {e}");
+                        Logger.Log(LogLevel.Error, "debugrc", $"DebugRC failed listening: {e}");
                     }
                 });
             }

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
@@ -648,7 +648,7 @@ namespace Celeste.Mod {
 
                         // be sure to save this module's save data and session before reloading it, so that they are not lost.
                         if (SaveData.Instance != null) {
-                            Logger.Log("core", $"Saving save data slot {SaveData.Instance.FileSlot} for {module.Metadata} before reloading");
+                            Logger.Log(LogLevel.Verbose, "core", $"Saving save data slot {SaveData.Instance.FileSlot} for {module.Metadata} before reloading");
                             if (module.SaveDataAsync) {
                                 module.WriteSaveData(SaveData.Instance.FileSlot, module.SerializeSaveData(SaveData.Instance.FileSlot));
                             } else {
@@ -660,7 +660,7 @@ namespace Celeste.Mod {
                             }
 
                             if (SaveData.Instance.CurrentSession?.InArea ?? false) {
-                                Logger.Log("core", $"Saving session slot {SaveData.Instance.FileSlot} for {module.Metadata} before reloading");
+                                Logger.Log(LogLevel.Verbose, "core", $"Saving session slot {SaveData.Instance.FileSlot} for {module.Metadata} before reloading");
                                 if (module.SaveDataAsync) {
                                     module.WriteSession(SaveData.Instance.FileSlot, module.SerializeSession(SaveData.Instance.FileSlot));
                                 } else {

--- a/Celeste.Mod.mm/Mod/Everest/Everest.LuaLoader.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.LuaLoader.cs
@@ -29,11 +29,11 @@ namespace Celeste.Mod {
                 try {
                     string pathOverride = Path.Combine(PathEverest, "boot.lua");
                     if (File.Exists(pathOverride)) {
-                        Logger.Log("Everest.LuaLoader", "Found external Lua boot script.");
+                        Logger.Log(LogLevel.Info, "Everest.LuaLoader", "Found external Lua boot script.");
                         stream = new FileStream(pathOverride, FileMode.Open, FileAccess.Read);
 
                     } else if (Content.TryGet<AssetTypeLua>("Lua/boot", out ModAsset asset)) {
-                        Logger.Log("Everest.LuaLoader", "Found built-in Lua boot script.");
+                        Logger.Log(LogLevel.Verbose, "Everest.LuaLoader", "Found built-in Lua boot script.");
                         stream = asset.Stream;
                     }
 
@@ -42,7 +42,7 @@ namespace Celeste.Mod {
                         return;
                     }
 
-                    Logger.Log("Everest.LuaLoader", "Creating Lua context and running Lua boot script.");
+                    Logger.Log(LogLevel.Verbose, "Everest.LuaLoader", "Creating Lua context and running Lua boot script.");
 
                     using (StreamReader reader = new StreamReader(stream))
                         text = reader.ReadToEnd();

--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -773,7 +773,7 @@ namespace Celeste.Mod {
 
                 if (SaveData.Instance != null) {
                     // we are in a save. we are expecting the save data to already be loaded at this point
-                    Logger.Log("core", $"Loading save data slot {SaveData.Instance.FileSlot} for {module.Metadata}");
+                    Logger.Log(LogLevel.Verbose, "core", $"Loading save data slot {SaveData.Instance.FileSlot} for {module.Metadata}");
                     if (module.SaveDataAsync) {
                         module.DeserializeSaveData(SaveData.Instance.FileSlot, module.ReadSaveData(SaveData.Instance.FileSlot));
                     } else {
@@ -784,7 +784,7 @@ namespace Celeste.Mod {
 
                     if (SaveData.Instance.CurrentSession?.InArea ?? false) {
                         // we are in a level. we are expecting the session to already be loaded at this point
-                        Logger.Log("core", $"Loading session slot {SaveData.Instance.FileSlot} for {module.Metadata}");
+                        Logger.Log(LogLevel.Verbose, "core", $"Loading session slot {SaveData.Instance.FileSlot} for {module.Metadata}");
                         if (module.SaveDataAsync) {
                             module.DeserializeSession(SaveData.Instance.FileSlot, module.ReadSession(SaveData.Instance.FileSlot));
                         } else {
@@ -798,7 +798,7 @@ namespace Celeste.Mod {
                 // Check if the module defines a PrepareMapDataProcessors method. If this is the case, we want to reload maps so that they are applied.
                 // We should also run the map data processors again if new berry types are registered, so that CoreMapDataProcessor assigns them checkpoint IDs and orders.
                 if (newStrawberriesRegistered || module.GetType().GetMethod("PrepareMapDataProcessors", new Type[] { typeof(MapDataFixup) })?.DeclaringType == module.GetType()) {
-                    Logger.Log("core", $"Module {module.Metadata} has custom strawberries or map data processors: reloading maps.");
+                    Logger.Log(LogLevel.Verbose, "core", $"Module {module.Metadata} has custom strawberries or map data processors: reloading maps.");
                     AssetReloadHelper.ReloadAllMaps();
                 }
             }
@@ -808,7 +808,7 @@ namespace Celeste.Mod {
                 Type[] types = FakeAssembly.GetFakeEntryAssembly().GetTypesSafe();
                 foreach (Type type in types) {
                     if (typeof(Oui).IsAssignableFrom(type) && !type.IsAbstract && !overworld.UIs.Any(ui => ui.GetType() == type)) {
-                        Logger.Log("core", $"Instanciating UI from {module.Metadata}: {type.FullName}");
+                        Logger.Log(LogLevel.Verbose, "core", $"Instantiating UI from {module.Metadata}: {type.FullName}");
 
                         Oui oui = (Oui) Activator.CreateInstance(type);
                         oui.Visible = false;

--- a/Celeste.Mod.mm/Mod/Everest/LuaTypeBuilder.cs
+++ b/Celeste.Mod.mm/Mod/Everest/LuaTypeBuilder.cs
@@ -24,11 +24,11 @@ namespace Celeste.Mod {
             try {
                 string pathOverride = Path.Combine(PathEverest, "typebuilder.lua");
                 if (File.Exists(pathOverride)) {
-                    Logger.Log("Everest.LuaTypeBuilder", "Found external Lua typebuilder script.");
+                    Logger.Log(LogLevel.Info, "Everest.LuaTypeBuilder", "Found external Lua typebuilder script.");
                     stream = new FileStream(pathOverride, FileMode.Open, FileAccess.Read);
 
                 } else if (Content.TryGet<AssetTypeLua>("Lua/typebuilder", out ModAsset asset)) {
-                    Logger.Log("Everest.LuaTypeBuilder", "Found built-in Lua typebuilder script.");
+                    Logger.Log(LogLevel.Verbose, "Everest.LuaTypeBuilder", "Found built-in Lua typebuilder script.");
                     stream = asset.Stream;
                 }
 

--- a/Celeste.Mod.mm/Mod/Helpers/ModUpdaterHelper.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/ModUpdaterHelper.cs
@@ -39,7 +39,7 @@ namespace Celeste.Mod.Helpers {
             try {
                 string modUpdaterDatabaseUrl = getModUpdaterDatabaseUrl();
 
-                Logger.Log("ModUpdaterHelper", $"Downloading last versions list from {modUpdaterDatabaseUrl}");
+                Logger.Log(LogLevel.Verbose, "ModUpdaterHelper", $"Downloading last versions list from {modUpdaterDatabaseUrl}");
 
                 using (WebClient wc = new CompressedWebClient()) {
                     string yamlData = wc.DownloadString(modUpdaterDatabaseUrl);
@@ -47,10 +47,10 @@ namespace Celeste.Mod.Helpers {
                     foreach (string name in updateCatalog.Keys) {
                         updateCatalog[name].Name = name;
                     }
-                    Logger.Log("ModUpdaterHelper", $"Downloaded {updateCatalog.Count} item(s)");
+                    Logger.Log(LogLevel.Verbose, "ModUpdaterHelper", $"Downloaded {updateCatalog.Count} item(s)");
                 }
             } catch (Exception e) {
-                Logger.Log("ModUpdaterHelper", $"Downloading database failed!");
+                Logger.Log(LogLevel.Warn, "ModUpdaterHelper", $"Downloading database failed!");
                 Logger.LogDetailed(e);
             }
 
@@ -66,7 +66,7 @@ namespace Celeste.Mod.Helpers {
         public static SortedDictionary<ModUpdateInfo, EverestModuleMetadata> ListAvailableUpdates(Dictionary<string, ModUpdateInfo> updateCatalog, bool excludeBlacklist) {
             SortedDictionary<ModUpdateInfo, EverestModuleMetadata> availableUpdatesCatalog = new SortedDictionary<ModUpdateInfo, EverestModuleMetadata>(new MostRecentUpdatedFirst());
 
-            Logger.Log("ModUpdaterHelper", "Checking for updates");
+            Logger.Log(LogLevel.Verbose, "ModUpdaterHelper", "Checking for updates");
 
             foreach (EverestModule module in Everest.Modules) {
                 EverestModuleMetadata metadata = module.Metadata;
@@ -74,14 +74,14 @@ namespace Celeste.Mod.Helpers {
                     && (!excludeBlacklist || !Everest.Loader.UpdaterBlacklist.Any(path => Path.Combine(Everest.Loader.PathMods, path) == metadata.PathArchive))) {
 
                     string xxHashStringInstalled = BitConverter.ToString(metadata.Hash).Replace("-", "").ToLowerInvariant();
-                    Logger.Log("ModUpdaterHelper", $"Mod {metadata.Name}: installed hash {xxHashStringInstalled}, latest hash(es) {string.Join(", ", updateCatalog[metadata.Name].xxHash)}");
+                    Logger.Log(LogLevel.Verbose, "ModUpdaterHelper", $"Mod {metadata.Name}: installed hash {xxHashStringInstalled}, latest hash(es) {string.Join(", ", updateCatalog[metadata.Name].xxHash)}");
                     if (!updateCatalog[metadata.Name].xxHash.Contains(xxHashStringInstalled)) {
                         availableUpdatesCatalog[updateCatalog[metadata.Name]] = metadata;
                     }
                 }
             }
 
-            Logger.Log("ModUpdaterHelper", $"{availableUpdatesCatalog.Count} update(s) available");
+            Logger.Log(LogLevel.Verbose, "ModUpdaterHelper", $"{availableUpdatesCatalog.Count} update(s) available");
             return availableUpdatesCatalog;
         }
 
@@ -93,7 +93,7 @@ namespace Celeste.Mod.Helpers {
         public static void VerifyChecksum(ModUpdateInfo update, string filePath) {
             string actualHash = BitConverter.ToString(Everest.GetChecksum(filePath)).Replace("-", "").ToLowerInvariant();
             string expectedHash = update.xxHash[0];
-            Logger.Log("ModUpdaterHelper", $"Verifying checksum: actual hash is {actualHash}, expected hash is {expectedHash}");
+            Logger.Log(LogLevel.Verbose, "ModUpdaterHelper", $"Verifying checksum: actual hash is {actualHash}, expected hash is {expectedHash}");
             if (expectedHash != actualHash) {
                 throw new IOException($"Checksum error: expected {expectedHash}, got {actualHash}");
             }
@@ -112,16 +112,16 @@ namespace Celeste.Mod.Helpers {
                 if (content.GetType() == typeof(ZipModContent) && (content as ZipModContent).Path == mod.PathArchive) {
                     ZipModContent modZip = content as ZipModContent;
 
-                    Logger.Log("ModUpdaterHelper", $"Closing mod .zip: {modZip.Path}");
+                    Logger.Log(LogLevel.Verbose, "ModUpdaterHelper", $"Closing mod .zip: {modZip.Path}");
                     modZip.Dispose();
                 }
             }
 
             // delete the old zip, and move the new one.
-            Logger.Log("ModUpdaterHelper", $"Deleting mod .zip: {mod.PathArchive}");
+            Logger.Log(LogLevel.Verbose, "ModUpdaterHelper", $"Deleting mod .zip: {mod.PathArchive}");
             File.Delete(mod.PathArchive);
 
-            Logger.Log("ModUpdaterHelper", $"Moving {zipPath} to {mod.PathArchive}");
+            Logger.Log(LogLevel.Verbose, "ModUpdaterHelper", $"Moving {zipPath} to {mod.PathArchive}");
             File.Move(zipPath, mod.PathArchive);
         }
 
@@ -133,10 +133,10 @@ namespace Celeste.Mod.Helpers {
         public static void TryDelete(string path) {
             if (File.Exists(path)) {
                 try {
-                    Logger.Log("ModUpdaterHelper", $"Deleting file {path}");
+                    Logger.Log(LogLevel.Verbose, "ModUpdaterHelper", $"Deleting file {path}");
                     File.Delete(path);
                 } catch (Exception) {
-                    Logger.Log("ModUpdaterHelper", $"Removing {path} failed");
+                    Logger.Log(LogLevel.Warn, "ModUpdaterHelper", $"Removing {path} failed");
                 }
             }
         }
@@ -147,7 +147,7 @@ namespace Celeste.Mod.Helpers {
         /// </summary>
         private static string getModUpdaterDatabaseUrl() {
             using (WebClient wc = new WebClient()) {
-                Logger.Log("ModUpdaterHelper", "Fetching mod updater database URL");
+                Logger.Log(LogLevel.Verbose, "ModUpdaterHelper", "Fetching mod updater database URL");
                 return wc.DownloadString("https://everestapi.github.io/modupdater.txt").Trim();
             }
         }

--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistry.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistry.cs
@@ -247,10 +247,10 @@ namespace Celeste.Mod {
 
         public static void RegisterDecal(string decalPath, DecalInfo info) {
             if (RegisteredDecals.ContainsKey(decalPath)) {
-                Logger.Log("Decal Registry", $"Replaced decal {decalPath}");
+                Logger.Log(LogLevel.Verbose, "Decal Registry", $"Replaced decal {decalPath}");
                 RegisteredDecals[decalPath] = info;
             } else {
-                Logger.Log("Decal Registry", $"Registered decal {decalPath}");
+                Logger.Log(LogLevel.Verbose, "Decal Registry", $"Registered decal {decalPath}");
                 RegisteredDecals.Add(decalPath, info);
             }
         }

--- a/Celeste.Mod.mm/Mod/UI/AutoModUpdater.cs
+++ b/Celeste.Mod.mm/Mod/UI/AutoModUpdater.cs
@@ -111,7 +111,7 @@ namespace Celeste.Mod.UI {
                     // download it...
                     modUpdatingMessage = $"{progressString} {Dialog.Clean("AUTOUPDATECHECKER_DOWNLOADING")}";
 
-                    Logger.Log("AutoModUpdater", $"Downloading {update.URL} to {zipPath}");
+                    Logger.Log(LogLevel.Verbose, "AutoModUpdater", $"Downloading {update.URL} to {zipPath}");
                     Func<int, long, int, bool> progressCallback = (position, length, speed) => {
                         if (skipUpdate) {
                             return false;
@@ -139,7 +139,7 @@ namespace Celeste.Mod.UI {
                     showCancel = false;
 
                     if (skipUpdate) {
-                        Logger.Log("AutoModUpdater", "Update was skipped");
+                        Logger.Log(LogLevel.Verbose, "AutoModUpdater", "Update was skipped");
 
                         // try to delete mod-update.zip if it still exists.
                         ModUpdaterHelper.TryDelete(zipPath);
@@ -165,7 +165,7 @@ namespace Celeste.Mod.UI {
 
                 } catch (Exception e) {
                     // update failed
-                    Logger.Log("AutoModUpdater", $"Updating {update.Name} failed");
+                    Logger.Log(LogLevel.Warn, "AutoModUpdater", $"Updating {update.Name} failed");
                     Logger.LogDetailed(e);
                     failuresOccured = true;
 

--- a/Celeste.Mod.mm/Mod/UI/OuiDependencyDownloader.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiDependencyDownloader.cs
@@ -85,7 +85,7 @@ namespace Celeste.Mod.UI {
                 }
                 Lines[Lines.Count - 1] = $"{Dialog.Clean("DEPENDENCYDOWNLOADER_LOADING_INSTALLED_MODS")} {Dialog.Clean("DEPENDENCYDOWNLOADER_DONE")}";
 
-                Logger.Log("OuiDependencyDownloader", "Computing dependencies to download...");
+                Logger.Log(LogLevel.Verbose, "OuiDependencyDownloader", "Computing dependencies to download...");
 
                 // these mods are not installed currently, we will install them
                 Dictionary<string, ModUpdateInfo> modsToInstall = new Dictionary<string, ModUpdateInfo>();
@@ -112,10 +112,10 @@ namespace Celeste.Mod.UI {
 
                 foreach (EverestModuleMetadata dependency in MissingDependencies) {
                     if (Everest.Loader.Delayed.Any(delayedMod => dependency.Name == delayedMod.Item1.Name)) {
-                        Logger.Log("OuiDependencyDownloader", $"{dependency.Name} is installed but failed to load, skipping");
+                        Logger.Log(LogLevel.Verbose, "OuiDependencyDownloader", $"{dependency.Name} is installed but load is delayed, skipping");
 
                     } else if (dependency.Name == "Everest") {
-                        Logger.Log("OuiDependencyDownloader", $"Everest should be updated");
+                        Logger.Log(LogLevel.Verbose, "OuiDependencyDownloader", $"Everest should be updated");
                         shouldAutoExit = false;
 
                         if (dependency.Version.Major != 1 || dependency.Version.Build > 0 || dependency.Version.Revision > 0) {
@@ -130,20 +130,20 @@ namespace Celeste.Mod.UI {
                             }
                         }
                     } else if (tryUnblacklist(dependency, allModsInformation, modFilenamesToUnblacklist)) {
-                        Logger.Log("OuiDependencyDownloader", $"{dependency.Name} is blacklisted, and should be unblacklisted instead");
+                        Logger.Log(LogLevel.Verbose, "OuiDependencyDownloader", $"{dependency.Name} is blacklisted, and should be unblacklisted instead");
 
                     } else if (!availableDownloads.ContainsKey(dependency.Name)) {
-                        Logger.Log("OuiDependencyDownloader", $"{dependency.Name} was not found in the database");
+                        Logger.Log(LogLevel.Verbose, "OuiDependencyDownloader", $"{dependency.Name} was not found in the database");
                         modsNotFound.Add(dependency.Name);
                         shouldAutoExit = false;
 
                     } else if (availableDownloads[dependency.Name].xxHash.Count > 1) {
-                        Logger.Log("OuiDependencyDownloader", $"{dependency.Name} has multiple versions and cannot be installed automatically");
+                        Logger.Log(LogLevel.Verbose, "OuiDependencyDownloader", $"{dependency.Name} has multiple versions and cannot be installed automatically");
                         modsNotInstallableAutomatically.Add(dependency.Name);
                         shouldAutoExit = false;
 
                     } else if (!isVersionCompatible(dependency.Version, availableDownloads[dependency.Name].Version)) {
-                        Logger.Log("OuiDependencyDownloader", $"{dependency.Name} has a version in database ({availableDownloads[dependency.Name].Version}) that would not satisfy dependency ({dependency.Version})");
+                        Logger.Log(LogLevel.Verbose, "OuiDependencyDownloader", $"{dependency.Name} has a version in database ({availableDownloads[dependency.Name].Version}) that would not satisfy dependency ({dependency.Version})");
 
                         // add the required version to the list of versions for this mod
                         HashSet<Version> requiredVersions = modsWithIncompatibleVersionInDatabase.TryGetValue(dependency.Name, out HashSet<Version> result) ? result : new HashSet<Version>();
@@ -164,12 +164,12 @@ namespace Celeste.Mod.UI {
                         }
 
                         if (installedVersion != null) {
-                            Logger.Log("OuiDependencyDownloader", $"{dependency.Name} is already installed and will be updated");
+                            Logger.Log(LogLevel.Verbose, "OuiDependencyDownloader", $"{dependency.Name} is already installed and will be updated");
                             modsToUpdate[dependency.Name] = availableDownloads[dependency.Name];
                             modsToUpdateCurrentVersions[dependency.Name] = installedVersion;
 
                         } else {
-                            Logger.Log("OuiDependencyDownloader", $"{dependency.Name} will be installed");
+                            Logger.Log(LogLevel.Verbose, "OuiDependencyDownloader", $"{dependency.Name} will be installed");
                             modsToInstall[dependency.Name] = availableDownloads[dependency.Name];
                         }
                     }
@@ -316,7 +316,7 @@ namespace Celeste.Mod.UI {
                             // comment this line to unblacklist this mod.
                             blacklistTxt.WriteLine("# " + line);
                             modsLeftToUnblacklist.Remove(line);
-                            Logger.Log("OuiDependencyDownloader", "Commented out line from blacklist.txt: " + line);
+                            Logger.Log(LogLevel.Verbose, "OuiDependencyDownloader", "Commented out line from blacklist.txt: " + line);
                         } else {
                             // copy the line as is.
                             blacklistTxt.WriteLine(line);
@@ -328,7 +328,7 @@ namespace Celeste.Mod.UI {
                     // some mods we are supposed to unblacklist aren't in the blacklist.txt file...?
                     LogLine(Dialog.Clean("DEPENDENCYDOWNLOADER_UNBLACKLIST_FAILED"));
                     foreach (string mod in modsLeftToUnblacklist) {
-                        Logger.Log("OuiDependencyDownloader", "This mod could not be found in blacklist.txt: " + mod);
+                        Logger.Log(LogLevel.Warn, "OuiDependencyDownloader", "This mod could not be found in blacklist.txt: " + mod);
                     }
                     return false;
                 }
@@ -349,7 +349,7 @@ namespace Celeste.Mod.UI {
             try {
                 databaseVersion = new Version(databaseVersionString);
             } catch (Exception e) {
-                Logger.Log("OuiDependencyDownloader", $"Could not parse version number: {databaseVersionString}");
+                Logger.Log(LogLevel.Warn, "OuiDependencyDownloader", $"Could not parse version number: {databaseVersionString}");
                 Logger.LogDetailed(e);
                 return false;
             }
@@ -435,10 +435,10 @@ namespace Celeste.Mod.UI {
                 // try to delete the file if it still exists.
                 if (File.Exists(downloadDestination)) {
                     try {
-                        Logger.Log("OuiDependencyDownloader", $"Deleting temp file {downloadDestination}");
+                        Logger.Log(LogLevel.Verbose, "OuiDependencyDownloader", $"Deleting temp file {downloadDestination}");
                         File.Delete(downloadDestination);
                     } catch (Exception) {
-                        Logger.Log("OuiDependencyDownloader", $"Removing {downloadDestination} failed");
+                        Logger.Log(LogLevel.Warn, "OuiDependencyDownloader", $"Removing {downloadDestination} failed");
                     }
                 }
             }

--- a/Celeste.Mod.mm/Mod/UI/OuiModToggler.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiModToggler.cs
@@ -89,7 +89,7 @@ namespace Celeste.Mod.UI {
 
             // our list is complete!
             stopwatch.Stop();
-            Logger.Log("OuiModToggler", $"Found {allModYamls.Count} mod(s) with yaml files, took {stopwatch.ElapsedMilliseconds} ms");
+            Logger.Log(LogLevel.Verbose, "OuiModToggler", $"Found {allModYamls.Count} mod(s) with yaml files, took {stopwatch.ElapsedMilliseconds} ms");
             return allModYamls;
         }
 
@@ -363,7 +363,7 @@ namespace Celeste.Mod.UI {
             }
 
             blacklistedMods.Add(file);
-            Logger.Log("OuiModToggler", $"{file} was added to the blacklist");
+            Logger.Log(LogLevel.Verbose, "OuiModToggler", $"{file} was added to the blacklist");
 
             if (toggleDependencies && modYamls.TryGetValue(file, out EverestModuleMetadata[] metadatas)) {
                 // we should blacklist all mods that has this mod as a dependency.
@@ -388,7 +388,7 @@ namespace Celeste.Mod.UI {
             }
 
             blacklistedMods.Remove(file);
-            Logger.Log("OuiModToggler", $"{file} was removed from the blacklist");
+            Logger.Log(LogLevel.Verbose, "OuiModToggler", $"{file} was removed from the blacklist");
 
             if (toggleDependencies && modYamls.TryGetValue(file, out EverestModuleMetadata[] metadatas)) {
                 // we should remove all of the mod's dependencies from the blacklist.

--- a/Celeste.Mod.mm/Mod/UI/OuiModUpdateList.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiModUpdateList.cs
@@ -124,7 +124,7 @@ namespace Celeste.Mod.UI {
                     // This means fetching the updates just finished. We have to remove the "Checking for updates" button
                     // and put the actual update list instead.
 
-                    Logger.Log("OuiModUpdateList", "Rendering updates");
+                    Logger.Log(LogLevel.Verbose, "OuiModUpdateList", "Rendering updates");
 
                     menu.Remove(fetchingButton);
                     fetchingButton = null;
@@ -263,7 +263,7 @@ namespace Celeste.Mod.UI {
                 downloadMod(update, button, zipPath);
 
                 if (ongoingUpdateCancelled) {
-                    Logger.Log("OuiModUpdateList", "Update was cancelled");
+                    Logger.Log(LogLevel.Verbose, "OuiModUpdateList", "Update was cancelled");
 
                     // try to delete mod-update.zip if it still exists.
                     ModUpdaterHelper.TryDelete(zipPath);
@@ -290,7 +290,7 @@ namespace Celeste.Mod.UI {
             } catch (Exception e) {
                 // update failed
                 button.Label = $"{ModUpdaterHelper.FormatModName(update.Name)} ({Dialog.Clean("MODUPDATECHECKER_FAILED")})";
-                Logger.Log("OuiModUpdateList", $"Updating {update.Name} failed");
+                Logger.Log(LogLevel.Warn, "OuiModUpdateList", $"Updating {update.Name} failed");
                 Logger.LogDetailed(e);
 
                 // try to delete mod-update.zip if it still exists.
@@ -306,7 +306,7 @@ namespace Celeste.Mod.UI {
         /// <param name="button">The button for that mod shown on the interface</param>
         /// <param name="zipPath">The path to the zip the update will be downloaded to</param>
         private static void downloadMod(ModUpdateInfo update, TextMenu.Button button, string zipPath) {
-            Logger.Log("OuiModUpdateList", $"Downloading {update.URL} to {zipPath}");
+            Logger.Log(LogLevel.Verbose, "OuiModUpdateList", $"Downloading {update.URL} to {zipPath}");
 
             Func<int, long, int, bool> progressCallback = (position, length, speed) => {
                 if (ongoingUpdateCancelled) {

--- a/Celeste.Mod.mm/Patches/AreaData.cs
+++ b/Celeste.Mod.mm/Patches/AreaData.cs
@@ -357,7 +357,7 @@ namespace Celeste {
                 }
                 Array.Resize(ref area.Mode, modei);
 
-                Logger.Log("AreaData", $"{i}: {area.GetSID()} - {area.Mode.Length} sides");
+                Logger.Log(LogLevel.Verbose, "AreaData", $"{i}: {area.GetSID()} - {area.Mode.Length} sides");
 
                 // Update old MapData areas and load any new areas.
 

--- a/Celeste.Mod.mm/Patches/Audio.cs
+++ b/Celeste.Mod.mm/Patches/Audio.cs
@@ -263,7 +263,7 @@ namespace Celeste {
                 Audio.cachedEventDescriptions.Add(path, desc);
 
             } else if (status == RESULT.ERR_EVENT_NOTFOUND) {
-                Logger.Log("Audio", $"Event not found: {path}");
+                Logger.Log(LogLevel.Warn, "Audio", $"Event not found: {path}");
 
             } else {
                 throw new Exception("FMOD getEvent failed: " + status);

--- a/Celeste.Mod.mm/Patches/GameLoader.cs
+++ b/Celeste.Mod.mm/Patches/GameLoader.cs
@@ -171,7 +171,7 @@ namespace Celeste {
             if (previousVersion < new Version(1, 2109, 0)) {
                 // user just upgraded: create mod save data backups.
                 // (this is very similar to OverworldLoader.CheckVariantsPostcardAtLaunch)
-                Logger.Log("core", $"User just upgraded from version {previousVersion}: creating mod save data backups.");
+                Logger.Log(LogLevel.Verbose, "core", $"User just upgraded from version {previousVersion}: creating mod save data backups.");
 
                 for (int i = 0; i < 3; i++) { // only the first 3 saves really matter.
                     if (!UserIO.Exists(SaveData.GetFilename(i))) {

--- a/Celeste.Mod.mm/Patches/Monocle/Atlas.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Atlas.cs
@@ -385,7 +385,7 @@ namespace Monocle {
                 vtex = VirtualContentExt.CreateTexture(asset);
             } catch {
                 // The game is going to crash from this. Log the offending texture to make debugging easier.
-                Logger.Log(LogLevel.Verbose, "Atlas.Ingest", $"Error while loading texture {path} ({asset.Source?.Name ?? "???"}) into atlas {Path.GetFileName(DataPath)}");
+                Logger.Log(LogLevel.Error, "Atlas.Ingest", $"Error while loading texture {path} ({asset.Source?.Name ?? "???"}) into atlas {Path.GetFileName(DataPath)}");
                 throw;
             }
             MTextureMeta meta = asset.GetMeta<MTextureMeta>();

--- a/Celeste.Mod.mm/Patches/Monocle/Commands.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Commands.cs
@@ -415,7 +415,7 @@ namespace Monocle {
 
                 if (ContainCantDrawChar(innerException.Message + innerException.StackTrace)) {
                     Engine.Commands.Log("Please check log.txt for full exception log, because it contains characters that can't be displayed.", Color.Yellow);
-                    Logger.Log("Commands", innerException.ToString());
+                    Logger.LogDetailed(innerException, "Commands");
                 }
             }
         }

--- a/Celeste.Mod.mm/Patches/Monocle/PixelFont.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/PixelFont.cs
@@ -14,13 +14,13 @@ namespace Monocle {
 
         [MonoModReplace]
         public new PixelFontSize AddFontSize(string path, Atlas atlas = null, bool outline = false) {
-            Logger.Log("PixelFont", $"Loading font: {path}");
+            Logger.Log(LogLevel.Verbose, "PixelFont", $"Loading font: {path}");
 
             PixelFontSize loadedSize = null;
 
             // load the vanilla font if it exists.
             if (patch_Calc.orig_XMLExists(path)) {
-                Logger.Log("PixelFont", "=> vanilla font file");
+                Logger.Log(LogLevel.Verbose, "PixelFont", "=> vanilla font file");
                 XmlElement data = patch_Calc.orig_LoadXML(path)["font"];
                 loadedSize = AddFontSize(path, data, atlas, outline);
                 Sizes.Remove(loadedSize);
@@ -33,7 +33,7 @@ namespace Monocle {
                 .Where(map => map.ContainsKey(modPath))
                 .Select(map => map[modPath])) {
 
-                Logger.Log("PixelFont", $"=> mod font file from {modAsset.Source.Name}");
+                Logger.Log(LogLevel.Verbose, "PixelFont", $"=> mod font file from {modAsset.Source.Name}");
                 XmlElement data = loadXMLFromModAsset(modAsset)["font"];
                 PixelFontSize newFontSize = AddFontSize(path, data, atlas, outline);
                 Sizes.Remove(newFontSize);
@@ -73,7 +73,7 @@ namespace Monocle {
             // associate the textures for the new font to the existing font.
             originalSize.Textures.AddRange(newSize.Textures);
 
-            Logger.Log("PixelFont", $"==> Imported {newCharacterCount} new characters");
+            Logger.Log(LogLevel.Verbose, "PixelFont", $"==> Imported {newCharacterCount} new characters");
             return originalSize;
         }
     }

--- a/Celeste.Mod.mm/Patches/Monocle/SpriteBank.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/SpriteBank.cs
@@ -120,7 +120,7 @@ namespace Monocle {
                         pendingDeletion.Add(modNode);
                     } else {
                         // mod XML different from vanilla, keep it.
-                        Logger.Log("SpriteBank", $"Sprite \"{modNode.Name}\" will be overridden with {path}.");
+                        Logger.Log(LogLevel.Verbose, "SpriteBank", $"Sprite \"{modNode.Name}\" will be overridden with {path}.");
 
                         // if it copies another sprite, keep its name so that we do not delete it.
                         string copy = modNode.Attributes["copy"]?.Value;
@@ -130,14 +130,14 @@ namespace Monocle {
                     }
                 } else {
                     // sprite doesn't exist in vanilla.
-                    Logger.Log("SpriteBank", $"Sprite \"{modNode.Name}\" will be added from {path}.");
+                    Logger.Log(LogLevel.Verbose, "SpriteBank", $"Sprite \"{modNode.Name}\" will be added from {path}.");
                 }
             }
 
             // delete all sprites marked for deletion, except ones that are copied by sprites we want to keep (because this would break the XML).
             foreach (XmlNode toDelete in pendingDeletion.ToArray()) {
                 if (doNotDelete.Contains(toDelete.Name)) {
-                    Logger.Log("SpriteBank", $"Sprite \"{toDelete.Name}\" will be overridden with {path}, because it is copied by another sprite.");
+                    Logger.Log(LogLevel.Verbose, "SpriteBank", $"Sprite \"{toDelete.Name}\" will be overridden with {path}, because it is copied by another sprite.");
                 } else {
                     modSprites.RemoveChild(toDelete);
                 }

--- a/Celeste.Mod.mm/Patches/PlaybackData.cs
+++ b/Celeste.Mod.mm/Patches/PlaybackData.cs
@@ -95,7 +95,7 @@ namespace Celeste {
             // load vanilla tutorials
             foreach (string path in Directory.GetFiles(Path.Combine(Engine.ContentDirectory, "Tutorials"))) {
                 string fileNameWithoutExtension = Path.GetFileNameWithoutExtension(path);
-                Logger.Log("PlaybackData", $"Loading vanilla tutorial: {fileNameWithoutExtension}");
+                Logger.Log(LogLevel.Verbose, "PlaybackData", $"Loading vanilla tutorial: {fileNameWithoutExtension}");
 
                 List<Player.ChaserState> tutorial = Import(File.ReadAllBytes(path));
                 if (tutorial != null)
@@ -121,7 +121,7 @@ namespace Celeste {
                         tutorialPath = tutorialPath.Substring("Tutorials/".Length);
 
                     // load tutorial.
-                    Logger.Log("PlaybackData", $"Loading tutorial: {tutorialPath}");
+                    Logger.Log(LogLevel.Verbose, "PlaybackData", $"Loading tutorial: {tutorialPath}");
                     List<Player.ChaserState> tutorial = Import(child.Data);
                     if (tutorial != null)
                         Tutorials[tutorialPath] = tutorial;

--- a/Celeste.Mod.mm/Patches/RunThread.cs
+++ b/Celeste.Mod.mm/Patches/RunThread.cs
@@ -80,7 +80,7 @@ namespace Celeste {
                             timeout = DateTime.UtcNow + TimeSpan.FromSeconds(5);
                         if ((DateTime.UtcNow - timeout.Value).Ticks >= 0) {
                             lock (threads) {
-                                Logger.Log("RunThread.WaitAll", $"Backgound thread taking too long, discarding it.\n{threadInfos[0]}");
+                                Logger.Log(LogLevel.Verbose, "RunThread.WaitAll", $"Background thread taking too long, discarding it.\n{threadInfos[0]}");
                                 threads.RemoveAt(0);
                                 threadTimes.RemoveAt(0);
                                 threadInfos.RemoveAt(0);


### PR DESCRIPTION
With the recent logging update, we need to make sure that our existing levels are appropriate. This change sets all levels explicitly so they are easily searchable. Most were defaulted to Verbose, but a few levels here and there were changed for consistency.