### PR TITLE
Drastically reduce memory allocations of SaveData.get_TotalCassettes()

### DIFF
--- a/Celeste.Mod.mm/Patches/SaveData.cs
+++ b/Celeste.Mod.mm/Patches/SaveData.cs
@@ -88,7 +88,8 @@ namespace Celeste {
             get {
                 if (LevelSet == "Celeste")
                     return UnlockedAreas_Unsafe;
-                return LevelSetStats.AreaOffset + LevelSetStats.UnlockedAreas;
+                var stats = LevelSetStats;
+                return stats.AreaOffset + stats.UnlockedAreas;
             }
             set {
                 if (LevelSets == null || LevelSet == "Celeste") {
@@ -179,14 +180,16 @@ namespace Celeste {
         public new int MaxArea {
             [MonoModReplace]
             get {
-                return LevelSetStats.AreaOffset + LevelSetStats.MaxArea;
+                var stats = LevelSetStats;
+                return stats.AreaOffset + stats.MaxArea;
             }
         }
 
         public new int MaxAssistArea {
             [MonoModReplace]
             get {
-                return LevelSetStats.AreaOffset + LevelSetStats.MaxAssistArea;
+                var stats = LevelSetStats;
+                return stats.AreaOffset + stats.MaxAssistArea;
             }
         }
 
@@ -210,6 +213,21 @@ namespace Celeste {
                     return;
                 }
                 LevelSetStats.Poem = value;
+            }
+        }
+
+        public new int TotalCassettes {
+            [MonoModReplace] // optimise the method
+            get {
+                int totalCassettes = 0;
+                var areas = Areas_Safe; // this getter hides extremely expensive calculations. Evil!
+                var maxArea = MaxArea;
+
+                for (int i = 0; i <= maxArea; ++i) {
+                    if (areas[i].Cassette && !AreaData.Get(i).Interlude)
+                        totalCassettes++;
+                }
+                return totalCassettes;
             }
         }
 

--- a/Celeste.Mod.mm/Patches/SaveData.cs
+++ b/Celeste.Mod.mm/Patches/SaveData.cs
@@ -88,7 +88,7 @@ namespace Celeste {
             get {
                 if (LevelSet == "Celeste")
                     return UnlockedAreas_Unsafe;
-                var stats = LevelSetStats;
+                LevelSetStats stats = LevelSetStats;
                 return stats.AreaOffset + stats.UnlockedAreas;
             }
             set {
@@ -96,7 +96,8 @@ namespace Celeste {
                     UnlockedAreas_Unsafe = value;
                     return;
                 }
-                LevelSetStats.UnlockedAreas = value - LevelSetStats.AreaOffset;
+                LevelSetStats stats = LevelSetStats;
+                stats.UnlockedAreas = value - stats.AreaOffset;
             }
         }
 
@@ -180,7 +181,7 @@ namespace Celeste {
         public new int MaxArea {
             [MonoModReplace]
             get {
-                var stats = LevelSetStats;
+                LevelSetStats stats = LevelSetStats;
                 return stats.AreaOffset + stats.MaxArea;
             }
         }
@@ -188,7 +189,7 @@ namespace Celeste {
         public new int MaxAssistArea {
             [MonoModReplace]
             get {
-                var stats = LevelSetStats;
+                LevelSetStats stats = LevelSetStats;
                 return stats.AreaOffset + stats.MaxAssistArea;
             }
         }
@@ -220,8 +221,8 @@ namespace Celeste {
             [MonoModReplace] // optimise the method
             get {
                 int totalCassettes = 0;
-                var areas = Areas_Safe; // this getter hides extremely expensive calculations. Evil!
-                var maxArea = MaxArea;
+                List<AreaStats> areas = Areas_Safe; // this getter hides extremely expensive calculations. Evil!
+                int maxArea = MaxArea;
 
                 for (int i = 0; i <= maxArea; ++i) {
                     if (areas[i].Cassette && !AreaData.Get(i).Interlude)


### PR DESCRIPTION
From `Celeste.SaveData.get_TotalCassettes()` taking ~60% of all per-frame allocations even in maps with entities that generate tons of memory allocations, this PR makes this function take ~8%. This definitely will have positive impact on GC times.

Of course, there's still a ways to go (this really should be a free operation), however the way save data is handled is so fundamentally horrible for performance that a full rewrite of this file is in order, but that's too daunting for me at the moment.