### PR TITLE
fix AmbienceVolume being serialised when null

### DIFF
--- a/Celeste.Mod.mm/Patches/AudioState.cs
+++ b/Celeste.Mod.mm/Patches/AudioState.cs
@@ -1,9 +1,14 @@
 #pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
 
+using System.Xml.Serialization;
+
 namespace Celeste {
     class patch_AudioState : AudioState {
 
         public float? AmbienceVolume;
+
+        [XmlIgnore]
+        public bool AmbienceVolumeSpecified { get { return AmbienceVolume.HasValue; } }
 
         public extern void orig_Apply(bool forceSixteenthNoteHack = false);
         public new void Apply(bool forceSixteenthNoteHack = false) {

--- a/Celeste.Mod.mm/Patches/AudioState.cs
+++ b/Celeste.Mod.mm/Patches/AudioState.cs
@@ -8,7 +8,7 @@ namespace Celeste {
         public float? AmbienceVolume;
 
         [XmlIgnore]
-        public bool AmbienceVolumeSpecified { get { return AmbienceVolume.HasValue; } }
+        public bool AmbienceVolumeSpecified => AmbienceVolume.HasValue;
 
         public extern void orig_Apply(bool forceSixteenthNoteHack = false);
         public new void Apply(bool forceSixteenthNoteHack = false) {


### PR DESCRIPTION
previously, the AmbienceVolume field was written to the save file unconditionally, which produced unreadable XML when it was `null` (i.e. when the player hadn't interacted with an `everest/ambienceVolumeTrigger`).

this fixes that issue by saving the field only if it contains a value, using a magic property.