### PR TITLE
Remove the aggressive GC call in Level.Reload

### DIFF
--- a/Celeste.Mod.mm/Patches/Level.cs
+++ b/Celeste.Mod.mm/Patches/Level.cs
@@ -69,6 +69,10 @@ namespace Celeste {
         [PatchLevelUpdate] // ... except for manually manipulating the method via MonoModRules
         public extern new void Update();
 
+        [MonoModIgnore] // We don't want to change anything about the method...
+        [PatchLevelReload] // ... except for manually manipulating the method via MonoModRules
+        public extern new void Reload();
+
         [MonoModReplace]
         public new void RegisterAreaComplete() {
             bool completed = Completed;
@@ -550,6 +554,12 @@ namespace MonoMod {
     class PatchLevelRenderAttribute : Attribute { }
 
     /// <summary>
+    /// Patch the method to remove the very aggressive GC call.
+    /// </summary>
+    [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchLevelReload))]
+    class PatchLevelReloadAttribute : Attribute { }
+
+    /// <summary>
     /// Patch the Godzilla-sized level transition method instead of reimplementing it in Everest.
     /// </summary>
     [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchTransitionRoutine))]
@@ -774,5 +784,15 @@ namespace MonoMod {
             c.Emit(OpCodes.Ldc_I4_0);
         }
 
+        public static void PatchLevelReload(ILContext context, CustomAttribute attrib) {
+            ILCursor c = new ILCursor(context);
+
+            // Remove this overly aggressive gc call:
+            // GC.Collect();
+            // GC.WaitForPendingFinalizers();
+            c.GotoNext(MoveType.Before, instr => instr.MatchCall("System.GC", "Collect"));
+            c.Remove();
+            c.Remove();
+        }
     }
 }


### PR DESCRIPTION
The `GC.Collect()` call in `Level.Reload` is often responsible for over 50% of all load times after dying.
![image](https://user-images.githubusercontent.com/50085307/218327969-e0082159-c776-4b6a-b2ce-be310e751459.png)
This is because it does a *full* GC run through all generations, which is quite useless, since most of the RAM used by Celeste is used up by things that can never get GC'd anyway.

This patch is already available via Frost Helper's `No Reload GC` experimental setting, and didn't seem to cause any gameplay lag spikes.