### PR TITLE
Fix explosion boost leniency inconsistency

### DIFF
--- a/Celeste.Mod.mm/Patches/Level.cs
+++ b/Celeste.Mod.mm/Patches/Level.cs
@@ -41,6 +41,8 @@ namespace Celeste {
 
         private float unpauseTimer;
 
+        internal bool playerWasExplodeLaunchedThisFrame;
+
         /// <summary>
         /// If in vanilla levels, gets the spawnpoint closest to the bottom left of the level.<br/>
         /// Otherwise, get the default spawnpoint from the level data if present, falling back to
@@ -697,6 +699,7 @@ namespace MonoMod {
             MethodReference m_Everest_CoreModule_Settings = MonoModRule.Modder.Module.GetType("Celeste.Mod.Core.CoreModule").FindProperty("Settings").GetMethod;
             TypeDefinition t_Everest_CoreModuleSettings = MonoModRule.Modder.Module.GetType("Celeste.Mod.Core.CoreModuleSettings");
             MethodReference m_ButtonBinding_Pressed = MonoModRule.Modder.Module.GetType("Celeste.Mod.ButtonBinding").FindProperty("Pressed").GetMethod;
+            FieldDefinition f_playerWasExplodeLaunchedThisFrame = context.Method.DeclaringType.FindField("playerWasExplodeLaunchedThisFrame");
 
             ILCursor cursor = new ILCursor(context);
 
@@ -705,6 +708,12 @@ namespace MonoMod {
 
             // insert FixChaserStatesTimeStamp()
             cursor.Emit(OpCodes.Ldarg_0).Emit(OpCodes.Call, m_FixChaserStatesTimeStamp);
+
+            // insert playerWasExplodeLaunchedThisFrame = false after base.Update() call
+            cursor.GotoNext(MoveType.After, instr => instr.MatchCall("Monocle.Scene", "Update"));
+            cursor.Emit(OpCodes.Ldarg_0);
+            cursor.Emit(OpCodes.Ldc_I4_0);
+            cursor.Emit(OpCodes.Stfld, f_playerWasExplodeLaunchedThisFrame);
 
             /* We expect something similar enough to the following:
             call class Monocle.MInput/KeyboardData Monocle.MInput::get_Keyboard() // We're here


### PR DESCRIPTION
In vanilla, the one frame of leniency added to ExplodeLaunch boosts in 1.4 does not work consistently for Puffers if the player's Depth was set after the Puffers (e.g. when the player respawns after death vs. entering the room) because Puffers have Depth 0 and often call ExplodeLaunch from their Update method instead of a PlayerCollider callback, causing the "leniency" check in Player.Update to happen on the *same frame* as the check in ExplodeLaunch. This patch fixes that issue.
The simplest approach to fix this would be to give Puffers a Depth of -1, forcing them to update after the player, However, this would potentially change the update order of Puffers and other entities with Depth -1, such as FlingBirds, which are likely to appear in the same levels. Therefore, I'm choosing a different approach here, saving in the Level when ExplodeLaunch is called in a frame.
Because this is technically a change to vanilla "mechanics", a check is included to make this fix only apply in custom maps.