### PR TITLE
Start music early if CassetteSong metadata exists and LeadBeats is 0

### DIFF
--- a/Celeste.Mod.mm/Patches/CassetteBlockManager.cs
+++ b/Celeste.Mod.mm/Patches/CassetteBlockManager.cs
@@ -69,7 +69,7 @@ namespace Celeste {
             if (sfx == null && !isLevelMusic) {
                 string cassetteSong = AreaData.Areas[SceneAs<Level>().Session.Area.ID].CassetteSong;
                 sfx = Audio.CreateInstance(cassetteSong);
-                Audio.Play("event:/game/general/cassette_block_switch_2");
+                Audio.Play(SFX.game_gen_cassetteblock_switch_2);
 
                 if (leadBeats == 0) {
                     beatIndex = 0;

--- a/Celeste.Mod.mm/Patches/CassetteBlockManager.cs
+++ b/Celeste.Mod.mm/Patches/CassetteBlockManager.cs
@@ -56,6 +56,30 @@ namespace Celeste {
             }
         }
 
+        [MonoModLinkTo("Monocle.Entity", "Update")]
+        [MonoModIgnore]
+        public extern void base_Update();
+        [MonoModReplace]
+        public override void Update() {
+            base_Update();
+            if (isLevelMusic) {
+                sfx = Audio.CurrentMusicEventInstance;
+            }
+
+            if (sfx == null && !isLevelMusic) {
+                string cassetteSong = AreaData.Areas[SceneAs<Level>().Session.Area.ID].CassetteSong;
+                sfx = Audio.CreateInstance(cassetteSong);
+                Audio.Play("event:/game/general/cassette_block_switch_2");
+
+                if (leadBeats == 0) {
+                    beatIndex = 0;
+                    sfx?.start();
+                }
+            } else {
+                AdvanceMusic(Engine.DeltaTime * tempoMult);
+            }
+        }
+
         [MonoModReplace]
         public new void AdvanceMusic(float time) {
             beatTimer += time;


### PR DESCRIPTION
Using the `CassetteSong` map metadata field sets `LeadBeats` to 16 by default, which ticks down over time and starts the cassette song once the value reaches 0. This code never runs if the `LeadBeats` metadata field is set to 0 to begin with, meaning the cassette song never starts. My solution here simply adds three lines to the `Update` method of `CassetteBlockManager`
```cs
if (leadBeats == 0) {
    beatIndex = 0;
    sfx?.start();
}
```
Exactly where the cassette song is fetched so that it is started immediately. If you have any suggestion for a cleaner solution than replacing the whole method, I'd like to know.