### PR TITLE
Track the Sprite component

### DIFF
--- a/Celeste.Mod.mm/Patches/Monocle/Sprite.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Sprite.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 
 namespace Monocle {
     // The only patch_ that needs to be made public to allow accessing .Animation
+    [Tracked]
     public class patch_Sprite : Sprite {
 
         private Dictionary<string, Animation> animations;


### PR DESCRIPTION
Allows for easier sprite manipulation/replacement. Number of Sprites per scene is typically not that large so should be low-impact