### PR TITLE
Fix TextInput.OnInput not firing on Wayland

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -544,6 +544,7 @@ namespace Celeste.Mod {
 
         internal static void Shutdown() {
             DebugRC.Shutdown();
+            TextInput.Shutdown();
             Events.Celeste.Shutdown();
         }
 

--- a/Celeste.Mod.mm/Mod/Everest/TextInput.cs
+++ b/Celeste.Mod.mm/Mod/Everest/TextInput.cs
@@ -31,6 +31,10 @@ namespace Celeste.Mod {
                 // public static event Action<char> TextInput;
                 e_TextInput.AddEventHandler(null, new Action<char>(ReceiveTextInput).CastDelegate(e_TextInput.EventHandlerType));
 
+                // Some platforms like Linux/Wayland may require calling TextInputEXT.StartTextInput to receive events for TextInputEXT.TextInput
+                MethodInfo m_StartTextInput = t_TextInputExt?.GetMethod("StartTextInput", new Type[] { } );
+                m_StartTextInput?.Invoke(t_TextInputExt, null);
+
                 // SDL2 offers SDL_GetClipboardText and SDL_SetClipboardText
                 Type t_SDL2 = typeof(Keyboard).Assembly.GetType("SDL2.SDL");
                 _GetClipboardText = t_SDL2.GetMethod("SDL_GetClipboardText").CreateDelegate(typeof(Func<string>)) as Func<string>;

--- a/Celeste.Mod.mm/Mod/Everest/TextInput.cs
+++ b/Celeste.Mod.mm/Mod/Everest/TextInput.cs
@@ -32,7 +32,7 @@ namespace Celeste.Mod {
                 e_TextInput.AddEventHandler(null, new Action<char>(ReceiveTextInput).CastDelegate(e_TextInput.EventHandlerType));
 
                 // Some platforms like Linux/Wayland may require calling TextInputEXT.StartTextInput to receive events for TextInputEXT.TextInput
-                MethodInfo m_StartTextInput = t_TextInputExt?.GetMethod("StartTextInput", new Type[] { } );
+                MethodInfo m_StartTextInput = t_TextInputExt.GetMethod("StartTextInput", Type.EmptyTypes );
                 m_StartTextInput?.Invoke(t_TextInputExt, null);
 
                 // SDL2 offers SDL_GetClipboardText and SDL_SetClipboardText
@@ -64,6 +64,20 @@ namespace Celeste.Mod {
                     return value;
                 }).GetResult();
             }
+        }
+
+        internal static void Shutdown() {
+            if (!Initialized)
+                return;
+            
+            Type t_TextInputExt = typeof(Keyboard).Assembly.GetType("Microsoft.Xna.Framework.Input.TextInputEXT");
+            EventInfo e_TextInput = t_TextInputExt?.GetEvent("TextInput");
+            
+            if (e_TextInput == null)
+                return;
+            
+            MethodInfo m_StopTextInput = t_TextInputExt.GetMethod("StopTextInput", Type.EmptyTypes);
+            m_StopTextInput?.Invoke(t_TextInputExt, null);
         }
 
         internal static void ReceiveTextInput(char c) {


### PR DESCRIPTION
### Bug Description

On Linux using Wayland the TextInput.OnInput event was not firing resulting in the debug console and CelesteNet chat not accepting any input after being opened.

### System info

OS: Arch Linux x86_64
Kernel: Linux 6.2.1-arch1-1
WM: sway

### Reproduction

1) Run Celeste with Everest loaded
2) Open debug console using `~` or `.`
3) Try typing in the console

### Fix description

This fix just adds a call to `TextInputEXT.StartTextInput()` on initialization of TextInput.

As per [TextInputEXT documentation](https://github.com/FNA-XNA/FNA/wiki/5:-FNA-Extensions#textinputext) one should call `TextInputEXT.StartTextInput()` before trying to receive events through the `TextInputEXT.TextInput` event.

A similar [bug](https://github.com/libsdl-org/SDL/issues/4857#issuecomment-962843448) was reported on the SDL2 repository. These seem correlated as FNA uses SDL2 internally AFAIK.

### Considerations

The method `SDL_StartTextInput` seems to intend on opening a virtual keyboard when the platform requires it. This should possibly be checked on Platforms like the SteamDeck or similar. I was not able to produce this behaviour using my system and do not own a SteamDeck.