### PR TITLE
Implement culling for Wires, Flaglines, Cobwebs, TileGrids.

### DIFF
--- a/Celeste.Mod.mm/Mod/Helpers/CullHelper.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/CullHelper.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.Xna.Framework;
+using Monocle;
+using System;
+
+namespace Celeste.Mod.Helpers {
+    /// <summary>
+    /// Exposes static functions that allow you to easily check if something is currently visible, to be used for culling.
+    /// </summary>
+    public static class CullHelper {
+        /// <summary>
+        /// Checks whether the rectangle (x, y, w, h) is visible inside of the camera
+        /// </summary>
+        public static bool IsRectangleVisible(float x, float y, float w, float h, float lenience = 4f, Camera camera = null) {
+            camera ??= (Engine.Scene as Level)?.Camera;
+            if (camera is null) {
+                return true;
+            }
+
+            return x + w >= camera.Left - lenience
+                && x <= camera.Right + lenience
+                && y + h >= camera.Top - lenience
+                && y <= camera.Bottom + 180f + lenience;
+        }
+
+        /// <summary>
+        /// Checks if the curve is visible by creating a rectangle containing the edge points of the curve (Begin, Control, End)
+        /// </summary>
+        public static bool IsCurveVisible(SimpleCurve curve, float lenience = 8f, Camera camera = null) {
+            Vector2 a = curve.Begin;
+            Vector2 b = curve.Control;
+            Vector2 c = curve.End;
+
+            float left = Math.Min(a.X, Math.Min(b.X, c.X));
+            float right = Math.Max(a.X, Math.Max(b.X, c.X));
+            float top = Math.Min(a.Y, Math.Min(b.Y, c.Y));
+            float bottom = Math.Max(a.Y, Math.Max(b.Y, c.Y));
+
+            return IsRectangleVisible(left, top, right - left, bottom - top, lenience, camera);
+        }
+    }
+}

--- a/Celeste.Mod.mm/Patches/Cobweb.cs
+++ b/Celeste.Mod.mm/Patches/Cobweb.cs
@@ -1,7 +1,15 @@
 ﻿#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
 
+using Celeste.Mod.Helpers;
 using Microsoft.Xna.Framework;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
 using Monocle;
+using MonoMod;
+using MonoMod.Cil;
+using MonoMod.Utils;
+using System;
+using System.Linq;
 
 namespace Celeste {
     class patch_Cobweb : Cobweb {
@@ -26,5 +34,41 @@ namespace Celeste {
             area.CobwebColor = prevColors;
         }
 
+        [MonoModIgnore]
+        [PatchCobwebDrawCobweb]
+        private extern void DrawCobweb(Vector2 a, Vector2 b, int steps, bool drawOffshoots);
+
+        private static bool IsVisible(SimpleCurve curve) {
+            return CullHelper.IsCurveVisible(curve);
+        }
+    }
+}
+
+namespace MonoMod {
+    /// <summary>
+    /// Patches the method to implement culling.
+    /// </summary>
+    [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchDrawCobweb))]
+    class PatchCobwebDrawCobweb : Attribute { }
+
+    static partial class MonoModRules {
+        public static void PatchDrawCobweb(ILContext il, CustomAttribute attrib) {
+            ILCursor cursor = new ILCursor(il);
+
+            VariableDefinition curveLocal = cursor.Body.Variables.First(v => v.VariableType.Name.Contains("SimpleCurve"));
+
+            // inject our culling after the recursive DrawCobweb call - we need to cull each offshoot individually or we'll have pop-in.
+            cursor.GotoNext(MoveType.After, instr => instr.MatchLdfld("Monocle.SimpleCurve", "Begin"));
+            cursor.GotoNext(MoveType.After, instr => instr.MatchStloc(out _));
+
+            cursor.Emit(OpCodes.Ldloc_S, curveLocal);
+            cursor.Emit(OpCodes.Call, il.Method.DeclaringType.FindMethod("System.Boolean IsVisible(Monocle.SimpleCurve)"));
+
+            // return early if IsVisible returned false
+            ILLabel label = cursor.DefineLabel();
+            cursor.Emit(OpCodes.Brtrue, label);
+            cursor.Emit(OpCodes.Ret);
+            cursor.MarkLabel(label);
+        }
     }
 }

