### PR TITLE
allow decals to be rotated

### DIFF
--- a/Celeste.Mod.mm/Patches/Decal.cs
+++ b/Celeste.Mod.mm/Patches/Decal.cs
@@ -126,6 +126,12 @@ namespace Celeste {
             orig_ctor(texture, position, scale, depth);
         }
 
+        [MonoModConstructor]
+        public void ctor(string texture, Vector2 position, Vector2 scale, int depth, float rotation) {
+            ctor(texture, position, scale, depth);
+            Rotation = rotation;
+        }
+
         [MonoModIgnore]
         [MonoModPublic]
         public extern void MakeParallax(float amount);
@@ -406,8 +412,10 @@ namespace MonoMod {
 
             // now, out of the MTexture methods, find the one to replace it with:
             MethodReference m_Draw = MTexture.Methods.Where((m_new) => (
-                // the new method has one more parameter;
-                m_new.Parameters.Count == m_orig.Parameters.Count + 1
+                // the new method has the same name;
+                m_new.Name == m_orig.Name
+                // it has one more parameter;
+                && m_new.Parameters.Count == m_orig.Parameters.Count + 1
                 // the rest are the same;
                 && m_new.Parameters.Zip(m_orig.Parameters, (p_new, p_orig) => p_new.ParameterType == p_orig.ParameterType).All(b => b)
                 // and the new parameter is rotation

--- a/Celeste.Mod.mm/Patches/DecalData.cs
+++ b/Celeste.Mod.mm/Patches/DecalData.cs
@@ -1,0 +1,9 @@
+namespace Celeste {
+    class patch_DecalData : DecalData {
+
+#pragma warning disable CS0649 // The field is never assigned and will always be null
+        public float Rotation;
+#pragma warning restore CS0649
+
+    }
+}

--- a/Celeste.Mod.mm/Patches/DecalData.cs
+++ b/Celeste.Mod.mm/Patches/DecalData.cs
@@ -1,9 +1,9 @@
+#pragma warning disable CS0649 // The field is never assigned and will always be null
+
 namespace Celeste {
     class patch_DecalData : DecalData {
 
-#pragma warning disable CS0649 // The field is never assigned and will always be null
         public float Rotation;
-#pragma warning restore CS0649
 
     }
 }

--- a/Celeste.Mod.mm/Patches/DecalData.cs
+++ b/Celeste.Mod.mm/Patches/DecalData.cs
@@ -4,5 +4,6 @@ namespace Celeste {
     class patch_DecalData : DecalData {
 
         public float Rotation;
+
     }
 }

--- a/Celeste.Mod.mm/Patches/DecalData.cs
+++ b/Celeste.Mod.mm/Patches/DecalData.cs
@@ -4,6 +4,5 @@ namespace Celeste {
     class patch_DecalData : DecalData {
 
         public float Rotation;
-
     }
 }

--- a/Celeste.Mod.mm/Patches/LevelData.cs
+++ b/Celeste.Mod.mm/Patches/LevelData.cs
@@ -72,57 +72,31 @@ namespace MonoMod {
 
 
         public static void PatchLevelDataDecalLoader(ILContext context, CustomAttribute attrib) {
-            TypeDefinition DecalData = MonoModRule.Modder.FindType("Celeste.DecalData").Resolve();
-            TypeDefinition BinaryPackerElement = MonoModRule.Modder.FindType("Celeste.BinaryPacker/Element").Resolve();
+            TypeDefinition t_DecalData = MonoModRule.Modder.FindType("Celeste.DecalData").Resolve();
+            TypeDefinition t_BinaryPackerElement = MonoModRule.Modder.FindType("Celeste.BinaryPacker/Element").Resolve();
 
-            FieldDefinition f_DecalDataRotation = DecalData.FindField("Rotation");
-            MethodDefinition m_BinaryPackerElementAttrFloat = BinaryPackerElement.FindMethod("AttrFloat");
+            FieldDefinition f_DecalDataRotation = t_DecalData.FindField("Rotation");
+            MethodDefinition m_BinaryPackerElementAttrFloat = t_BinaryPackerElement.FindMethod("AttrFloat");
 
+            // Goal is to set: decaldata.Rotation = element.AttrFloat("rotation")
             ILCursor cursor = new ILCursor(context);
 
+            int local = -1;
             int matches = 0;
-            while (cursor.TryGotoNext(MoveType.Before, instr => instr.MatchCallvirt("System.Collections.Generic.List`1<Celeste.DecalData>", "Add"))) {
-                /*
-                we are inserting:
-
-                // decaldata.Texture = (string)element.Attributes["texture"];
-                   IL_0a5f: dup
-                   IL_0a60: ldloc.s 11
-                   IL_0a62: ldfld class [mscorlib]System.Collections.Generic.Dictionary`2<string, object> Celeste.BinaryPacker/Element::Attributes
-                   IL_0a67: ldstr "texture"
-                   IL_0a6c: callvirt instance !1 class [mscorlib]System.Collections.Generic.Dictionary`2<string, object>::get_Item(!0)
-                   IL_0a71: castclass [mscorlib]System.String
-                   IL_0a76: stfld string Celeste.DecalData::Texture
-                // decaldata.Rotation = element.AttrFloat("rotation", 0.0f);
-                        ->  dup
-                            ldloc.s 11
-                            ldstr "rotation"
-                            ldc_r4 0.0
-                            callvirt instance float32 Celeste.BinaryPacker/Element::AttrFloat(string, float32)
-                            stfld float32 Celeste.DecalData::Rotation
-                // BgDecals.Add(decaldata); // or FgDecals
-                   IL_0a7b: callvirt instance void class [mscorlib]System.Collections.Generic.List`1<class Celeste.DecalData>::Add(!0)
-
-                in both places where a DecalData instance is added to a List
-                */
-
-                // first we find the binarypacker element representing the decal:
-                cursor.FindPrev(out ILCursor[] packer_element_loc_cursors, instr => instr.MatchLdloc(out int _));
-                packer_element_loc_cursors[0].Next.MatchLdloc(out int packer_element_loc);
-
-                // now, we duplicate the DecalData reference
+            // Grab the local variable holding the BinaryPacker Element and move to just before the DecalData is finished
+            while (cursor.TryGotoNext(instr => instr.MatchLdloc(out local), instr => instr.OpCode == OpCodes.Ldfld, instr => instr.MatchLdstr("texture"))) {
+                cursor.GotoNext(MoveType.After, instr => instr.MatchStfld("Celeste.DecalData", "Texture"));
+                // Duplicate the DecalData reference so we can add one more field
                 cursor.Emit(OpCodes.Dup);
-                // ask for the rotation field from the packer element, or a default of 0.0f
-                cursor.Emit(OpCodes.Ldloc, packer_element_loc);
+                // Load in the rotation attribute from the BinaryPacker Element and set the DecalData field
+                cursor.Emit(OpCodes.Ldloc, local);
                 cursor.Emit(OpCodes.Ldstr, "rotation");
-                cursor.Emit(OpCodes.Ldc_R4, 0.0f);
+                // cursor.Emit(OpCodes.Ldc_R4, 1.6f);
                 cursor.Emit(OpCodes.Callvirt, m_BinaryPackerElementAttrFloat);
-                // store the rotation in the decaldata
                 cursor.Emit(OpCodes.Stfld, f_DecalDataRotation);
-
-                cursor.Index++;
                 matches++;
             }
+            // We need to run this patch on FG and BG decals, so look for two matches
             if (matches != 2) {
                 throw new Exception($"Too few matches for HasAttr(\"tag\"): {matches}");
             }

--- a/Celeste.Mod.mm/Patches/LevelData.cs
+++ b/Celeste.Mod.mm/Patches/LevelData.cs
@@ -85,20 +85,23 @@ namespace MonoMod {
                 /*
                 we are inserting:
 
-                IL_0a5f: dup
-                IL_0a60: ldloc.s 11
-                IL_0a62: ldfld class [mscorlib]System.Collections.Generic.Dictionary`2<string, object> Celeste.BinaryPacker/Element::Attributes
-                IL_0a67: ldstr "texture"
-                IL_0a6c: callvirt instance !1 class [mscorlib]System.Collections.Generic.Dictionary`2<string, object>::get_Item(!0)
-                IL_0a71: castclass [mscorlib]System.String
-                IL_0a76: stfld string Celeste.DecalData::Texture
-                     ->  dup
-                         ldloc.s 11
-                         ldstr "rotation"
-                         ldc_r4 0.0
-                         callvirt instance float32 Celeste.BinaryPacker/Element::AttrFloat(string, float32)
-                         stfld float32 Celeste.DecalData::Rotation
-                IL_0a7b: callvirt instance void class [mscorlib]System.Collections.Generic.List`1<class Celeste.DecalData>::Add(!0)
+                // decaldata.Texture = (string)element.Attributes["texture"];
+                   IL_0a5f: dup
+                   IL_0a60: ldloc.s 11
+                   IL_0a62: ldfld class [mscorlib]System.Collections.Generic.Dictionary`2<string, object> Celeste.BinaryPacker/Element::Attributes
+                   IL_0a67: ldstr "texture"
+                   IL_0a6c: callvirt instance !1 class [mscorlib]System.Collections.Generic.Dictionary`2<string, object>::get_Item(!0)
+                   IL_0a71: castclass [mscorlib]System.String
+                   IL_0a76: stfld string Celeste.DecalData::Texture
+                // decaldata.Rotation = element.AttrFloat("rotation", 0.0f);
+                        ->  dup
+                            ldloc.s 11
+                            ldstr "rotation"
+                            ldc_r4 0.0
+                            callvirt instance float32 Celeste.BinaryPacker/Element::AttrFloat(string, float32)
+                            stfld float32 Celeste.DecalData::Rotation
+                // BgDecals.Add(decaldata); // or FgDecals
+                   IL_0a7b: callvirt instance void class [mscorlib]System.Collections.Generic.List`1<class Celeste.DecalData>::Add(!0)
 
                 in both places where a DecalData instance is added to a List
                 */
@@ -112,14 +115,12 @@ namespace MonoMod {
                 // ask for the rotation field from the packer element, or a default of 0.0f
                 cursor.Emit(OpCodes.Ldloc, packer_element_loc);
                 cursor.Emit(OpCodes.Ldstr, "rotation");
-                cursor.Emit(OpCodes.Ldc_R4, 0.0f);
+                cursor.Emit(OpCodes.Ldc_R4, (float)Math.PI / 2f);
                 cursor.Emit(OpCodes.Callvirt, m_BinaryPackerElementAttrFloat);
                 // store the rotation in the decaldata
                 cursor.Emit(OpCodes.Stfld, f_DecalDataRotation);
 
-                // make sure we won't find this location the next time we TryGotoNext
-                cursor.GotoNext(MoveType.After, instr => instr.MatchCallvirt("System.Collections.Generic.List`1<Celeste.DecalData>", "Add"));
-
+                cursor.Index++;
                 matches++;
             }
             if (matches != 2) {

--- a/Celeste.Mod.mm/Patches/LevelData.cs
+++ b/Celeste.Mod.mm/Patches/LevelData.cs
@@ -91,7 +91,7 @@ namespace MonoMod {
                 // Load in the rotation attribute from the BinaryPacker Element and set the DecalData field
                 cursor.Emit(OpCodes.Ldloc, local);
                 cursor.Emit(OpCodes.Ldstr, "rotation");
-                // cursor.Emit(OpCodes.Ldc_R4, 1.6f);
+                cursor.Emit(OpCodes.Ldc_R4, 0.0f);
                 cursor.Emit(OpCodes.Callvirt, m_BinaryPackerElementAttrFloat);
                 cursor.Emit(OpCodes.Stfld, f_DecalDataRotation);
                 matches++;

--- a/Celeste.Mod.mm/Patches/LevelData.cs
+++ b/Celeste.Mod.mm/Patches/LevelData.cs
@@ -115,7 +115,7 @@ namespace MonoMod {
                 // ask for the rotation field from the packer element, or a default of 0.0f
                 cursor.Emit(OpCodes.Ldloc, packer_element_loc);
                 cursor.Emit(OpCodes.Ldstr, "rotation");
-                cursor.Emit(OpCodes.Ldc_R4, (float)Math.PI / 2f);
+                cursor.Emit(OpCodes.Ldc_R4, 0.0f);
                 cursor.Emit(OpCodes.Callvirt, m_BinaryPackerElementAttrFloat);
                 // store the rotation in the decaldata
                 cursor.Emit(OpCodes.Stfld, f_DecalDataRotation);


### PR DESCRIPTION
allows a `rotation` float (in radians) to be added to decals in the map data, and rotates decals accordingly.

closes #467