### PR TITLE
Add --loglevel launch flag

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -306,6 +306,10 @@ namespace Celeste.Mod {
                 else if (arg == "--blacklist" && queue.Count >= 1)
                     Loader.NameTemporaryBlacklist = queue.Dequeue();
 
+                else if (arg == "--loglevel" && queue.Count >= 1) {
+                    if (Enum.TryParse(queue.Dequeue(), ignoreCase: true, out LogLevel level)) 
+                        Logger.SetLogLevelFromSettings("", level);
+                }
             }
         }
 

--- a/Celeste.Mod.mm/Patches/Celeste.cs
+++ b/Celeste.Mod.mm/Patches/Celeste.cs
@@ -66,6 +66,8 @@ namespace Celeste {
                     writer.WriteLine("# FNA only: force OpenGL (might be necessary to bypass a load crash on some PCs).");
                     writer.WriteLine("#--graphics OpenGL");
                     writer.WriteLine();
+                    writer.WriteLine("# Change default log level (verbose will print all logs).");
+                    writer.WriteLine("#--loglevel verbose");
 
                     if (File.Exists("launch.txt")) {
                         using (StreamReader reader = File.OpenText("launch.txt")) {


### PR DESCRIPTION
Lets you quickly set the default log print level. Easier to tell people to set this than edit their advanced Everest settings.

Applies before settings, so won't conflict with manually applied prefix settings.