### PR TITLE
Make GetTypesSafe filter out "unsafe" types

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Extensions.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Extensions.cs
@@ -335,11 +335,30 @@ namespace Celeste.Mod {
         public static bool IsUp(this TouchLocationState state)
             => state == TouchLocationState.Released || state == TouchLocationState.Invalid;
 
+        public static bool IsSafe(this Type type) {
+            try {
+                // "Probe" the type
+                _ = type.Name;
+                _ = type.Assembly.FullName;
+                _ = type.Module.FullyQualifiedName;
+
+                // Check declaring and base type
+                if (!type.DeclaringType?.IsSafe() ?? false)
+                    return false;
+                if (!type.BaseType?.IsSafe() ?? false)
+                    return false;
+
+                return true;
+            } catch {
+                return false;
+            }
+        }
+
         public static Type[] GetTypesSafe(this Assembly asm) {
             try {
-                return asm.GetTypes();
+                return asm.GetTypes().Where(t => t.IsSafe()).ToArray();
             } catch (ReflectionTypeLoadException e) {
-                return e.Types.Where(t => t != null).ToArray();
+                return e.Types.Where(t => t != null && t.IsSafe()).ToArray();
             }
         }
 


### PR DESCRIPTION
Currently, a lot of issues are emerging where code relying on `GetTypesSafe` fails in some way or another, because it directly or indirectly depends on a type contained in an unloaded optional dependency, as these will be contained in the output of `GetTypesSafe` and subsequently crash when specific reflection operations are performed. This PR would fix these kinds of issues at the source, as it would ensure all types returned by `GetTypesSafe` have been "tested" for dependencies on non-present assemblies.

If this were to be merged, commits like https://github.com/EverestAPI/Everest/commit/f479dbbbe9451635d1b1fd3f55ad0322baa39e11 can be reverted.