### PR TITLE
Remove various instances of spurious logging

### DIFF
--- a/Celeste.Mod.mm/Patches/Audio.cs
+++ b/Celeste.Mod.mm/Patches/Audio.cs
@@ -263,7 +263,7 @@ namespace Celeste {
                 Audio.cachedEventDescriptions.Add(path, desc);
 
             } else if (status == RESULT.ERR_EVENT_NOTFOUND) {
-                if (path is not ("null" or "event:/none" or "event:/null")) {
+                if (path is not ("null" or "event:/none")) {
                     Logger.Log(LogLevel.Warn, "Audio", $"Event not found: {path}");
                 }
 

--- a/Celeste.Mod.mm/Patches/Audio.cs
+++ b/Celeste.Mod.mm/Patches/Audio.cs
@@ -263,7 +263,9 @@ namespace Celeste {
                 Audio.cachedEventDescriptions.Add(path, desc);
 
             } else if (status == RESULT.ERR_EVENT_NOTFOUND) {
-                Logger.Log(LogLevel.Warn, "Audio", $"Event not found: {path}");
+                if (path is not ("null" or "event:/none" or "event:/null")) {
+                    Logger.Log(LogLevel.Warn, "Audio", $"Event not found: {path}");
+                }
 
             } else {
                 throw new Exception("FMOD getEvent failed: " + status);

--- a/Celeste.Mod.mm/Patches/BadelineBoost.cs
+++ b/Celeste.Mod.mm/Patches/BadelineBoost.cs
@@ -1,0 +1,38 @@
+using Microsoft.Xna.Framework;
+using Mono.Cecil;
+using MonoMod;
+using MonoMod.Cil;
+using System;
+using System.Collections;
+
+namespace Celeste {
+    class patch_BadelineBoost : BadelineBoost {
+        public patch_BadelineBoost(EntityData data, Vector2 offset) : base(data, offset) {
+            // no-op, ignored by MonoMod
+        }
+
+        [MonoModIgnore]
+        [PatchBadelineBoostBoostRoutine]
+        private extern IEnumerator BoostRoutine(Player player);
+    }
+}
+
+namespace MonoMod {
+    /// <summary>
+    /// Patches the BoostRoutine to remove a debug print left by the devs.
+    /// </summary>
+    [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchBadelineBoostBoostRoutine))]
+    class PatchBadelineBoostBoostRoutineAttribute : Attribute { }
+    static partial class MonoModRules {
+        public static void PatchBadelineBoostBoostRoutine(MethodDefinition method, CustomAttribute attrib) {
+            MethodDefinition routine = method.GetEnumeratorMoveNext();
+            new ILContext(routine).Invoke(ctx => {
+                ILCursor cursor = new ILCursor(ctx);
+
+                // remove Console.WriteLine("TIME: " + sw.ElapsedMilliseconds);
+                cursor.GotoNext(MoveType.AfterLabel, instr => instr.MatchLdstr("TIME: "));
+                cursor.RemoveRange(7);
+            });
+        }
+    }
+}

--- a/Celeste.Mod.mm/Patches/Level.cs
+++ b/Celeste.Mod.mm/Patches/Level.cs
@@ -635,6 +635,10 @@ namespace MonoMod {
                 }
             }
 
+            cctor_il.Emit(OpCodes.Dup);
+            cctor_il.Emit(OpCodes.Ldstr, "theoCrystalHoldingBarrier"); // theoCrystalHoldingBarrier is an unused entity appearing in chapter 5
+            cctor_il.Emit(OpCodes.Callvirt, m_LoadStrings_Add);
+            cctor_il.Emit(OpCodes.Pop);
             cctor_il.Emit(OpCodes.Stsfld, f_LoadStrings);
             cctor_il.Emit(OpCodes.Ret);
         }

--- a/Celeste.Mod.mm/Patches/NPC06_Badeline_Crying.cs
+++ b/Celeste.Mod.mm/Patches/NPC06_Badeline_Crying.cs
@@ -1,0 +1,39 @@
+using Microsoft.Xna.Framework;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using MonoMod;
+using MonoMod.Cil;
+using System;
+
+namespace Celeste {
+    class patch_NPC06_Badeline_Crying : NPC06_Badeline_Crying {
+        public patch_NPC06_Badeline_Crying(EntityData data, Vector2 offset) : base(data, offset) {
+            // no-op, ignored by MonoMod
+        }
+
+        [MonoModConstructor]
+        [MonoModIgnore]
+        [PatchNPC06BadelineCryingCtor]
+        public extern void ctor(EntityData data, Vector2 offset);
+    }
+}
+
+namespace MonoMod {
+
+    /// <summary>
+    /// Patch the constructor to use event:/none instead of other nonexistent event.
+    /// </summary>
+    [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchNPC06BadelineCryingCtor))]
+    class PatchNPC06BadelineCryingCtorAttribute : Attribute { }
+
+    static partial class MonoModRules {
+        public static void PatchNPC06BadelineCryingCtor(ILContext il, CustomAttribute attrib) {
+            ILCursor cursor = new ILCursor(il);
+
+            // use conventional fallback event instead of nonexistent event event:/char/badeline/boss_idle_ground
+            cursor.GotoNext(instr => instr.MatchLdstr("event:/char/badeline/boss_idle_ground"));
+            cursor.Remove();
+            cursor.Emit(OpCodes.Ldstr, "event:/none");
+        }
+    }
+}


### PR DESCRIPTION
- Don't log missing entity if the entity name is `theoCrystalHoldingBarrier`. This is an unused entity that appears in the level data for chapter 5, but does not have a code equivalent.
- Remove dev debug print from `BadelineBoost`.
- Don't log missing FMOD events if the name is `null`, `event:/none`, or `event:/null`. These are generally used as intentional placeholders if no audio is desired.
- Replace missing audio event `event:/char/badeline/boss_idle_ground` in `NPC06_Badeline_Crying` NPC with `event:/none`. A perfectly functional version of this event exists at `event:/env/local/06_reflection/boss_idle_ground`, but using this is quite a noticable change from vanilla and therefore probably out of scope for Everest.