### PR TITLE
Call Player.Die event only when player actually died

### DIFF
--- a/Celeste.Mod.mm/Patches/Player.cs
+++ b/Celeste.Mod.mm/Patches/Player.cs
@@ -121,6 +121,7 @@ namespace Celeste {
             PlayerDeadBody body = orig_Die(direction, evenIfInvincible, registerDeathInStats);
 
             if (body != null) {
+                Everest.Events.Player.Die(this);
                 // 2 catches spawn-blade-kill GBJs.
                 // 4 catches spawn-OOB-kill GBJs.
                 if (framesAlive < 6 && level != null) {
@@ -132,7 +133,6 @@ namespace Celeste {
                 }
             }
 
-            Everest.Events.Player.Die(this);
             return body;
         }
 


### PR DESCRIPTION
Previously, the event was called whenever Player.Die was called, even if the player was not killed, such as due to invincibility, reflection fall state, or already being dead.