### PR TITLE
Add spawnpoint attribute to mark default spawn

### DIFF
--- a/Celeste.Mod.mm/Patches/Level.cs
+++ b/Celeste.Mod.mm/Patches/Level.cs
@@ -42,7 +42,8 @@ namespace Celeste {
 
         /// <summary>
         /// If in vanilla levels, gets the spawnpoint closest to the bottom left of the level.<br/>
-        /// Otherwise, get the first spawnpoint defined in the level data.
+        /// Otherwise, get the default spawnpoint from the level data if present, falling back to
+        /// the first spawnpoint defined in the level data.
         /// </summary>
         public new Vector2 DefaultSpawnPoint {
             [MonoModReplace]
@@ -50,7 +51,8 @@ namespace Celeste {
                 if (Session.Area.GetLevelSet() == "Celeste")
                     return GetSpawnPoint(new Vector2(Bounds.Left, Bounds.Bottom));
 
-                return Session.LevelData.Spawns[0];
+                patch_LevelData levelData = (patch_LevelData) Session.LevelData;
+                return levelData.DefaultSpawn ?? levelData.Spawns[0];
             }
         }
 

--- a/Celeste.Mod.mm/Patches/LevelData.cs
+++ b/Celeste.Mod.mm/Patches/LevelData.cs
@@ -1,5 +1,6 @@
 #pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
 
+using Microsoft.Xna.Framework;
 using System;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
@@ -7,9 +8,12 @@ using MonoMod;
 using MonoMod.Cil;
 using MonoMod.InlineRT;
 using MonoMod.Utils;
+using System.Globalization;
 
 namespace Celeste {
     public class patch_LevelData : LevelData {
+
+        public Vector2? DefaultSpawn;
 
         public patch_LevelData(BinaryPacker.Element data) : base(data) {
             // no-op. MonoMod ignores this - we only need this to make the compiler shut up.
@@ -18,11 +22,18 @@ namespace Celeste {
         [MonoModIgnore]
         [PatchLevelDataBerryTracker]
         [PatchLevelDataDecalLoader]
+        [PatchLevelDataSpawnpointLoader]
         public extern void orig_ctor(BinaryPacker.Element data);
 
         [MonoModConstructor]
         public void ctor(BinaryPacker.Element data) {
             orig_ctor(data);
+        }
+
+        private void CheckForDefaultSpawn(BinaryPacker.Element spawn, Vector2 coords) {
+            if (DefaultSpawn == null && spawn.Attributes.TryGetValue("isDefaultSpawn", out object isDefaultSpawn) && Convert.ToBoolean(isDefaultSpawn, CultureInfo.InvariantCulture)) {
+                DefaultSpawn = coords;
+            }
         }
     }
 }
@@ -39,6 +50,12 @@ namespace MonoMod {
     /// </summary>
     [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchLevelDataDecalLoader))]
     class PatchLevelDataDecalLoader : Attribute { }
+
+    /// <summary>
+    /// Patch the constructor to recognize the default spawnpoint.
+    /// </summary>
+    [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchLevelDataSpawnpointLoader))]
+    class PatchLevelDataSpawnpointLoaderAttribute : Attribute { }
 
     static partial class MonoModRules {
 
@@ -107,6 +124,26 @@ namespace MonoMod {
             if (matches != 2) {
                 throw new Exception($"Too few matches for HasAttr(\"tag\"): {matches}");
             }
+        }
+
+        public static void PatchLevelDataSpawnpointLoader(ILContext context, CustomAttribute attrib) {
+            MethodDefinition m_LevelDataCheckForDefaultSpawn = context.Method.DeclaringType.FindMethod("CheckForDefaultSpawn");
+            TypeReference t_Vector2 = MonoModRule.Modder.FindType("Microsoft.Xna.Framework.Vector2").Resolve();
+            t_Vector2 = MonoModRule.Modder.Module.ImportReference(t_Vector2);
+            VariableDefinition v_spawnCoords = new VariableDefinition(t_Vector2);
+            context.Body.Variables.Add(v_spawnCoords);
+
+            ILCursor cursor = new ILCursor(context);
+
+            // call CheckForDefaultSpawn with checkpoint element and coordinates
+            cursor.GotoNext(instr => instr.MatchLdstr("player"));
+            cursor.GotoNext(MoveType.After, instr => instr.MatchNewobj("Microsoft.Xna.Framework.Vector2"));
+            cursor.Emit(OpCodes.Stloc, v_spawnCoords);
+            cursor.Emit(OpCodes.Ldarg_0);
+            cursor.Emit(OpCodes.Ldloc, 9);
+            cursor.Emit(OpCodes.Ldloc, v_spawnCoords);
+            cursor.Emit(OpCodes.Callvirt, m_LevelDataCheckForDefaultSpawn);
+            cursor.Emit(OpCodes.Ldloc, v_spawnCoords);
         }
     }
 }

--- a/Celeste.Mod.mm/Patches/LevelData.cs
+++ b/Celeste.Mod.mm/Patches/LevelData.cs
@@ -135,12 +135,13 @@ namespace MonoMod {
 
             ILCursor cursor = new ILCursor(context);
 
+            int element = -1;
             // call CheckForDefaultSpawn with checkpoint element and coordinates
-            cursor.GotoNext(instr => instr.MatchLdstr("player"));
+            cursor.GotoNext(instr => instr.MatchLdloc(out element), instr => instr.MatchLdfld("Celeste.BinaryPacker/Element", "Name"), instr => instr.MatchLdstr("player"));
             cursor.GotoNext(MoveType.After, instr => instr.MatchNewobj("Microsoft.Xna.Framework.Vector2"));
             cursor.Emit(OpCodes.Stloc, v_spawnCoords);
             cursor.Emit(OpCodes.Ldarg_0);
-            cursor.Emit(OpCodes.Ldloc, 9);
+            cursor.Emit(OpCodes.Ldloc, element);
             cursor.Emit(OpCodes.Ldloc, v_spawnCoords);
             cursor.Emit(OpCodes.Callvirt, m_LevelDataCheckForDefaultSpawn);
             cursor.Emit(OpCodes.Ldloc, v_spawnCoords);


### PR DESCRIPTION
This allows marking a specific spawnpoint as default in a starting room with multiple spawnpoints by setting the boolean attribute `isDefaultSpawn`. If no spawnpoint has this option set, the old fallback is used, so this will not break any existing maps.
The `isDefaultSpawn` attribute will need to be added to the Lönn plugin to make this feature usable. Cruor and Vexatos both agreed that this is the most sensible way to handle default spawnpoints.