### PR TITLE
Prevent crash if string option is null

### DIFF
--- a/Celeste.Mod.mm/Mod/UI/OuiModOptionString.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiModOptionString.cs
@@ -100,7 +100,7 @@ namespace Celeste.Mod.UI {
         }
 
         public OuiModOptionString Init(string value, Action<string> onValueChange, Action<bool> exit, int maxValueLength, int minValueLength) {
-            _Value = StartingValue = value;
+            _Value = StartingValue = value ?? "";
             OnValueChange = onValueChange;
 
             MaxValueLength = maxValueLength;


### PR DESCRIPTION
Currently, trying to edit a string-type setting that is currently null causes a crash. This fixes that crash by replacing null with the empty string when initializing OuiModOptionString.