### PR TITLE
Ensure dream blocks have the same number of particles on all platforms

### DIFF
--- a/Celeste.Mod.mm/Patches/DreamBlock.cs
+++ b/Celeste.Mod.mm/Patches/DreamBlock.cs
@@ -199,6 +199,23 @@ namespace Celeste {
 namespace MonoMod {
     /// <summary>
     /// Patches <see cref="DreamBlock.Setup()" /> to fix issue #556.
+    /// 
+    /// When Celeste calculates the required number of particles for the dream block,
+    /// there is a rounding error for values near whole numbers.
+    /// 
+    /// The calculation is (int)((width / 8f) * (height / 8f) * 0.7f)
+    /// 
+    /// For example, a 120x32 dream block should theoretically give 42 particles.
+    /// Due to single precision floating point calculations, this actually comes out
+    /// to 41.999 and is truncated to 41.
+    /// 
+    /// On macOS however, this is still calculated as 42.  This means that it consumes an
+    /// extra 5 random numbers in the sequence and desyncs other things in the room.
+    ///
+    /// Regardless of which value is "correct", the following fix makes macOS consistent
+    /// with Windows/Linux by subtracting a small value (0.001f) before truncating to int.
+    /// This should only affect values close to whole numbers, which happens only when
+    /// the total number of tiles in a dream block is a multiple of 10.
     /// </summary>
     [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchDreamBlockSetup))]
     class PatchDreamBlockSetupAttribute : Attribute { }


### PR DESCRIPTION
Windows can sometimes give a different value to macOS for float calculations close to a whole number, whereas they both agree if calculating with doubles.

Due to this, `DreamBlock.Setup` calculates a different number of particles for certain dream blocks.  This means more random samples taken, and a desync later in the room.

Solution is to subtract a small value before truncating to int, which gives the desired value on both platforms.

Bug and resolution tested on both Windows 10 and macOS 12.4 (Monterey).

Resolves #556 