### PR TITLE
Add unpause event

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Events.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Events.cs
@@ -91,6 +91,13 @@ namespace Celeste.Mod {
                 internal static void Pause(_Level level, int startIndex, bool minimal, bool quickReset)
                     => OnPause?.Invoke(level, startIndex, minimal, quickReset);
 
+                public delegate void UnpauseHandler(_Level level);
+                /// <summary>
+                /// Called after unpausing the Level.
+                /// </summary>
+                public static event UnpauseHandler OnUnpause;
+                internal static void Unpause(_Level level) => OnUnpause?.Invoke(level);
+
                 public delegate void CreatePauseMenuButtonsHandler(_Level level, TextMenu menu, bool minimal);
                 /// <summary>
                 /// Called when the Level's pause menu is created.

--- a/Celeste.Mod.mm/Patches/Level.cs
+++ b/Celeste.Mod.mm/Patches/Level.cs
@@ -127,10 +127,16 @@ namespace Celeste {
         public new void Pause(int startIndex = 0, bool minimal = false, bool quickReset = false) {
             orig_Pause(startIndex, minimal, quickReset);
 
-            if (!quickReset) {
-                TextMenu menu = Entities.GetToAdd().FirstOrDefault(e => e is TextMenu) as TextMenu;
-                if (menu != null)
+            if (Entities.GetToAdd().FirstOrDefault(e => e is TextMenu) is TextMenu menu) {
+                void Unpause() {
+                    Everest.Events.Level.Unpause(this);
+                }
+                menu.OnPause += Unpause;
+                menu.OnESC += Unpause;
+                if (!quickReset) {
+                    menu.OnCancel += Unpause; // the normal pause menu unpauses for all three of these, the quick reset menu does not
                     Everest.Events.Level.CreatePauseMenuButtons(this, menu, minimal);
+                }
             }
 
             Everest.Events.Level.Pause(this, startIndex, minimal, quickReset);


### PR DESCRIPTION
This PR adds an Everest event that is called when the level is unpaused. Unpausing happens via a delegate, which would make it annoying to detect using a Hook.