### PR TITLE
Use tracker for CrystalShatterTrigger

### DIFF
--- a/Celeste.Mod.mm/Mod/Entities/CrystalShatterTrigger.cs
+++ b/Celeste.Mod.mm/Mod/Entities/CrystalShatterTrigger.cs
@@ -20,14 +20,16 @@ namespace Celeste.Mod.Entities {
         public override void OnEnter(Player player) {
             base.OnEnter(player);
 
-            List<CrystalStaticSpinner> spinners = Scene.Entities.OfType<CrystalStaticSpinner>().ToList();
+            List<Entity> spinners = Scene.Tracker.GetEntities<CrystalStaticSpinner>();
             if (spinners.Count > 0) {
                 if (mode == Modes.All)
                     Audio.Play("event:/game/06_reflection/boss_spikes_burst");
 
-                foreach (CrystalStaticSpinner spinner in spinners)
+                foreach (Entity entity in spinners) {
+                    CrystalStaticSpinner spinner = (CrystalStaticSpinner) entity;
                     if (CollideCheck(spinner) || mode == Modes.All)
                         spinner.Destroy();
+                }
             }
 
             RemoveSelf();

--- a/Celeste.Mod.mm/Mod/Entities/CrystalShatterTrigger.cs
+++ b/Celeste.Mod.mm/Mod/Entities/CrystalShatterTrigger.cs
@@ -25,11 +25,9 @@ namespace Celeste.Mod.Entities {
                 if (mode == Modes.All)
                     Audio.Play("event:/game/06_reflection/boss_spikes_burst");
 
-                foreach (Entity entity in spinners) {
-                    CrystalStaticSpinner spinner = (CrystalStaticSpinner) entity;
+                foreach (CrystalStaticSpinner spinner in spinners)
                     if (CollideCheck(spinner) || mode == Modes.All)
                         spinner.Destroy();
-                }
             }
 
             RemoveSelf();


### PR DESCRIPTION
`CrystalStaticSpinner` is tracked (mostly for this exact purpose as far as I can tell), so there's no need to get them via the entity list.