### PR TITLE
Add RestartedFromGolden field to Session

### DIFF
--- a/Celeste.Mod.mm/Patches/Level.cs
+++ b/Celeste.Mod.mm/Patches/Level.cs
@@ -556,103 +556,99 @@ namespace MonoMod {
 
     static partial class MonoModRules {
 
-        public static void PatchLevelLoader(MethodDefinition method, CustomAttribute attrib) {
-            // We also need to do special work in the cctor.
-            MethodDefinition m_cctor = method.DeclaringType.FindMethod(".cctor");
+        public static void PatchLevelLoader(ILContext context, CustomAttribute attrib) {
+            FieldReference f_Session = context.Method.DeclaringType.FindField("Session");
+            FieldReference f_Session_RestartedFromGolden = f_Session.FieldType.Resolve().FindField("RestartedFromGolden");
+            MethodDefinition m_cctor = context.Method.DeclaringType.FindMethod(".cctor");
+            MethodDefinition m_LoadNewPlayer = context.Method.DeclaringType.FindMethod("Celeste.Player LoadNewPlayer(Microsoft.Xna.Framework.Vector2,Celeste.PlayerSpriteMode)");
+            MethodDefinition m_LoadCustomEntity = context.Method.DeclaringType.FindMethod("System.Boolean LoadCustomEntity(Celeste.EntityData,Celeste.Level)");
+            MethodDefinition m_PatchHeartGemBehavior = context.Method.DeclaringType.FindMethod("Celeste.AreaMode _PatchHeartGemBehavior(Celeste.AreaMode)");
 
-            MethodDefinition m_LoadNewPlayer = method.DeclaringType.FindMethod("Celeste.Player LoadNewPlayer(Microsoft.Xna.Framework.Vector2,Celeste.PlayerSpriteMode)");
-            MethodDefinition m_LoadCustomEntity = method.DeclaringType.FindMethod("System.Boolean LoadCustomEntity(Celeste.EntityData,Celeste.Level)");
+            // These are used for the static constructor patch
+            FieldDefinition f_LoadStrings = context.Method.DeclaringType.FindField("_LoadStrings");
+            TypeReference t_LoadStrings = f_LoadStrings.FieldType;
+            MethodReference m_LoadStrings_Add = MonoModRule.Modder.Module.ImportReference(t_LoadStrings.Resolve().FindMethod("Add"));
+            MethodReference m_LoadStrings_ctor = MonoModRule.Modder.Module.ImportReference(t_LoadStrings.Resolve().FindMethod("System.Void .ctor()"));
+            m_LoadStrings_Add.DeclaringType = t_LoadStrings;
+            m_LoadStrings_ctor.DeclaringType = t_LoadStrings;
 
-            FieldDefinition f_LoadStrings = method.DeclaringType.FindField("_LoadStrings");
+            ILCursor cursor = new ILCursor(context);
 
-            Mono.Collections.Generic.Collection<Instruction> cctor_instrs = m_cctor.Body.Instructions;
-            ILProcessor cctor_il = m_cctor.Body.GetILProcessor();
-
-            // Remove cctor ret for simplicity. Re-add later.
-            cctor_instrs.RemoveAt(cctor_instrs.Count - 1);
-
-            TypeDefinition td_LoadStrings = f_LoadStrings.FieldType.Resolve();
-            MethodReference m_LoadStrings_Add = MonoModRule.Modder.Module.ImportReference(td_LoadStrings.FindMethod("Add"));
-            m_LoadStrings_Add.DeclaringType = f_LoadStrings.FieldType;
-            MethodReference m_LoadStrings_ctor = MonoModRule.Modder.Module.ImportReference(td_LoadStrings.FindMethod("System.Void .ctor()"));
-            m_LoadStrings_ctor.DeclaringType = f_LoadStrings.FieldType;
-            cctor_il.Emit(OpCodes.Newobj, m_LoadStrings_ctor);
-
-            Mono.Collections.Generic.Collection<Instruction> instrs = method.Body.Instructions;
-            ILProcessor il = method.Body.GetILProcessor();
-            for (int instri = 0; instri < instrs.Count; instri++) {
-                Instruction instr = instrs[instri];
-
-                if (instr.MatchNewobj("Celeste.Player")) {
-                    instr.OpCode = OpCodes.Call;
-                    instr.Operand = m_LoadNewPlayer;
-                }
-
-                /* We expect something similar enough to the following:
-                ldwhatever the entityData into stack
-                ldfld     string Celeste.EntityData::Name // We're here
-                stloc*
-                ldloc*
-                call      uint32 '<PrivateImplementationDetails>'::ComputeStringHash(string)
-
-                Note that MonoMod requires the full type names (System.UInt32 instead of uint32) and skips escaping 's
-                */
-
-                if (instri > 0 &&
-                    instri < instrs.Count - 3 &&
-                    instr.MatchLdfld("Celeste.EntityData", "Name") &&
-                    instrs[instri + 1].MatchStloc(out int _) &&
-                    instrs[instri + 2].MatchLdloc(out int _) &&
-                    instrs[instri + 3].MatchCall("<PrivateImplementationDetails>", "System.UInt32 ComputeStringHash(System.String)")
-                ) {
-                    // Insert a call to our own entity handler here.
-                    // If it returns true, replace the name with ""
-
-                    // Avoid loading entityData again.
-                    // Instead, duplicate already loaded existing value.
-                    instrs.Insert(instri++, il.Create(OpCodes.Dup));
-                    // Load "this" onto stack - we're too lazy to shift this to the beginning of the stack.
-                    instrs.Insert(instri++, il.Create(OpCodes.Ldarg_0));
-
-                    // Call our static custom entity handler.
-                    instrs.Insert(instri++, il.Create(OpCodes.Call, m_LoadCustomEntity));
-
-                    // If we returned false, branch to ldfld. We still have the entity name on stack.
-                    // This basically translates to if (result) { pop; ldstr ""; }; ldfld ...
-                    instrs.Insert(instri, il.Create(OpCodes.Brfalse_S, instrs[instri]));
-                    instri++;
-                    // Otherwise, pop the entityData, load "" and jump to stloc to skip any original entity handler.
-                    instrs.Insert(instri++, il.Create(OpCodes.Pop));
-                    instrs.Insert(instri++, il.Create(OpCodes.Ldstr, ""));
-                    instrs.Insert(instri, il.Create(OpCodes.Br_S, instrs[instri + 1]));
-                    instri++;
-                }
-
-                if (instr.OpCode == OpCodes.Ldstr) {
-                    cctor_il.Emit(OpCodes.Dup);
-                    cctor_il.Emit(OpCodes.Ldstr, instr.Operand);
-                    cctor_il.Emit(OpCodes.Callvirt, m_LoadStrings_Add);
-                    cctor_il.Emit(OpCodes.Pop); // HashSet.Add returns a bool.
-                }
-
-                if (instri > 0 &&
-                    instri < instrs.Count - 4 &&
-                    instr.MatchLdfld("Celeste.Level", "Session") &&
-                    instrs[instri + 1].MatchLdflda("Celeste.Session", "Area") &&
-                    instrs[instri + 2].MatchLdfld("Celeste.AreaKey", "Mode") &&
-                    instrs[instri + 3].OpCode == OpCodes.Brfalse
-                ) {
-                    instrs.Insert(instri, il.Create(OpCodes.Ldarg_0));
-                    instrs.Insert(instri + 4, il.Create(OpCodes.Call, method.DeclaringType.FindMethod("Celeste.AreaMode _PatchHeartGemBehavior(Celeste.AreaMode)")));
-                }
+            // Insert our custom entity loader and use it for levelData.Entities and levelData.Triggers
+            //  Before: string name = entityData.Name;
+            //  After:  string name = (!Level.LoadCustomEntity(entityData2, this)) ? entityData2.Name : "";
+            int nameLoc = -1;
+            for (int i = 0; i < 2; i++) {
+                cursor.GotoNext(
+                    instr => instr.MatchLdfld("Celeste.EntityData", "Name"), // cursor.Next (get entity name)
+                    instr => instr.MatchStloc(out nameLoc), // cursor.Next.Next (save entity name)
+                    instr => instr.MatchLdloc(out _),
+                    instr => instr.MatchCall("<PrivateImplementationDetails>", "System.UInt32 ComputeStringHash(System.String)"));
+                cursor.Emit(OpCodes.Dup);
+                cursor.Emit(OpCodes.Ldarg_0);
+                cursor.Emit(OpCodes.Call, m_LoadCustomEntity);
+                cursor.Emit(OpCodes.Brfalse_S, cursor.Next); // False -> custom entity not loaded, so use the vanilla handler
+                cursor.Emit(OpCodes.Pop);
+                cursor.Emit(OpCodes.Ldstr, "");
+                cursor.Emit(OpCodes.Br_S, cursor.Next.Next); // True -> custom entity loaded, so skip the vanilla handler by saving "" as the entity name
+                cursor.Index++;
             }
 
-            cctor_il.Emit(OpCodes.Dup);
-            cctor_il.Emit(OpCodes.Ldstr, "theoCrystalHoldingBarrier"); // theoCrystalHoldingBarrier is an unused entity appearing in chapter 5
-            cctor_il.Emit(OpCodes.Callvirt, m_LoadStrings_Add);
-            cctor_il.Emit(OpCodes.Pop);
-            cctor_il.Emit(OpCodes.Stsfld, f_LoadStrings);
-            cctor_il.Emit(OpCodes.Ret);
+            // Reset to apply entity patches
+            cursor.Index = 0;
+
+            // Patch the winged golden berry so it counts golden deaths as a valid restart
+            //  Before: if (this.Session.Dashes == 0 && this.Session.StartedFromBeginning)
+            //  After:  if (this.Session.Dashes == 0 && (this.Session.StartedFromBeginning || this.Session.RestartedFromGolden))
+            cursor.GotoNext(instr => instr.MatchLdfld("Celeste.Session", "Dashes"));
+            cursor.GotoNext(MoveType.After, instr => instr.MatchLdfld("Celeste.Session", "StartedFromBeginning"));
+            cursor.Emit(OpCodes.Brtrue_S, cursor.Next.Next); // turn this into an "or" by adding the strawberry immediately if the first condition is true
+            cursor.Emit(OpCodes.Ldarg_0);
+            cursor.Emit(OpCodes.Ldfld, f_Session);
+            cursor.Emit(OpCodes.Ldfld, f_Session_RestartedFromGolden);
+
+            // Patch the HeartGem handler to always load if HeartIsEnd is set in the map meta
+            //  Before: if (!this.Session.HeartGem || this.Session.Area.Mode != AreaMode.Normal)
+            //  After:  if (!this.Session.HeartGem || this._PatchHeartGemBehavior(this.Session.Area.Mode) != AreaMode.Normal)
+            cursor.GotoNext(
+                instr => instr.MatchLdfld("Celeste.Level", "Session"), 
+                instr => instr.MatchLdflda("Celeste.Session", "Area"), 
+                instr => instr.MatchLdfld("Celeste.AreaKey", "Mode"), 
+                instr => instr.OpCode == OpCodes.Brfalse);
+            cursor.Emit(OpCodes.Ldarg_0);
+            cursor.Index += 3;
+            cursor.Emit(OpCodes.Call, m_PatchHeartGemBehavior);
+
+            // Patch Player creation so we avoid ever loading more than one at the same time
+            //  Before: Player player = new Player(this.Session.RespawnPoint.Value, spriteMode);
+            //  After:  Player player = Level.LoadNewPlayer(this.Session.RespawnPoint.Value, spriteMode);
+            cursor.GotoNext(instr => instr.MatchNewobj("Celeste.Player"));
+            cursor.Next.OpCode = OpCodes.Call;
+            cursor.Next.Operand = m_LoadNewPlayer;
+
+            // Reset to apply static constructor patch
+            cursor.Index = 0;
+
+            // Patch the static constructor to populate the _LoadStrings hashset with every vanilla entity name
+            // We use _LoadStrings in LoadCustomEntity to determine if an entity name is missing/invalid
+            // We manually add "theoCrystalHoldingBarrier" first since its entity handler was removed (unused but still in 5A bin)
+            string entityName = "theoCrystalHoldingBarrier";
+            new ILContext(m_cctor).Invoke(il => {
+                ILCursor cctorCursor = new ILCursor(il);
+
+                cctorCursor.Emit(OpCodes.Newobj, m_LoadStrings_ctor);
+                do {
+                    cctorCursor.Emit(OpCodes.Dup);
+                    cctorCursor.Emit(OpCodes.Ldstr, entityName);
+                    cctorCursor.Emit(OpCodes.Callvirt, m_LoadStrings_Add);
+                    cctorCursor.Emit(OpCodes.Pop); // HashSet.Add returns a bool.
+                }
+                while (cursor.TryGotoNext(
+                    instr => instr.MatchLdloc(nameLoc), // We located this in our entity loader patch
+                    instr => instr.MatchLdstr(out entityName))
+                );
+                cctorCursor.Emit(OpCodes.Stsfld, f_LoadStrings);
+            });
         }
 
         public static void PatchLevelLoaderDecalCreation(ILContext context, CustomAttribute attrib) {

--- a/Celeste.Mod.mm/Patches/Session.cs
+++ b/Celeste.Mod.mm/Patches/Session.cs
@@ -4,6 +4,8 @@ using MonoMod;
 
 namespace Celeste {
     public class patch_Session {
+        public bool RestartedFromGolden;
+
         public extern void orig_ctor(AreaKey area, string checkpoint = null, AreaStats oldStats = null);
 
         [MonoModConstructor]


### PR DESCRIPTION
Field will be `true` for a session created from a golden berry restart.

Dashless goldens and similar challenges usually rely on `Session.StartedFromBeginning`, which is `false` after a golden restart if the golden is not in the first room. This new field lets you account for that instead of requiring the player to restart the chapter to respawn the berry/restart the challenge.

The dashless golden handler was also patched to use this new field.

The IL patches that were edited have also been reworked to use `ILCursor`. One side effect is that many invalid strings that were saved in _LoadStrings have been removed (previously the patch was saving every `ldstr` used in `Level.orig_LoadLevel()` as an entity name). Apart from that, the decompiled output is the same.