--- a/Celeste.Mod.mm/Patches/Flagline.cs
+++ b/Celeste.Mod.mm/Patches/Flagline.cs
@@ -1,0 +1,92 @@
+﻿#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value null
+
+using Microsoft.Xna.Framework;
+using Mono.Cecil.Cil;
+using Mono.Cecil;
+using MonoMod.Cil;
+using System;
+using MonoMod;
+using System.Linq;
+using MonoMod.Utils;
+using Monocle;
+using Celeste.Mod.Helpers;
+
+namespace Celeste {
+    class patch_Flagline : Flagline {
+        public patch_Flagline(Vector2 to, Color lineColor, Color pinColor, Color[] colors, int minFlagHeight, int maxFlagHeight, int minFlagLength, int maxFlagLength, int minSpace, int maxSpace) 
+            : base(to, lineColor, pinColor, colors, minFlagHeight, maxFlagHeight, minFlagLength, maxFlagLength, minSpace, maxSpace) {
+            // no-op. MonoMod ignores this - we only need this to make the compiler shut up.
+        }
+
+        [MonoModIgnore]
+        [PatchFlaglineDraw]
+        public override extern void Render();
+
+        private bool IsVisible(SimpleCurve curve) {
+            Cloth[] clothes = this.clothes;
+            float maxHeight = 0f;
+            for (int i = 0; i < clothes.Length; i++) {
+                Cloth cloth = clothes[i];
+                float h = cloth.Height + (cloth.Length * ClothDroopAmount * 1.4f);
+
+                if (h > maxHeight) {
+                    maxHeight = h;
+                }
+            }
+
+            return CullHelper.IsCurveVisible(curve, maxHeight + 8f);
+        }
+
+        [MonoModIgnore]
+        private Cloth[] clothes;
+
+        [MonoModIgnore]
+        private struct Cloth {
+            public int Color;
+
+            public int Height;
+
+            public int Length;
+
+            public int Step;
+        }
+    }
+}
+
+namespace MonoMod {
+    /// <summary>
+    /// Patches the method to implement culling.
+    /// </summary>
+    [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchFlaglineDraw))]
+    class PatchFlaglineDraw : Attribute { }
+
+    static partial class MonoModRules {
+        public static void PatchFlaglineDraw(ILContext il, CustomAttribute attrib) {
+            ILCursor cursor = new ILCursor(il);
+
+            VariableDefinition curveLocal = cursor.Body.Variables.First(v => v.VariableType.Name.Contains("SimpleCurve"));
+
+            cursor.GotoNext(MoveType.After, instr => instr.MatchCall("Monocle.SimpleCurve", ".ctor"));
+
+            cursor.Emit(OpCodes.Ldarg_0);
+            cursor.Emit(OpCodes.Ldloc_S, curveLocal);
+            cursor.Emit(OpCodes.Call, il.Method.DeclaringType.FindMethod("System.Boolean IsVisible(Monocle.SimpleCurve)"));
+
+            // return early if IsVisible returned false
+            ILLabel label = cursor.DefineLabel();
+            cursor.Emit(OpCodes.Brtrue, label);
+            cursor.Emit(OpCodes.Ret);
+            cursor.MarkLabel(label);
+        }
+
+        public static void PatchFlaglineCtor(ILContext il, CustomAttribute attrib) {
+            ILCursor cursor = new ILCursor(il);
+
+            // move right before the ret opcode
+            cursor.Index = cursor.Instrs.Count - 2;
+
+            cursor.Emit(OpCodes.Ldarg_0);
+            cursor.Emit(OpCodes.Call, il.Method.DeclaringType.FindMethod("System.Void CacheMaxHeight()"));
+        }
+    }
+}

--- a/Celeste.Mod.mm/Patches/Flagline.cs
+++ b/Celeste.Mod.mm/Patches/Flagline.cs
@@ -78,15 +78,5 @@ namespace MonoMod {
             cursor.Emit(OpCodes.Ret);
             cursor.MarkLabel(label);
         }
