### PR TITLE
Backdrop.BeforeRender no longer gets called if not Visible + small optimisations

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Events.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Events.cs
@@ -119,8 +119,20 @@ namespace Celeste.Mod {
                 /// Called during <see cref="patch_Level.LoadCustomEntity(EntityData, _Level)"/>.
                 /// </summary>
                 public static event LoadEntityHandler OnLoadEntity;
-                internal static bool LoadEntity(_Level level, LevelData levelData, Vector2 offset, EntityData entityData)
-                    => OnLoadEntity?.InvokeWhileFalse(level, levelData, offset, entityData) ?? false;
+                internal static bool LoadEntity(_Level level, LevelData levelData, Vector2 offset, EntityData entityData) {
+                    LoadEntityHandler onLoadEntity = OnLoadEntity;
+
+                    if (onLoadEntity == null)
+                        return false;
+
+                    // replicates the InvokeWhileFalse extension method, but hardcoding the type to avoid dynamic dispatch
+                    foreach (LoadEntityHandler handler in onLoadEntity.GetInvocationList()) {
+                        if (handler(level, levelData, offset, entityData))
+                            return true;
+                    }
+
+                    return false;
+                }
 
                 public delegate Backdrop LoadBackdropHandler(MapData map, BinaryPacker.Element child, BinaryPacker.Element above);
                 public static event LoadBackdropHandler OnLoadBackdrop;

--- a/Celeste.Mod.mm/Patches/BackdropRenderer.cs
+++ b/Celeste.Mod.mm/Patches/BackdropRenderer.cs
@@ -6,7 +6,18 @@ namespace Celeste {
     class patch_BackdropRenderer : BackdropRenderer {
         private bool usingSpritebatch;
         private bool usingLoopingSpritebatch;
-        
+
+        [MonoModReplace]
+        public override void BeforeRender(Scene scene) {
+            foreach (Backdrop backdrop in Backdrops) {
+                // Only call BeforeRender if the backdrop is visible.
+                // This method should not be used for state changes, so this shouldn't have any impact on existing backdrops,
+                // while providing a massive performance boost in maps with many effects that are not visible most of the time.
+                if (backdrop.Visible)
+                    backdrop.BeforeRender(scene);
+            }
+        }
+
         /// <summary>
         /// Start a new spritebatch for backdrop rendering that uses SamplerState.PointWrap, but is otherwise identical to the one started by StartSpritebatch.
         /// </summary>

--- a/Celeste.Mod.mm/Patches/SeekerBarrier.cs
+++ b/Celeste.Mod.mm/Patches/SeekerBarrier.cs
@@ -1,0 +1,49 @@
+﻿using Celeste.Mod.Helpers;
+using Microsoft.Xna.Framework;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using MonoMod;
+using MonoMod.Cil;
+using MonoMod.Utils;
+using System;
+
+namespace Celeste {
+    public class patch_SeekerBarrier : SeekerBarrier {
+        public patch_SeekerBarrier(EntityData data, Vector2 offset) : base(data, offset) {
+            // no-op. MonoMod ignores this - we only need this to make the compiler shut up.
+        }
+
+        [MonoModIgnore]
+        [PatchSeekerBarrierDraw]
+        public override extern void Render();
+
+        private bool IsVisible() => CullHelper.IsRectangleVisible(Position.X, Position.Y, Width, Height);
+    }
+}
+
+namespace MonoMod {
+    /// <summary>
+    /// Patches the method to implement culling.
+    /// </summary>
+    [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchSeekerBarrierDraw))]
+    class PatchSeekerBarrierDraw : Attribute { }
+
+    static partial class MonoModRules {
+        public static void PatchSeekerBarrierDraw(ILContext il, CustomAttribute attrib) {
+            ILCursor cursor = new ILCursor(il);
+
+            // Insert this code at the start of the method:
+            // if (!IsVisible())
+            //     return;
+
+            cursor.Emit(OpCodes.Ldarg_0);
+            cursor.Emit(OpCodes.Call, il.Method.DeclaringType.FindMethod("System.Boolean IsVisible()"));
+
+            // return early if IsVisible returned false
+            ILLabel label = cursor.DefineLabel();
+            cursor.Emit(OpCodes.Brtrue, label);
+            cursor.Emit(OpCodes.Ret);
+            cursor.MarkLabel(label);
+        }
+    }
+}

--- a/Celeste.Mod.mm/Patches/Spikes.cs
+++ b/Celeste.Mod.mm/Patches/Spikes.cs
@@ -1,0 +1,50 @@
+﻿using Celeste.Mod.Helpers;
+using Microsoft.Xna.Framework;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using MonoMod;
+using MonoMod.Cil;
+using MonoMod.Utils;
+using System;
+
+namespace Celeste {
+    public class patch_Spikes : Spikes {
+        public patch_Spikes(Vector2 position, int size, Directions direction, string type) 
+            : base(position, size, direction, type) {
+            // no-op. MonoMod ignores this - we only need this to make the compiler shut up.
+        }
+
+        [MonoModIgnore]
+        [PatchSpikesDraw]
+        public override extern void Render();
+
+        private bool IsVisible() => CullHelper.IsRectangleVisible(Position.X, Position.Y, Width, Height);
+    }
+}
+
+namespace MonoMod {
+    /// <summary>
+    /// Patches the method to implement culling.
+    /// </summary>
+    [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchSpikesDraw))]
+    class PatchSpikesDraw : Attribute { }
+
+    static partial class MonoModRules {
+        public static void PatchSpikesDraw(ILContext il, CustomAttribute attrib) {
+            ILCursor cursor = new ILCursor(il);
+
+            // Insert this code at the start of the method:
+            // if (!IsVisible())
+            //     return;
+
+            cursor.Emit(OpCodes.Ldarg_0);
+            cursor.Emit(OpCodes.Call, il.Method.DeclaringType.FindMethod("System.Boolean IsVisible()"));
+
+            // return early if IsVisible returned false
+            ILLabel label = cursor.DefineLabel();
+            cursor.Emit(OpCodes.Brtrue, label);
+            cursor.Emit(OpCodes.Ret);
+            cursor.MarkLabel(label);
+        }
+    }
+}


### PR DESCRIPTION
* `Backdrop.BeforeRender` currently gets called all the time, even if the backdrop is not visible. While *some* modded backdrops manually add a `if (!Visible) return;` check at the start of the method, most of them (and all of vanilla) don't. Since this method doesn't get used for updating state, it can be relatively safely changed to only get called when the backdrop is visible. This gives major performance boosts to large maps like Heartsides.
Might be worth checking mods for improper usage of this method first though.

This PR also has some smaller optimisations:
* Added culling for Spikes and Seeker Barriers
* Made Everest.Events.LoadEntity no longer use the `InvokeWhileFalse` extension method, as it uses dynamic dispatch behind the scenes, which actually showed up quite a bit in performance checks. The method got essentially inlined into `LoadEntity` now, but with types known ahead of time.