### PR TITLE
Prevent crash when dying on the same frame as entering Detach Followers Trigger

### DIFF
--- a/Celeste.Mod.mm/Patches/DetachStrawberryTrigger.cs
+++ b/Celeste.Mod.mm/Patches/DetachStrawberryTrigger.cs
@@ -1,0 +1,23 @@
+﻿#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
+
+using Celeste.Mod;
+using Microsoft.Xna.Framework;
+using System.Collections;
+
+namespace Celeste {
+    class patch_DetachStrawberryTrigger : DetachStrawberryTrigger {
+
+        public patch_DetachStrawberryTrigger(EntityData data, Vector2 offset) : base(data, offset) {
+            // no-op, ignored by MonoMod
+        }
+
+        // not my spelling mistake
+        private extern IEnumerator orig_DetatchFollower(Follower follower);
+        private IEnumerator DetatchFollower(Follower follower) {
+            if (!follower.HasLeader) {
+                yield break; // don't detach follower if follower is no longer following leader (e.g. because player died)
+            }
+            yield return new SwapImmediately(orig_DetatchFollower(follower));
+        }
+    }
+}


### PR DESCRIPTION
When the player dies on the same frame as entering a Detach Followers Trigger, they lose all their followers after the `DetatchFollowers` coroutine gets created, but before it runs, so `follower.Leader` will be null in that routine. This patch adds a null check and prevents the execution of the rest of the routine if it fails.