### PR TITLE
Fix Delete handler in Map Select

### DIFF
--- a/Celeste.Mod.mm/Mod/UI/OuiMapSearch.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiMapSearch.cs
@@ -120,7 +120,6 @@ namespace Celeste.Mod.UI {
 
         private void clearSearch() {
             search = "";
-            searchPrev = "";
         }
 
         private void cleanExit() {

--- a/Celeste.Mod.mm/Mod/UI/OuiMapSearch.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiMapSearch.cs
@@ -508,7 +508,7 @@ namespace Celeste.Mod.UI {
                         clearSearch();
                         Audio.Play(SFX.ui_main_rename_entry_backspace);
                     } else {
-                        Audio.Play(SFX.ui_main_button_invalid);
+                        Audio.Play(SFX.ui_main_button_back);
                         cleanExit();
                     }
                     searchConsumedButton = true;

--- a/Celeste.Mod.mm/Mod/UI/OuiMapSearch.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiMapSearch.cs
@@ -177,10 +177,6 @@ namespace Celeste.Mod.UI {
                     return;
                 }
 
-            } else if (c == (char) 127) {
-                // Delete - clear.
-                // Handled in Update().
-
             } else if (c == ' ') {
                 // Space - append.
                 if (search.Length > 0) {

--- a/Celeste.Mod.mm/Mod/UI/OuiMapSearch.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiMapSearch.cs
@@ -1,5 +1,6 @@
 ﻿using FMOD.Studio;
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Input;
 using Monocle;
 using System;
 using System.Collections;
@@ -179,15 +180,7 @@ namespace Celeste.Mod.UI {
 
             } else if (c == (char) 127) {
                 // Delete - clear.
-                if (search.Length > 0) {
-                    clearSearch();
-                    Audio.Play(SFX.ui_main_rename_entry_backspace);
-                    goto ValidButton;
-                } else {
-                    Audio.Play(SFX.ui_main_button_invalid);
-                    cleanExit();
-                    goto ValidButton;
-                }
+                // Handled in Update().
 
             } else if (c == ' ') {
                 // Space - append.
@@ -511,6 +504,17 @@ namespace Celeste.Mod.UI {
 
         public override void Update() {
             if (Searching) {
+                if (MInput.Keyboard.Pressed(Keys.Delete)) {
+                    if (search.Length > 0) {
+                        clearSearch();
+                        Audio.Play(SFX.ui_main_rename_entry_backspace);
+                    } else {
+                        Audio.Play(SFX.ui_main_button_invalid);
+                        cleanExit();
+                    }
+                    searchConsumedButton = true;
+                    MInput.UpdateNull();
+                }
                 MInput.Disabled = searchConsumedButton;
             }
             searchConsumedButton = false;


### PR DESCRIPTION
Fixes the <kbd>Delete</kbd> handler by checking `MInput.Keyboard.Pressed(Keys.Delete)` in `Update()` instead of using `OnTextInput(char c)`. 

Closes #553.