### PR TITLE
Improvements to CustomTextVignette

### DIFF
--- a/Celeste.Mod.mm/Mod/Entities/CustomTextVignette.cs
+++ b/Celeste.Mod.mm/Mod/Entities/CustomTextVignette.cs
@@ -1,4 +1,5 @@
-﻿using FMOD.Studio;
+﻿using Celeste.Mod.Meta;
+using FMOD.Studio;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Monocle;
@@ -7,7 +8,6 @@ using System.Collections;
 
 namespace Celeste.Mod.Entities {
     public class CustomTextVignette : Scene {
-        private const float SFXDuration = 18.683f;
 
         public bool CanPause => menu == null;
 
@@ -20,9 +20,10 @@ namespace Celeste.Mod.Entities {
         private bool started;
         private bool exiting;
 
-        private float timer;
         private float fade;
         private float pauseFade;
+        private float initialDelay;
+        private float finalDelay;
 
         private FancyText.Text text;
         private int textStart;
@@ -32,28 +33,35 @@ namespace Celeste.Mod.Entities {
         private HudRenderer renderer;
         private HiresSnow snow;
 
-        public CustomTextVignette(Session session, string text, HiresSnow snow = null) {
+        public CustomTextVignette(Session session, MapMetaTextVignette meta, HiresSnow snow = null)  {
             this.session = session;
             areaMusic = session.Audio.Music.Event;
             session.Audio.Music.Event = null;
             session.Audio.Apply();
 
-            sfx = Audio.Play(SFX.music_prologue_intro_vignette);
+            sfx = Audio.Play(meta.Audio);
 
             if (snow == null) {
                 fade = 1f;
                 snow = new HiresSnow();
             }
+            snow.Direction = meta.SnowDirection;
             Add(renderer = new HudRenderer());
             Add(this.snow = snow);
             RendererList.UpdateLists();
 
-            this.text = FancyText.Parse(Dialog.Get(text), 960, 8, 0f);
+            initialDelay = meta.InitialDelay;
+            finalDelay = meta.FinalDelay;
+
+            text = FancyText.Parse(Dialog.Get(meta.Dialog), 960, 8, 0f);
             textCoroutine = new Coroutine(TextSequence());
         }
 
+        public CustomTextVignette(Session session, string text, HiresSnow snow = null) // maintain interface for backwards compatibility
+            : this(session, new MapMetaTextVignette {Dialog = text}, snow) { }
+
         private IEnumerator TextSequence() {
-            yield return 3f;
+            yield return initialDelay;
 
             while (textStart < text.Count) {
                 textAlpha = 1f;
@@ -78,6 +86,12 @@ namespace Celeste.Mod.Entities {
                 textStart = text.GetNextPageStart(textStart);
                 yield return 0.5f;
             }
+            if (finalDelay > 0) {
+                yield return finalDelay;
+            }
+            if (!started) {
+                StartGame();
+            }
             textStart = int.MaxValue;
         }
 
@@ -88,12 +102,7 @@ namespace Celeste.Mod.Entities {
                     if (textCoroutine != null && textCoroutine.Active) {
                         textCoroutine.Update();
                     }
-
-                    timer += Engine.DeltaTime;
-                    if (timer >= SFXDuration && !started) {
-                        StartGame();
-                    }
-                    if (timer < (SFXDuration - 2f) && menu == null && (Input.Pause.Pressed || Input.ESC.Pressed)) {
+                    if (menu == null && (Input.Pause.Pressed || Input.ESC.Pressed)) {
                         Input.Pause.ConsumeBuffer();
                         Input.ESC.ConsumeBuffer();
                         OpenMenu();
@@ -175,11 +184,11 @@ namespace Celeste.Mod.Entities {
                 Draw.SpriteBatch.Begin(SpriteSortMode.Deferred, BlendState.AlphaBlend, SamplerState.LinearClamp, null, RasterizerState.CullNone, null, Engine.ScreenMatrix);
 
                 if (fade > 0f) {
-                    Draw.Rect(-1f, -1f, 1922f, 1082f, Color.Black * fade);
+                    Draw.Rect(-1f, -1f, Celeste.TargetWidth + 2f, Celeste.TargetHeight + 2f, Color.Black * fade);
                 }
 
                 if (textStart < text.Nodes.Count && textAlpha > 0f) {
-                    text.Draw(new Vector2(1920f, 1080f) * 0.5f, new Vector2(0.5f, 0.5f), Vector2.One, textAlpha * (1f - pauseFade), textStart);
+                    text.DrawJustifyPerLine(new Vector2(Celeste.TargetWidth, Celeste.TargetHeight) * 0.5f, new Vector2(0.5f, 0.5f), Vector2.One, textAlpha * (1f - pauseFade), textStart);
                 }
 
                 Draw.SpriteBatch.End();

--- a/Celeste.Mod.mm/Mod/Entities/CustomTextVignette.cs
+++ b/Celeste.Mod.mm/Mod/Entities/CustomTextVignette.cs
@@ -8,7 +8,6 @@ using System.Collections;
 
 namespace Celeste.Mod.Entities {
     public class CustomTextVignette : Scene {
-
         public bool CanPause => menu == null;
 
         private Session session;
@@ -33,7 +32,7 @@ namespace Celeste.Mod.Entities {
         private HudRenderer renderer;
         private HiresSnow snow;
 
-        public CustomTextVignette(Session session, MapMetaTextVignette meta, HiresSnow snow = null)  {
+        public CustomTextVignette(Session session, MapMetaTextVignette meta, HiresSnow snow = null) {
             this.session = session;
             areaMusic = session.Audio.Music.Event;
             session.Audio.Music.Event = null;

--- a/Celeste.Mod.mm/Mod/Meta/MapMeta.cs
+++ b/Celeste.Mod.mm/Mod/Meta/MapMeta.cs
@@ -510,6 +510,9 @@ namespace Celeste.Mod.Meta {
 
     public class MapMetaTextVignette {
         public string Dialog { get; set; }
+        public string Audio { get; set; } = SFX.music_prologue_intro_vignette; // for backwards compatibility reasons, default to prologue audio if not specified
+        public float InitialDelay { get; set; } = 3;
+        public float FinalDelay { get; set; }
         [YamlIgnore] public Vector2 SnowDirection => SnowDirectionArray.ToVector2() ?? Vector2.UnitY; //Snowing downwards by default
         [YamlMember(Alias = "SnowDirection")] public float[] SnowDirectionArray { get; set; }
     }

--- a/Celeste.Mod.mm/Mod/Meta/MapMeta.cs
+++ b/Celeste.Mod.mm/Mod/Meta/MapMeta.cs
@@ -513,7 +513,7 @@ namespace Celeste.Mod.Meta {
         public string Audio { get; set; } = SFX.music_prologue_intro_vignette; // for backwards compatibility reasons, default to prologue audio if not specified
         public float InitialDelay { get; set; } = 3;
         public float FinalDelay { get; set; }
-        [YamlIgnore] public Vector2 SnowDirection => SnowDirectionArray.ToVector2() ?? Vector2.UnitY; //Snowing downwards by default
+        [YamlIgnore] public Vector2 SnowDirection => SnowDirectionArray.ToVector2() ?? -Vector2.UnitX; //Snowing to the left by default
         [YamlMember(Alias = "SnowDirection")] public float[] SnowDirectionArray { get; set; }
     }
 

--- a/Celeste.Mod.mm/Patches/LevelEnter.cs
+++ b/Celeste.Mod.mm/Patches/LevelEnter.cs
@@ -64,14 +64,11 @@ namespace Celeste {
                 Engine.Scene = new CustomScreenVignette(session, meta: screen);
                 return true;
             } else if (playVignette && (text = area.GetMeta()?.LoadingVignetteText) != null && text.Dialog != null) {
-                HiresSnow snow = null;
-                if (Engine.Scene is Overworld)
-                    snow = (Engine.Scene as Overworld).Snow;
+                if (Engine.Scene is not Overworld {Snow: HiresSnow snow}) {
+                    snow = null;
+                }
 
-                if (snow != null && text.SnowDirection != null)
-                    snow.Direction = text.SnowDirection;
-
-                Engine.Scene = new CustomTextVignette(session, text.Dialog, snow);
+                Engine.Scene = new CustomTextVignette(session, text, snow);
                 return true;
             }
 


### PR DESCRIPTION
Improve custom vignettes in a few ways:

- Allow customizing the audio (currently still defaults to the prologue audio for backwards compatibility).
- No longer ends after a hardcoded wait duration, uses the `CoreVignette` approach instead.
- Allow customizing wait times at the start and end (vanilla has a shorter initial wait time in `CoreVignette` than `IntroVignette`, the wait time at the end can be used e.g. to wait for a sound to finish as `IntroVignette` does).
- Make sure the snow direction always gets applied, not just when reusing an existing `HiresSnow` (probably never matters).
- Center all text lines for text with line breaks.
- Make snow in vignette blow to the left by default to match vanilla.

The new wait time attributes, as well as the wind direction one, should also be documented on the wiki.