### PR TITLE
Fix relinker not resolving cross-mod dependencies

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Relinker.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Relinker.cs
@@ -231,7 +231,7 @@ namespace Celeste.Mod {
                             _RelinkedModules.Add(mod.Assembly.Name.Name, mod);
                             mod = null;
                         } else
-                            Logger.Log(LogLevel.Warn, "relinker", $"Encountered module name conflict loading assembly {meta} - {asmname} - {mod.Assembly.Name}");
+                            Logger.Log(LogLevel.Warn, "relinker", $"Encountered module name conflict loading cached assembly {meta} - {asmname} - {mod.Assembly.Name}");
 
                         return asm;
                     } catch (Exception e) {

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Relinker.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Relinker.cs
@@ -221,6 +221,15 @@ namespace Celeste.Mod {
                     try {
                         Assembly asm = Assembly.LoadFrom(cachedPath);
                         _RelinkedAssemblies.Add(asm);
+
+                        ModuleDefinition mod = ModuleDefinition.ReadModule(cachedPath);
+                        if (!_RelinkedModules.ContainsKey(mod.Assembly.Name.Name))
+                            _RelinkedModules.Add(mod.Assembly.Name.Name, mod);
+                        else {
+                            Logger.Log(LogLevel.Warn, "relinker", $"Encountered module name conflict loading assembly {meta} - {asmname} - {mod.Assembly.Name}");
+                            mod.Dispose();
+                        }
+
                         return asm;
                     } catch (Exception e) {
                         Logger.Log(LogLevel.Warn, "relinker", $"Failed loading {meta} - {asmname}");

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Relinker.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Relinker.cs
@@ -203,6 +203,7 @@ namespace Celeste.Mod {
                 string cachedPath = GetCachedPath(meta, asmname);
                 string cachedChecksumPath = cachedPath.Substring(0, cachedPath.Length - 4) + ".sum";
 
+                // Calculate checksums
                 string[] checksums = new string[2 + (checksumsExtra?.Length ?? 0)];
                 if (GameChecksum == null)
                     GameChecksum = Everest.GetChecksum(Assembly.GetAssembly(typeof(Relinker)).Location).ToHexadecimalString();
@@ -215,29 +216,34 @@ namespace Celeste.Mod {
                         checksums[i + 2] = checksumsExtra[i];
                     }
 
+                // Try to load a cached assembly if it exists and the checksums match
                 if (File.Exists(cachedPath) && File.Exists(cachedChecksumPath) &&
                     ChecksumsEqual(checksums, File.ReadAllLines(cachedChecksumPath))) {
                     Logger.Log(LogLevel.Verbose, "relinker", $"Loading cached assembly for {meta} - {asmname}");
+                    
+                    // Load the assembly and the module definition
+                    ModuleDefinition mod = ModuleDefinition.ReadModule(cachedPath);
                     try {
                         Assembly asm = Assembly.LoadFrom(cachedPath);
                         _RelinkedAssemblies.Add(asm);
 
-                        ModuleDefinition mod = ModuleDefinition.ReadModule(cachedPath);
-                        if (!_RelinkedModules.ContainsKey(mod.Assembly.Name.Name))
+                        if (!_RelinkedModules.ContainsKey(mod.Assembly.Name.Name)) {
                             _RelinkedModules.Add(mod.Assembly.Name.Name, mod);
-                        else {
+                            mod = null;
+                        } else
                             Logger.Log(LogLevel.Warn, "relinker", $"Encountered module name conflict loading assembly {meta} - {asmname} - {mod.Assembly.Name}");
-                            mod.Dispose();
-                        }
 
                         return asm;
                     } catch (Exception e) {
                         Logger.Log(LogLevel.Warn, "relinker", $"Failed loading {meta} - {asmname}");
                         e.LogDetailed();
                         return null;
+                    } finally {
+                        mod?.Dispose();
                     }
                 }
 
+                // Determine the dependency and assembly resolver
                 if (depResolver == null)
                     depResolver = GenerateModDependencyResolver(meta);
 
@@ -256,6 +262,7 @@ namespace Celeste.Mod {
                 try {
                     _Relinking = meta;
 
+                    // Setup the MonoModder
                     MonoModder modder = Modder;
 
                     modder.Input = stream;
@@ -264,6 +271,7 @@ namespace Celeste.Mod {
 
                     ((DefaultAssemblyResolver) modder.AssemblyResolver).ResolveFailure += resolver;
 
+                    // Read and setup debug symbols (if they exist)
                     modder.ReaderParameters.SymbolStream = OpenStream(meta, out string symbolPath, meta.DLL.Substring(0, meta.DLL.Length - 4) + ".pdb", meta.DLL + ".mdb");
                     modder.ReaderParameters.ReadSymbols = modder.ReaderParameters.SymbolStream != null;
                     if (modder.ReaderParameters.SymbolReaderProvider != null &&
@@ -291,8 +299,10 @@ namespace Celeste.Mod {
                         ((RelinkerSymbolReaderProvider) modder.ReaderParameters.SymbolReaderProvider).Format = DebugSymbolFormat.Auto;
                     }
 
+                    // Map assembly dependencies
                     modder.MapDependencies();
 
+                    // Parse runtime rules if they haven't already been parsed
                     if (!RuntimeRulesParsed) {
                         RuntimeRulesParsed = true;
 
@@ -316,12 +326,14 @@ namespace Celeste.Mod {
                         }
                     }
 
+                    // Patch the assembly
                     prePatch?.Invoke(modder);
 
                     modder.ParseRules(modder.Module);
 
                     modder.AutoPatch();
 
+                    // Write patched assembly and debug symbols back to disk
                     ISymbolWriterProvider symbolWriterProvider = modder.WriterParameters.SymbolWriterProvider;
 
                     RetryWrite:
@@ -354,6 +366,7 @@ namespace Celeste.Mod {
                     e.LogDetailed();
                     return null;
                 } finally {
+                    // Clean up modder
                     ((DefaultAssemblyResolver) Modder.AssemblyResolver).ResolveFailure -= resolver;
                     Modder.ReaderParameters.SymbolStream?.Dispose();
 
@@ -370,6 +383,7 @@ namespace Celeste.Mod {
                 }
 
                 try {
+                    // Write new checksums
                     if (File.Exists(cachedChecksumPath)) {
                         File.Delete(cachedChecksumPath);
                     }
@@ -377,6 +391,7 @@ namespace Celeste.Mod {
                         File.WriteAllLines(cachedChecksumPath, checksums);
                     }
 
+                    // Log the assembly load and dependencies
                     Logger.Log(LogLevel.Verbose, "relinker", $"Loading assembly for {meta} - {asmname} - {module.Assembly.Name}");
                     if (Modder != null)
                         foreach(AssemblyNameReference aref in module.AssemblyReferences) {
@@ -387,6 +402,7 @@ namespace Celeste.Mod {
                         }
 
                     try {
+                        // Load the assembly and the module definition
                         Assembly asm = Assembly.LoadFrom(cachedPath);
                         _RelinkedAssemblies.Add(asm);
 
@@ -410,9 +426,11 @@ namespace Celeste.Mod {
             private static MissingDependencyResolver GenerateModDependencyResolver(EverestModuleMetadata meta) {
                 if (!string.IsNullOrEmpty(meta.PathArchive)) {
                     return (mod, main, name, fullName) => {
+                        // Try to resolve cross-mod references
                         if (_RelinkedModules.TryGetValue(name, out ModuleDefinition def))
                             return def;
 
+                        // Try to resolve the DLL inside of the mod ZIP
                         string path = name + ".dll";
                         if (!string.IsNullOrEmpty(meta.DLL))
                             path = Path.Combine(Path.GetDirectoryName(meta.DLL), path);
@@ -434,9 +452,11 @@ namespace Celeste.Mod {
 
                 if (!string.IsNullOrEmpty(meta.PathDirectory)) {
                     return (mod, main, name, fullName) => {
+                        // Try to resolve cross-mod references
                         if (_RelinkedModules.TryGetValue(name, out ModuleDefinition def))
                             return def;
 
+                        // Try to resolve the DLL inside of the mod folder
                         string path = name + ".dll";
                         if (!string.IsNullOrEmpty(meta.DLL))
                             path = Path.Combine(Path.GetDirectoryName(meta.DLL), path);


### PR DESCRIPTION
Previously, the relinker didn't resolve cross-mod assembly references when patching the mod's assemblies using `MonoModder`. It also didn't throw any warnings or errors either, causing the relinking process to silently derail. This caused certain actions to cause bugs which were very hard to debug / pin down, like overriding a class from another mod and proceeding to call a method using `base.` causing an infinite recursive loop and subsequently a stack overflow crash. This fix resolves this issue by introducing a dictionary of currently relinked modules (`_RelinkedModules`), and consulting it in addition to other sources when trying to resolve assembly references. Additionally, a warning was added to notify modders when a dependent assembly failed to be resolved properly.