### PR TITLE
Add `modoptions` command to toggle 'Show Mod Options in Game' setting

### DIFF
--- a/Celeste.Mod.mm/Mod/Helpers/Commands.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/Commands.cs
@@ -32,5 +32,10 @@ namespace Celeste.Mod.Helpers {
             } else
                 Engine.Commands.Log($"Invalid log level! Use Verbose, Debug, Info, Warn, or Error");
         }
+
+        [Command("modoptions", "toggles Everest's 'Show Mod Options in Game' setting")]
+        public static void ToggleShowModOptions() {
+            Core.CoreModule.Settings.ShowModOptionsInGame = !Core.CoreModule.Settings.ShowModOptionsInGame;
+        }
     }
 }


### PR DESCRIPTION
Had somebody in the speedrunning section ask if this could be made a thing so toggling the setting is more accessible in-game, basically exactly the same functionality as the `assist` and `variants` commands. The reason they want to be able to quickly change it is that the extra "Mod Options" entry in the pause screen changes the position of other options and messes with visual cues or inhibits fast menu movement, and it's just a bit annoying to back out all the way to the overworld to toggle it.

Happy to edit the command name itself if desired, or to scrap this in general - I've already made them a quick mod for it anyway so I don't think it's too big a deal, but it's not really doing any harm to add it either.