### PR TITLE
Allow 'log.txt' filename to be changed via EVEREST_LOG_FILENAME= in env

### DIFF
--- a/Celeste.Mod.mm/Patches/Celeste.cs
+++ b/Celeste.Mod.mm/Patches/Celeste.cs
@@ -130,7 +130,7 @@ namespace Celeste {
             // Only applying log rotation on default name, feel free to improve LogRotationHelper to deal with custom log file names...
             if (logfile == "log.txt" && File.Exists("log.txt")) {
                 if (new FileInfo("log.txt").Length > 0) {
-                    // move the old log file to the LogHistory folder.
+                    // move the old log.txt to the LogHistory folder.
                     // note that the cleanup will only be done when the core module is loaded: the settings aren't even loaded right now,
                     // so we don't know how many files we should keep.
                     if (!Directory.Exists("LogHistory")) {

--- a/Celeste.Mod.mm/Patches/Celeste.cs
+++ b/Celeste.Mod.mm/Patches/Celeste.cs
@@ -149,7 +149,7 @@ namespace Celeste {
                 Match match = regexBadCharacter.Match(logfile);
 
                 if (match.Success) {
-                    StringBuilder errorText = new StringBuilder($"Custom log filename set in EVEREST_LOG_FILENAME contains invalid character(s): ", 100);
+                    StringBuilder errorText = new StringBuilder($"Custom log filename set in EVEREST_LOG_FILENAME=\"{logfile}\" contains invalid character(s): ", 100);
 
                     while (match.Success) {
                         foreach (Capture c in match.Groups[0].Captures)

--- a/Celeste.Mod.mm/Patches/Celeste.cs
+++ b/Celeste.Mod.mm/Patches/Celeste.cs
@@ -124,23 +124,27 @@ namespace Celeste {
                 return;
             }
 
-            if (File.Exists("log.txt")) {
-                if (new FileInfo("log.txt").Length > 0) {
-                    // move the old log.txt to the LogHistory folder.
+            string logfile = Environment.GetEnvironmentVariable("EVEREST_LOGFILE") ?? "log.txt";
+            string log_abspath = Path.Combine(Directory.GetCurrentDirectory(), logfile);
+
+            // Only applying log rotation on default name, feel free to improve LogRotationHelper to deal with custom log file names...
+            if (logfile == "log.txt" && File.Exists(logfile)) {
+                if (new FileInfo(logfile).Length > 0) {
+                    // move the old log file to the LogHistory folder.
                     // note that the cleanup will only be done when the core module is loaded: the settings aren't even loaded right now,
                     // so we don't know how many files we should keep.
                     if (!Directory.Exists("LogHistory")) {
                         Directory.CreateDirectory("LogHistory");
                     }
-                    File.Move("log.txt", Path.Combine("LogHistory", LogRotationHelper.GetFileNameByDate(File.GetLastWriteTime("log.txt"))));
+                    File.Move(logfile, Path.Combine("LogHistory", LogRotationHelper.GetFileNameByDate(File.GetLastWriteTime(logfile))));
                 } else {
                     // log is empty! (this actually happens more often than you'd think, because of Steam re-opening Celeste)
                     // just delete it.
-                    File.Delete("log.txt");
+                    File.Delete(logfile);
                 }
             }
 
-            using (Stream fileStream = new FileStream("log.txt", FileMode.OpenOrCreate, FileAccess.Write, FileShare.ReadWrite | FileShare.Delete))
+            using (Stream fileStream = new FileStream(log_abspath, FileMode.OpenOrCreate, FileAccess.Write, FileShare.ReadWrite | FileShare.Delete))
             using (StreamWriter fileWriter = new StreamWriter(fileStream, Console.OutputEncoding))
             using (LogWriter logWriter = new LogWriter {
                 STDOUT = Console.Out,

--- a/Celeste.Mod.mm/Patches/Celeste.cs
+++ b/Celeste.Mod.mm/Patches/Celeste.cs
@@ -128,19 +128,19 @@ namespace Celeste {
             string log_abspath = Path.Combine(Directory.GetCurrentDirectory(), logfile);
 
             // Only applying log rotation on default name, feel free to improve LogRotationHelper to deal with custom log file names...
-            if (logfile == "log.txt" && File.Exists(logfile)) {
-                if (new FileInfo(logfile).Length > 0) {
+            if (logfile == "log.txt" && File.Exists("log.txt")) {
+                if (new FileInfo("log.txt").Length > 0) {
                     // move the old log file to the LogHistory folder.
                     // note that the cleanup will only be done when the core module is loaded: the settings aren't even loaded right now,
                     // so we don't know how many files we should keep.
                     if (!Directory.Exists("LogHistory")) {
                         Directory.CreateDirectory("LogHistory");
                     }
-                    File.Move(logfile, Path.Combine("LogHistory", LogRotationHelper.GetFileNameByDate(File.GetLastWriteTime(logfile))));
+                    File.Move("log.txt", Path.Combine("LogHistory", LogRotationHelper.GetFileNameByDate(File.GetLastWriteTime("log.txt"))));
                 } else {
                     // log is empty! (this actually happens more often than you'd think, because of Steam re-opening Celeste)
                     // just delete it.
-                    File.Delete(logfile);
+                    File.Delete("log.txt");
                 }
             }
 

--- a/Celeste.Mod.mm/Patches/Celeste.cs
+++ b/Celeste.Mod.mm/Patches/Celeste.cs
@@ -125,7 +125,6 @@ namespace Celeste {
             }
 
             string logfile = Environment.GetEnvironmentVariable("EVEREST_LOGFILE") ?? "log.txt";
-            string log_abspath = Path.Combine(Directory.GetCurrentDirectory(), logfile);
 
             // Only applying log rotation on default name, feel free to improve LogRotationHelper to deal with custom log file names...
             if (logfile == "log.txt" && File.Exists("log.txt")) {
@@ -144,7 +143,7 @@ namespace Celeste {
                 }
             }
 
-            using (Stream fileStream = new FileStream(log_abspath, FileMode.OpenOrCreate, FileAccess.Write, FileShare.ReadWrite | FileShare.Delete))
+            using (Stream fileStream = new FileStream(logfile, FileMode.OpenOrCreate, FileAccess.Write, FileShare.ReadWrite | FileShare.Delete))
             using (StreamWriter fileWriter = new StreamWriter(fileStream, Console.OutputEncoding))
             using (LogWriter logWriter = new LogWriter {
                 STDOUT = Console.Out,


### PR DESCRIPTION
Default behavior is unchanged and logs to `log.txt` with the existing log rotator.

I want to be able to change where logs are written to so that e.g. I can run multiple Itch.io Celestes for Celestenet testing and have them write individual logs.

When putting this in `everest-env.txt`
```ini
EVEREST_LOG_FILENAME=my_custom_log.txt
```

or launching with `EVEREST_LOG_FILENAME=mylog.txt ./Celeste.exe` etc. the specified filename will be used as a log file instead. 
The log rotation will not kick in, since that was only built to turn `log.txt` into `log_[date+time].txt` log backups, no custom names there unless someone else wants to implement that.

The filename is checked against `Path.GetInvalidFileNameChars()` which hopefully returns something sensible on every OS we run on, and unlike `Path.GetInvalidPathChars()` it will not allow any paths (`/` and `\` not allowed).

If the name doesn't already end in `.txt`, that will be appended just to be safe.

Using an invalid name, the game will fail to launch:
```ini
EVEREST_LOG_FILENAME=../a"t?est.txt ./Celeste.exe
```
```
08/25/2022 21:37:59
System.ArgumentException: Custom log filename set in EVEREST_LOG_FILENAME="../a"t?est.txt" contains invalid character(s): / " ?
   at Celeste.Celeste.Main(String[] args) in C:\Users\rf\Documents\code\Everest\Celeste.Mod.mm\Patches\Celeste.cs:line 32
   at Celeste.Mod.BOOT.Main(String[] args) in C:\Users\rf\Documents\code\Everest\Celeste.Mod.mm\Mod\Everest\BOOT.cs:line 0
```

---
**Edit: Old message below, behavior has been changed.**

---

Should this test if the specified file is actually a writeable file path and if it isn't, should it fall back to `log.txt`? 

~~Currently it will crash, like so:~~
```
Monocle Engine Error Log
==========================================

08/23/2022 23:05:22
System.UnauthorizedAccessException: Access to the path 'C:\mylog.txt' is denied.
   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.IO.FileStream.Init(String path, FileMode mode, FileAccess access, Int32 rights, Boolean useRights, FileShare share, Int32 bufferSize, FileOptions options, SECURITY_ATTRIBUTES secAttrs, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)
   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share)
   at Celeste.Celeste.Main(String[] args) in C:\Users\rf\Documents\code\Everest\Celeste.Mod.mm\Patches\Celeste.cs:line 30
   at Celeste.Mod.BOOT.Main(String[] args) in C:\Users\rf\Documents\code\Everest\Celeste.Mod.mm\Mod\Everest\BOOT.cs:line 0
```

~~I just realized this does allow writing to arbitrary files with absolute paths or `../../`, is this any concern of ours? Should this be restricted to filenames with no paths?~~