-
-        public static void PatchFlaglineCtor(ILContext il, CustomAttribute attrib) {
-            ILCursor cursor = new ILCursor(il);
-
-            // move right before the ret opcode
-            cursor.Index = cursor.Instrs.Count - 2;
-
-            cursor.Emit(OpCodes.Ldarg_0);
-            cursor.Emit(OpCodes.Call, il.Method.DeclaringType.FindMethod("System.Void CacheMaxHeight()"));
-        }
     }
 }

--- a/Celeste.Mod.mm/Patches/Monocle/TileGrid.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/TileGrid.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Xna.Framework;
+﻿using Celeste;
+using Microsoft.Xna.Framework;
 
 namespace Monocle {
     class patch_TileGrid : TileGrid {
@@ -11,6 +12,12 @@ namespace Monocle {
         public new void RenderAt(Vector2 position) {
             if (Alpha <= 0f) {
                 return;
+            }
+
+            // Many entities (both vanilla and modded) don't set this field, which gets rid of culling.
+            // Let's just set this to the most obvious value...
+            if (ClipCamera is null && Scene is Level lvl) {
+                ClipCamera = lvl.Camera;
             }
 
             Rectangle clippedRenderTiles = GetClippedRenderTiles();

--- a/Celeste.Mod.mm/Patches/Wire.cs
+++ b/Celeste.Mod.mm/Patches/Wire.cs
@@ -1,0 +1,50 @@
+﻿using Celeste.Mod.Helpers;
+using Microsoft.Xna.Framework;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using MonoMod;
+using MonoMod.Cil;
+using MonoMod.Utils;
+using System;
+
+namespace Celeste {
+    class patch_Wire : Wire {
+        public patch_Wire(EntityData data, Vector2 offset) : base(data, offset) {
+            // no-op. MonoMod ignores this - we only need this to make the compiler shut up.
+        }
+
+        [MonoModIgnore]
+        [PatchWireRender]
+        public extern override void Render();
+
+        private bool IsVisible() {
+            return CullHelper.IsCurveVisible(Curve, 2f);
+        }
+    }
+}
+
+namespace MonoMod {
+    /// <summary>
+    /// Patches the method to implement culling.
+    /// </summary>
+    [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchWireRender))]
+    class PatchWireRender : Attribute { }
+
+    static partial class MonoModRules {
+        public static void PatchWireRender(ILContext il, CustomAttribute attrib) {
+            ILCursor cursor = new ILCursor(il);
+
+            // insert culling code after the curve is fully set up.
+            cursor.GotoNext(MoveType.After, instr => instr.MatchStfld("Monocle.SimpleCurve", "Control"));
+
+            cursor.Emit(OpCodes.Ldarg_0);
+            cursor.Emit(OpCodes.Call, il.Method.DeclaringType.FindMethod("System.Boolean IsVisible()"));
+
+            // return early if IsVisible returned false
+            ILLabel label = cursor.DefineLabel();
+            cursor.Emit(OpCodes.Brtrue, label);
+            cursor.Emit(OpCodes.Ret);
+            cursor.MarkLabel(label);
+        }
+    }
+}


### PR DESCRIPTION
Also exposes a `public static class Celeste.Mod.Helpers.CullHelper` which contains some helper functions for culling entities. In the future, this could be expanded with more functions (like checking Sprites, lines, etc.).

`TileGrid`s already have culling in vanilla via the `ClipCamera` field. However, most tile-entities *don't* actually set this field (both in vanilla and in mods), making them render all the time. With this PR, this field will get automatically set to `Level.Camera` if inside a level and the field isn't set to anything else, which should cover 99.99% of use cases.

All in all, this PR provides a **huge** boost to maps that heavily use these entities, especially because the Performinator:tm: doesn't quite work well with noded entities.

Code based on [Frost Helper's experimental setting](https://github.com/JaThePlayer/FrostHelper/blob/master/Code/FrostHelper/EXPERIMENTAL/FlaglineCull.cs).