### PR TITLE
Fix inputs are not deregistered when hot reloading

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -843,6 +843,7 @@ namespace Celeste.Mod {
         /// </summary>
         /// <param name="module"></param>
         internal static void Unregister(this EverestModule module) {
+            module.OnInputDeregister();
             module.Unload();
 
             Assembly asm = module.GetType().Assembly;


### PR DESCRIPTION
If the old inputs are not deregistered, `Minput.VirtualInputs` will get bigger and bigger, which will affect the efficiency of the game.