### PR TITLE
Add OnLoadingThread event

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Events.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Events.cs
@@ -72,6 +72,16 @@ namespace Celeste.Mod {
                     => OnCreateButtons?.Invoke(menu, buttons);
             }
 
+            public static class LevelLoader {
+                public delegate void LoadingThreadHandler(_Level level);
+                /// <summary>
+                /// Called at the end of the map loading thread.
+                /// </summary>
+                public static event LoadingThreadHandler OnLoadingThread;
+                internal static void LoadingThread(_Level level)
+                    => OnLoadingThread?.Invoke(level);
+            }
+
             public static class Level {
                 public delegate void PauseHandler(_Level level, int startIndex, bool minimal, bool quickReset);
                 /// <summary>

--- a/Celeste.Mod.mm/Patches/LevelLoader.cs
+++ b/Celeste.Mod.mm/Patches/LevelLoader.cs
@@ -172,7 +172,7 @@ namespace Celeste {
 
 namespace MonoMod {
     /// <summary>
-    /// Patch the Godzilla-sized level loading thread method instead of reimplementing it in Everest.
+    /// Adds a SubHudRenderer to the level and invokes the OnLoadingThread event at the end of the loading thread.
     /// </summary>
     [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchLevelLoaderThread))]
     class PatchLevelLoaderThreadAttribute : Attribute { }
@@ -220,6 +220,14 @@ namespace MonoMod {
             cursor.Emit(OpCodes.Callvirt, m_LevelLoader_get_Level);
             cursor.Emit(OpCodes.Ldarg_0);
             cursor.Emit(OpCodes.Callvirt, m_LevelLoader_get_Level);
+            /* ---------------------------------------------------- */
+            MethodDefinition m_Everest_Events_LevelLoader_LoadingThread = MonoModRule.Modder.Module.GetType("Celeste.Mod.Everest/Events/LevelLoader").FindMethod("System.Void LoadingThread(Celeste.Level)");
+
+            // Now we want to move to just before the end of the loading thread and invoke an event for mods to hook
+            cursor.GotoNext(MoveType.After, instr => instr.MatchStfld("Celeste.Level", "Pathfinder"));
+            cursor.Emit(OpCodes.Ldarg_0);
+            cursor.Emit(OpCodes.Callvirt, m_LevelLoader_get_Level);
+            cursor.Emit(OpCodes.Call, m_Everest_Events_LevelLoader_LoadingThread);
         }
 
     }

--- a/Celeste.Mod.mm/Patches/LevelLoader.cs
+++ b/Celeste.Mod.mm/Patches/LevelLoader.cs
@@ -164,7 +164,8 @@ namespace Celeste {
         }
 
         [MonoModIgnore] // We don't want to change anything about the method...
-        [PatchLevelLoaderThread] // ... except for manually manipulating the method via MonoModRules
+        [PatchLoadingThreadAddEvent] // ... except for manually manipulating the method via MonoModRules
+        [PatchLoadingThreadAddSubHudRenderer] 
         private extern void LoadingThread();
 
     }
@@ -172,14 +173,20 @@ namespace Celeste {
 
 namespace MonoMod {
     /// <summary>
-    /// Adds a SubHudRenderer to the level and invokes the OnLoadingThread event at the end of the loading thread.
+    /// Adds a SubHudRenderer to the level in the loader thread.
     /// </summary>
-    [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchLevelLoaderThread))]
-    class PatchLevelLoaderThreadAttribute : Attribute { }
+    [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchLoadingThreadAddSubHudRenderer))]
+    class PatchLoadingThreadAddSubHudRendererAttribute : Attribute { }
+
+    /// <summary>
+    /// Invokes the OnLoadingThread event at the end of the loading thread.
+    /// </summary>
+    [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchLoadingThreadAddEvent))]
+    class PatchLoadingThreadAddEventAttribute : Attribute { }
 
     static partial class MonoModRules {
 
-        public static void PatchLevelLoaderThread(ILContext context, CustomAttribute attrib) {
+        public static void PatchLoadingThreadAddSubHudRenderer(ILContext context, CustomAttribute attrib) {
             TypeDefinition t_Level = MonoModRule.Modder.FindType("Celeste.Level").Resolve();
             FieldDefinition f_SubHudRenderer = t_Level.FindField("SubHudRenderer");
             MethodDefinition ctor_SubHudRenderer = f_SubHudRenderer.FieldType.Resolve().FindMethod("System.Void .ctor()");
@@ -220,10 +227,15 @@ namespace MonoMod {
             cursor.Emit(OpCodes.Callvirt, m_LevelLoader_get_Level);
             cursor.Emit(OpCodes.Ldarg_0);
             cursor.Emit(OpCodes.Callvirt, m_LevelLoader_get_Level);
-            /* ---------------------------------------------------- */
+        }
+
+        public static void PatchLoadingThreadAddEvent(ILContext context, CustomAttribute attrib) {
+            MethodDefinition m_LevelLoader_get_Level = context.Method.DeclaringType.FindMethod("Celeste.Level get_Level()");
             MethodDefinition m_Everest_Events_LevelLoader_LoadingThread = MonoModRule.Modder.Module.GetType("Celeste.Mod.Everest/Events/LevelLoader").FindMethod("System.Void LoadingThread(Celeste.Level)");
 
-            // Now we want to move to just before the end of the loading thread and invoke an event for mods to hook
+            ILCursor cursor = new ILCursor(context);
+
+            // We want to move to just before the end of the loading thread and invoke an event for mods to hook
             cursor.GotoNext(MoveType.After, instr => instr.MatchStfld("Celeste.Level", "Pathfinder"));
             cursor.Emit(OpCodes.Ldarg_0);
             cursor.Emit(OpCodes.Callvirt, m_LevelLoader_get_Level);


### PR DESCRIPTION
Invokes an event at the end of the `LevelLoader.LoadingThread`. Useful for mods that add global entities, manipulate sprite banks, etc.