### PR TITLE
Add TimeRateModifier component

### DIFF
--- a/Celeste.Mod.mm/Mod/Entities/TimeRateModifier.cs
+++ b/Celeste.Mod.mm/Mod/Entities/TimeRateModifier.cs
@@ -1,0 +1,18 @@
+﻿using Monocle;
+
+namespace Celeste.Mod.Entities {
+    /// <summary>
+    /// Allows an entity to apply a multiplier to the time rate without causing conflicts.
+    /// </summary>
+    [Tracked]
+    public class TimeRateModifier : Component {
+
+        public float Multiplier;
+        public bool Enabled;
+        
+        public TimeRateModifier(float multiplier, bool enabled = true) : base(false, false) {
+            Multiplier = multiplier;
+            Enabled = enabled;
+        }
+    }
+}


### PR DESCRIPTION
This component allows entities to apply a multiplier to the current time rate without having to worry about conflicting with other entities. Also, since the modification is attached to a component, it will automatically be reverted when the entity is removed from the scene.