### PR TITLE
Allow CrystalShatterTrigger to shatter distant spinners

### DIFF
--- a/Celeste.Mod.mm/Mod/Entities/CrystalShatterTrigger.cs
+++ b/Celeste.Mod.mm/Mod/Entities/CrystalShatterTrigger.cs
@@ -25,9 +25,13 @@ namespace Celeste.Mod.Entities {
                 if (mode == Modes.All)
                     Audio.Play("event:/game/06_reflection/boss_spikes_burst");
 
-                foreach (CrystalStaticSpinner spinner in spinners)
-                    if (CollideCheck(spinner) || mode == Modes.All)
+                foreach (CrystalStaticSpinner spinner in spinners) {
+                    bool wasCollidable = spinner.Collidable;
+                    spinner.Collidable = true;
+                    if (mode == Modes.All || CollideCheck(spinner))
                         spinner.Destroy();
+                    spinner.Collidable = wasCollidable;
+                }
             }
 
             RemoveSelf();


### PR DESCRIPTION
The Contained option for crystal shatter triggers uses CollideCheck to determine which spinners to shatter. However, since spinners become uncollidable when offscreen or far away from the player, this misses those spinners. This PR fixes that by temporarily making each spinner collidable. It also swaps the destruction conditions to avoid unnecessary expensive collision checks when the mode is set to All.