### PR TITLE
Restructure Decal Registry

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Content.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Content.cs
@@ -721,7 +721,6 @@ namespace Celeste.Mod {
                     format = ".yml";
 
                 } else if (file == "DecalRegistry.xml") {
-                    Logger.Log(LogLevel.Verbose, "Decal Registry", "found DecalRegistry.xml");
                     type = typeof(AssetTypeDecalRegistry);
                     file = file.Substring(0, file.Length - 4);
 
@@ -870,12 +869,7 @@ namespace Celeste.Mod {
                         AssetReloadHelper.ReloadLevel();
 
                     } else if (next.Type == typeof(AssetTypeDecalRegistry)) {
-                        string fileContents;
-                        using (StreamReader reader = new StreamReader(next.Stream)) {
-                            fileContents = reader.ReadToEnd();
-                        }
-                        // Reload decal registry entirely, from every mod, so that decal attributes apply in the same order than on startup consistenly
-                        DecalRegistry.LoadDecalRegistry();
+                        DecalRegistry.LoadModDecalRegistry(next);
                         AssetReloadHelper.ReloadLevel();
 
                     } else if (next.Type == typeof(AssetTypeDialog) || next.Type == typeof(AssetTypeDialogExport)) {

--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistry.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistry.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 using Monocle;
 using System;
 using System.Collections.Generic;
@@ -12,9 +13,15 @@ namespace Celeste.Mod {
     /// Allows custom decals to have properties that are otherwise hardcoded, such as reflections, parallax, etc.
     /// </summary>
     public static class DecalRegistry {
+        /// <summary>
+        /// Mapping of decal paths to decal registry properties.
+        /// </summary>
+        public static readonly Dictionary<string, DecalInfo> RegisteredDecals = new Dictionary<string, DecalInfo>();
 
-        // string is propertyName
-        public static Dictionary<string, Action<Decal, XmlAttributeCollection>> PropertyHandlers = new Dictionary<string, Action<Decal, XmlAttributeCollection>>() {
+        /// <summary>
+        /// Everest-defined decal registry properties. See <see cref="AddPropertyHandler"/> to add a custom property.
+        /// </summary>
+        internal static Dictionary<string, Action<Decal, XmlAttributeCollection>> PropertyHandlers = new Dictionary<string, Action<Decal, XmlAttributeCollection>>() {
             { "parallax", delegate(Decal decal, XmlAttributeCollection attrs) {
                 if (attrs["amount"] != null)
                     ((patch_Decal)decal).MakeParallax(float.Parse(attrs["amount"].Value));
@@ -162,39 +169,9 @@ namespace Celeste.Mod {
             }},
         };
 
-        // Helper functions for scaling Decal Registry fields
-        public static Vector2 GetScaledOffset(this Decal self, float x, float y) {
-            return new Vector2(x * ((patch_Decal) self).Scale.X, y * ((patch_Decal) self).Scale.Y);
-        }
-
-        public static float GetScaledRadius(this Decal self, float radius) {
-            return radius * ((Math.Abs(((patch_Decal) self).Scale.X) + Math.Abs(((patch_Decal) self).Scale.Y)) / 2f);
-        }
-
-        public static void ScaleRectangle(this Decal self, ref float x, ref float y, ref float width, ref float height) {
-            Vector2 scale = ((patch_Decal) self).Scale;
-            x *= Math.Abs(scale.X);
-            y *= Math.Abs(scale.Y);
-            width *= Math.Abs(scale.X);
-            height *= Math.Abs(scale.Y);
-
-            x = (scale.X < 0) ? -x - width : x;
-            y = (scale.Y < 0) ? -y - height : y;
-        }
-
-        public static void ScaleRectangle(this Decal self, ref int x, ref int y, ref int width, ref int height) {
-            Vector2 scale = ((patch_Decal) self).Scale;
-            x = (int) (x * Math.Abs(scale.X));
-            y = (int) (y * Math.Abs(scale.Y));
-            width = (int) (width * Math.Abs(scale.X));
-            height = (int) (height * Math.Abs(scale.Y));
-
-            x = (scale.X < 0) ? -x - width : x;
-            y = (scale.Y < 0) ? -y - height : y;
-        }
-
-        public static Dictionary<string, DecalInfo> RegisteredDecals = new Dictionary<string, DecalInfo>();
-
+        /// <summary>
+        /// Adds a custom property to the decal registry. See <see cref="PropertyHandlers"/> for the list of Everest-defined properties.
+        /// </summary>
         public static void AddPropertyHandler(string propertyName, Action<Decal, XmlAttributeCollection> action) {
             if (PropertyHandlers.ContainsKey(propertyName)) {
                 string asmName = Assembly.GetCallingAssembly().GetName().Name;
@@ -210,30 +187,121 @@ namespace Celeste.Mod {
         }
 
         /// <summary>
-        /// Reads a DecalRegistry.xml file's contents
+        /// Returns a vector offset scaled relative to a decal.
         /// </summary>
-        public static List<KeyValuePair<string, DecalInfo>> ReadDecalRegistryXml(string fileContents) {
-            // XmlElement file = Calc.LoadXML(path)["decals"];
+        public static Vector2 GetScaledOffset(this Decal self, float x, float y) {
+            return new Vector2(x * ((patch_Decal) self).Scale.X, y * ((patch_Decal) self).Scale.Y);
+        }
+
+        /// <summary>
+        /// Returns a radius scaled relative to a decal.
+        /// </summary>
+        public static float GetScaledRadius(this Decal self, float radius) {
+            return radius * ((Math.Abs(((patch_Decal) self).Scale.X) + Math.Abs(((patch_Decal) self).Scale.Y)) / 2f);
+        }
+
+        /// <summary>
+        /// Returns the components of a rectangle scaled relative to a decal (float).
+        /// </summary>
+        public static void ScaleRectangle(this Decal self, ref float x, ref float y, ref float width, ref float height) {
+            Vector2 scale = ((patch_Decal) self).Scale;
+            x *= Math.Abs(scale.X);
+            y *= Math.Abs(scale.Y);
+            width *= Math.Abs(scale.X);
+            height *= Math.Abs(scale.Y);
+
+            x = (scale.X < 0) ? -x - width : x;
+            y = (scale.Y < 0) ? -y - height : y;
+        }
+
+        /// <summary>
+        /// Returns the components of a rectangle scaled relative to a decal (int).
+        /// </summary>
+        public static void ScaleRectangle(this Decal self, ref int x, ref int y, ref int width, ref int height) {
+            Vector2 scale = ((patch_Decal) self).Scale;
+            x = (int) (x * Math.Abs(scale.X));
+            y = (int) (y * Math.Abs(scale.Y));
+            width = (int) (width * Math.Abs(scale.X));
+            height = (int) (height * Math.Abs(scale.Y));
+
+            x = (scale.X < 0) ? -x - width : x;
+            y = (scale.Y < 0) ? -y - height : y;
+        }
+
+        /// <summary>
+        /// Loads the decal registry for every enabled mod.
+        /// </summary>
+        internal static void LoadDecalRegistry() {
+            foreach (ModContent mod in Everest.Content.Mods) {
+                if (mod.Map.TryGetValue("DecalRegistry", out ModAsset asset) && asset.Type == typeof(AssetTypeDecalRegistry)) {
+                    LoadModDecalRegistry(asset);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Loads a mod's decal registry file.
+        /// </summary>
+        internal static void LoadModDecalRegistry(ModAsset decalRegistry) {
+            Logger.Log(LogLevel.Debug, "Decal Registry", $"Loading registry for {decalRegistry.Source.Name}");
+
+            char[] digits = new[] { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' };
+            string basePath = ((patch_Atlas) GFX.Game).RelativeDataPath + "decals/";
+            List<string> localDecals = decalRegistry.Source.Map.Keys
+                .Where(s => s.StartsWith(basePath))
+                .Select(s => s.Substring(basePath.Length).TrimEnd(digits).ToLower())
+                .Distinct()
+                .ToList();
+
+            foreach (KeyValuePair<string, DecalInfo> decalRegistration in ReadDecalRegistryXml(decalRegistry)) {
+                string registeredPath = decalRegistration.Key;
+                DecalInfo info = decalRegistration.Value;
+
+                bool found = false;
+                if (registeredPath.EndsWith("*") || registeredPath.EndsWith("/")) {
+                    registeredPath = registeredPath.TrimEnd('*');
+                    foreach (string decalPath in localDecals) {
+                        // Wildcard matches must be longer than the subpath, and don't match on decals in subfolders
+                        if (decalPath.StartsWith(registeredPath) && decalPath.Length > registeredPath.Length 
+                            && decalPath.LastIndexOf('/') <= registeredPath.Length - 1) {
+                            RegisterDecal(decalPath, info);
+                            found = true;
+                        }
+                    }
+                } else if (localDecals.Contains(registeredPath)) {
+                    RegisterDecal(registeredPath, info);
+                    found = true;
+                } 
+                
+                if (!found) {
+                    Logger.Log(LogLevel.Warn, "Decal Registry", $"Could not find any decals in {decalRegistry.Source.Name} under path {decalRegistration.Key}");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Reads a decal registry file and returns a sorted list of properties per decal path.
+        /// </summary>
+        private static List<KeyValuePair<string, DecalInfo>> ReadDecalRegistryXml(ModAsset decalRegistry) {
             XmlDocument doc = new XmlDocument();
-            doc.LoadXml(fileContents);
-            XmlElement file = doc["decals"];
+            doc.Load(decalRegistry.Stream);
 
             List<KeyValuePair<string, DecalInfo>> elements = new();
-            foreach (XmlNode node in file) {
+
+            foreach (XmlNode node in doc["decals"]) {
                 if (node is XmlElement decal) {
                     string decalPath = decal.Attr("path", null)?.ToLower();
                     if (decalPath == null) {
-                        Logger.Log(LogLevel.Warn, "Decal Registry", "Decal didn't have a path attribute!");
+                        Logger.Log(LogLevel.Warn, "Decal Registry", $"Decal in {decalRegistry.Source.Name} registry didn't have a path attribute!");
                         continue;
                     }
-                    DecalInfo info = new DecalInfo();
-                    info.CustomProperties = new List<KeyValuePair<string, XmlAttributeCollection>>();
-                    // Read all the properties
+
+                    DecalInfo info = new DecalInfo { 
+                        CustomProperties = new List<KeyValuePair<string, XmlAttributeCollection>>() 
+                    };
+
                     foreach (XmlNode node2 in decal.ChildNodes) {
                         if (node2 is XmlElement property) {
-                            if (property.Attributes == null) {
-                                property.SetAttribute("a", "only here to prevent crashes");
-                            }
                             info.CustomProperties.Add(new KeyValuePair<string, XmlAttributeCollection>(property.Name, property.Attributes));
                         }
                     }
@@ -242,39 +310,6 @@ namespace Celeste.Mod {
                 }
             }
 
-            return elements;
-        }
-
-        public static void RegisterDecal(string decalPath, DecalInfo info) {
-            if (RegisteredDecals.ContainsKey(decalPath)) {
-                Logger.Log(LogLevel.Verbose, "Decal Registry", $"Replaced decal {decalPath}");
-                RegisteredDecals[decalPath] = info;
-            } else {
-                Logger.Log(LogLevel.Verbose, "Decal Registry", $"Registered decal {decalPath}");
-                RegisteredDecals.Add(decalPath, info);
-            }
-        }
-
-        public static void LoadDecalRegistry() {
-            List<KeyValuePair<string, DecalInfo>> completeDecalRegistry = new();
-
-            foreach (ModAsset asset in
-                Everest.Content.Mods
-                .Select(mod => mod.Map.TryGetValue("DecalRegistry", out ModAsset asset) ? asset : null)
-                .Where(asset => asset != null && asset.Type == typeof(AssetTypeDecalRegistry))
-            ) {
-                string fileContents;
-                using (StreamReader reader = new StreamReader(asset.Stream)) {
-                    fileContents = reader.ReadToEnd();
-                }
-                completeDecalRegistry.AddRange(ReadDecalRegistryXml(fileContents));
-            }
-
-            // We can treat this as if we only had a single, full decal registry, to keep consistency between files
-            ApplyDecalRegistry(completeDecalRegistry);
-        }
-
-        public static void ApplyDecalRegistry(List<KeyValuePair<string, DecalInfo>> elements) {
             // Sort by priority in this order: folders -> matching paths -> single decal
             elements.Sort((a, b) => {
                 int scoreA = a.Key[a.Key.Length - 1] switch {
@@ -291,32 +326,16 @@ namespace Celeste.Mod {
                 return (scoreA == scoreB && scoreA == 1) ? a.Key.Length - b.Key.Length : scoreB - scoreA;
             });
 
-            foreach (KeyValuePair<string, DecalInfo> pair in elements) {
-                string decalPath = pair.Key;
-                DecalInfo info = pair.Value;
-                if (decalPath.EndsWith("*") || decalPath.EndsWith("/")) {
-                    // Removing the '/' made the path wrong
-                    decalPath = decalPath.TrimEnd('*');
-                    int pathLength = decalPath.Length;
+            return elements;
+        }
 
-                    foreach (string subDecalPath in
-                        GFX.Game.GetTextures().Keys
-                        .GroupBy(
-                            s => s.StartsWith("decals/") ?
-                                s.Substring(7).TrimEnd('0','1','2','3','4','5','6','7','8','9').ToLower() :
-                                null,
-                            (s, matches) => s
-                        )
-                        .Where(str => str != null && str.StartsWith(decalPath) && str.Length > pathLength)
-                    ) {
-                        // Decals in subfolders are considered as unmatched
-                        if (!subDecalPath.Remove(0, pathLength).Contains("/"))
-                            RegisterDecal(subDecalPath, info);
-                    }
-                } else {
-                    // Single decal registered
-                    RegisterDecal(decalPath, info);
-                }
+        private static void RegisterDecal(string decalPath, DecalInfo info) {
+            if (RegisteredDecals.ContainsKey(decalPath)) {
+                Logger.Log(LogLevel.Verbose, "Decal Registry", $"Replaced decal {decalPath}");
+                RegisteredDecals[decalPath] = info;
+            } else {
+                Logger.Log(LogLevel.Verbose, "Decal Registry", $"Registered decal {decalPath}");
+                RegisteredDecals.Add(decalPath, info);
             }
         }
 

--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistry.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistry.cs
@@ -1,9 +1,7 @@
 ﻿using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
 using Monocle;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Xml;


### PR DESCRIPTION
1. Use content map instead of gameplay atlas texture list. This fixes a bug where we can't register directory/wildcard paths if the registry is ingested before the textures are (see Discord discussion [here](https://discord.com/channels/403698615446536203/1014018168047538196/1014052229755441242)).
2. Limit registered decals to those within the source mod. This reduces conflicts and lets us reload individual registries instead of having to regenerate the global registry.
3. Rework interfaces and add documentation. Restricting access to the internal implementation will make it easier to make changes in the future.

To-Do: reloading a mod's registry should unload its registered paths before re-applying the registry. Not in this PR since this one was mainly to fix the ingest bug + get parity with the old version (which didn't unload old registrations either).