### PR TITLE
Fix font files not ingested

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Content.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Content.cs
@@ -762,6 +762,9 @@ namespace Celeste.Mod {
                     } else if (file.EndsWith(".txt.export")) {
                         type = typeof(AssetTypeDialogExport);
                         file = file.Substring(0, file.Length - 7);
+                    } else if (format == "fnt") {
+                        type = typeof(AssetTypeFont);
+                        file = file.Substring(0, file.Length - 4);
                     }
 
                 } else if (file.StartsWith("Maps/") && format == "bin") {
@@ -785,12 +788,8 @@ namespace Celeste.Mod {
                         file += ".guids";
                     }
 
-                } else if (format == "fnt") {
-                    type = typeof(AssetTypeFont);
-                    file = file.Substring(0, file.Length - 4);
-
-                // Parse custom types from mods
                 } else if (OnGuessType != null) {
+                    // Parse custom types from mods
                     Delegate[] ds = OnGuessType.GetInvocationList();
                     for (int i = 0; i < ds.Length; i++) {
                         string fileMod = ((TypeGuesser) ds[i])(file, out Type typeMod, out string formatMod);

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Content.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Content.cs
@@ -25,7 +25,6 @@ namespace Celeste.Mod {
     // Asset types for which we want to log conflicts (we also log for Texture2D and ObjModel)
     public sealed class AssetTypeAssembly { private AssetTypeAssembly() { } }
     public sealed class AssetTypeBank { private AssetTypeBank() { } }
-    public sealed class AssetTypeFont { private AssetTypeFont() { } }
     public sealed class AssetTypeGUIDs { private AssetTypeGUIDs() { } }
     public sealed class AssetTypeMap { private AssetTypeMap() { } }
     public sealed class AssetTypeObjModelExport { private AssetTypeObjModelExport() { } }
@@ -35,6 +34,7 @@ namespace Celeste.Mod {
     public sealed class AssetTypeDecalRegistry : AssetTypeNonConflict { private AssetTypeDecalRegistry() { } }
     public sealed class AssetTypeDialog : AssetTypeNonConflict { private AssetTypeDialog() { } }
     public sealed class AssetTypeDialogExport : AssetTypeNonConflict { private AssetTypeDialogExport() { } }
+    public sealed class AssetTypeFont : AssetTypeNonConflict { private AssetTypeFont() { } }
     public sealed class AssetTypeDirectory : AssetTypeNonConflict { private AssetTypeDirectory() { } }
     public sealed class AssetTypeMetadataYaml : AssetTypeNonConflict { private AssetTypeMetadataYaml() { } }
     public sealed class AssetTypeSpriteBank : AssetTypeNonConflict { private AssetTypeSpriteBank() { } }


### PR DESCRIPTION
Fixed a bug in #471.

When ingesting a font file, for example `Dialog/Fonts/chinese.fnt`, this condition is evaluated to `true`, but none of the conditions inside it is `true`.

https://github.com/EverestAPI/Everest/blob/0496e2e6e4609970e95047adc79e91169be76381/Celeste.Mod.mm/Mod/Everest/Everest.Content.cs#L750-L757

Then the file path is not changed to `Dialog/Fonts/chinese`, but the game expects it, so the game can't display characters when adding them to existing font or a complete custom font.


