### PR TITLE
Fix and expand fallback texture usage in tilesets

### DIFF
--- a/Celeste.Mod.mm/Patches/Autotiler.cs
+++ b/Celeste.Mod.mm/Patches/Autotiler.cs
@@ -245,11 +245,9 @@ namespace Celeste {
 
             // Satisfies error handling for the orig_ method too.
             if (!lookup.TryGetValue(tile, out patch_TerrainType terrainType)) {
-                throw new AutotilerException($"Level contains a tileset with an id of '{tile}' that is not defined.") {
-                    Source = "TileHandler",
-                    ID = tile,
-                    X = x,
-                    Y = y
+                Logger.Log(LogLevel.Error, "Autotiler", $"Undefined tile id '{tile}' at ({x}, {y})");
+                return new patch_Tiles {
+                    Textures = { ((patch_Atlas) GFX.Game).GetFallback() },
                 };
             }
 
@@ -385,7 +383,7 @@ namespace Celeste {
         }
 
         public bool TryGetCustomDebris(out string path, char tiletype) {
-            return !string.IsNullOrEmpty(path = lookup[tiletype].Debris);
+            return !string.IsNullOrEmpty(path = lookup.TryGetValue(tiletype, out patch_TerrainType t) ? t.Debris : "");
         }
 
         // Required because TerrainType is private.

--- a/Celeste.Mod.mm/Patches/Monocle/Tileset.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Tileset.cs
@@ -1,0 +1,32 @@
+#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
+
+using MonoMod;
+
+namespace Monocle {
+    /// <summary>
+    /// Add bounds checking (wrap indices using %) to indexers.
+    /// </summary>
+    public class patch_Tileset : Tileset {
+        private MTexture[,] tiles;
+
+        [MonoModIgnore]
+        public patch_Tileset(MTexture texture, int tileWidth, int tileHeight)
+            : base(texture, tileWidth, tileHeight) {}
+
+        public new MTexture this[int x, int y] {
+            [MonoModReplace]
+            get {
+                return tiles[x % tiles.GetLength(0), y % tiles.GetLength(1)];
+            }
+        }
+
+        public new MTexture this[int index] {
+            [MonoModReplace]
+            get {
+                if (index < 0)
+                    return null;
+                return tiles[index % tiles.GetLength(0), (index / tiles.GetLength(0)) % tiles.GetLength(1)];
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR is a `cherry-pick` of some of the fixes introduced in #572 

---

This PR fixes two crashes, instead opting to display the fallback texture wherever possible.

## OOB Tileset Indexing
Tilesets with masks that attempt to index outside of their texture currently crash with a fairly opaque error:
```
System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at Celeste.Autotiler.orig_ReadInto(TerrainType data, Tileset tileset, XmlElement xml)
   at Celeste.Autotiler.ReadInto(TerrainType data, Tileset tileset, XmlElement xml)
   at Celeste.Autotiler..ctor(String filename)
...
```
This also happens when the tileset texture cannot be found, as it falls back to the [fallback texture (![gameplay fallback texture](https://github.com/EverestAPI/Everest/raw/dev/Celeste.Mod.mm/Content/Graphics/Atlases/Gameplay/__fallback.png))](https://github.com/EverestAPI/Everest/blob/dev/Celeste.Mod.mm/Content/Graphics/Atlases/Gameplay/__fallback.png) which is almost always smaller than the intended tileset.

With this PR, tileset indexing will always be wrapped so that out of bounds indexes will still return a part of the tileset texture. This may cause some confusion if a tileset uses the wrong template (but the texture is still found), as it will display "random" tiles from the texture, but I think this issue is still more intuitive than the current crash.

## Undefined Tilesets
With the fixes to tilesets that use the fallback texture, it is now viable to fall back to it for tilesets that are undefined.
**My one concern with this fix is the error message, which *may get logged for every tile in the map* in the worst case scenario.** This can cause significant lag when loading into the map, but the issue is also immediately apparent to the user once the map has successfully loaded.

Undefined tilesets will also no longer crash when attempting to find their associated debris texture.
