### PR TITLE
Improve error postcards

### DIFF
--- a/Celeste.Mod.mm/Mod/Helpers/AssetReloadHelper.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/AssetReloadHelper.cs
@@ -159,21 +159,17 @@ namespace Celeste.Mod {
                             Thread.Yield();
 
                     } catch (Exception e) {
-                        Logger.Log(LogLevel.Warn, "reload", $"Failed reloading area {level.Session?.Area.ToString() ?? "NULL"}");
+                        string sid = level.Session?.Area.GetSID() ?? "NULL";
+                        patch_LevelEnter.ErrorMessage = Dialog.Get("postcard_levelloadfailed").Replace("((sid))", sid);
+                        Logger.Log(LogLevel.Warn, "reload", $"Failed reloading map {sid}");
                         e.LogDetailed();
-
-                        string message = Dialog.Get("postcard_levelloadfailed")
-                            .Replace("((player))", SaveData.Instance.Name)
-                            .Replace("((sid))", level.Session?.Area.GetSID() ?? "NULL")
-                        ;
 
                         if (patch_Level.NextLoadedPlayer != null) {
                             patch_Level.NextLoadedPlayer = null;
                             patch_Level.SkipScreenWipes--;
                         }
 
-                        LevelEnterExt.ErrorMessage = message;
-                        ReturnToScene = patch_LevelEnter.ForceCreate(new Session(level.Session?.Area ?? new AreaKey(1).SetSID("")), false);
+                        ReturnToScene = patch_LevelEnter.ForceCreate(level.Session, false);
                         ReloadingLevel = false;
                         patch_Level.ShouldAutoPause = false;
                     }

--- a/Celeste.Mod.mm/Patches/LevelLoader.cs
+++ b/Celeste.Mod.mm/Patches/LevelLoader.cs
@@ -163,7 +163,7 @@ namespace Celeste {
             orig_ctor(session, startPosition);
 
             if (patch_LevelEnter.ErrorMessage == null) {
-                RunThread.Start(new Action(StartLoadingThread), "LEVEL_LOADER");
+                RunThread.Start(new Action(LoadingThread_Safe), "LEVEL_LOADER");
                 LastLoadingThread = patch_RunThread.Current;
 
                 // get rid of all entities in the pooler to make sure they don't keep references to the previous level.
@@ -185,7 +185,7 @@ namespace Celeste {
         [PatchLevelLoaderThread] // ... except for manually manipulating the method via MonoModRules
         private extern void LoadingThread();
 
-        private void StartLoadingThread() {
+        private void LoadingThread_Safe() {
             try {
                 LoadingThread();
             } catch (Exception e) {
@@ -239,7 +239,7 @@ namespace MonoMod {
         public static void PatchLevelLoaderOrigCtor(ILContext context, CustomAttribute attrib) {
             ILCursor cursor = new ILCursor(context);
             cursor.GotoNext(MoveType.After, instr => instr.MatchCallvirt("Celeste.LevelLoader", "set_Level"));
-            // removes RunThread.Start(new Action(this.StartLoadingThread), "LEVEL_LOADER", false);
+            // removes RunThread.Start(new Action(this.LoadingThread), "LEVEL_LOADER", false);
             cursor.RemoveRange(6);
         }
 


### PR DESCRIPTION
Partially addresses #479.

- Simplifies error postcard logic in `LevelEnter`
  - Cleans up usage in `Level` and `AssetReloadHelper` to match changes
- Adds error handling to `LevelLoader`

Mods now only have to set `LevelEnter.ErrorMessage` to activate an error postcard if they're inside a Level, although currently full exception handling is only being done for level loading. Due to how the game loop works, we would have to wrap each scene function (Update, Render, etc.) with try-catches if we wanted to handle everything.

I'll be working on adding unique postcard messages and improving logs for common errors after this is merged.