### PR TITLE
SettingSubHeaderAttribute and SettingSubTextAttribute within Settings SubMenus

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Extensions.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Extensions.cs
@@ -257,6 +257,42 @@ namespace Celeste.Mod {
             return option;
         }
 
+
+        /// <summary>
+        /// Add an Enter and Leave handler, displaying a description if selected.
+        /// </summary>
+        /// <param name="option">The input TextMenu.Item option.</param>
+        /// <param name="containingSubMenu">The submenu containing the TextMenu.Item option.</param>
+        /// <param name="parentContainer">The menu that the submenu is or will be part of.</param>
+        /// <param name="description"></param>
+        /// <returns>The passed option.</returns>
+        public static TextMenu.Item AddDescription(this TextMenu.Item option, TextMenuExt.SubMenu containingSubMenu, TextMenu parentContainer, string description) {
+            // build the description menu entry
+            TextMenuExt.EaseInSubHeaderExt descriptionText = new TextMenuExt.EaseInSubHeaderExt(description, false, parentContainer) {
+                TextColor = Color.Gray,
+                HeightExtra = 0f
+            };
+
+            if (containingSubMenu.Items.Contains(option)) {
+                // insert the description into item list after the option.
+                containingSubMenu.Insert(containingSubMenu.Items.IndexOf(option) + 1, descriptionText);
+            } else if (containingSubMenu.ContainsDelayedAddItem(option)) {
+                // insert the description into "delayed add" item list, when necessary
+                containingSubMenu.InsertDelayedAddItem(descriptionText, option);
+            }
+
+            option.OnEnter += delegate {
+                // make the description appear.
+                descriptionText.FadeVisible = true;
+            };
+            option.OnLeave += delegate {
+                // make the description disappear.
+                descriptionText.FadeVisible = false;
+            };
+
+            return option;
+        }
+
         // Celeste already ships with this.
         /*
         public static string ReadNullTerminatedString(this BinaryReader stream) {

--- a/Celeste.Mod.mm/Mod/Module/EverestModule.cs
+++ b/Celeste.Mod.mm/Mod/Module/EverestModule.cs
@@ -823,8 +823,18 @@ namespace Celeste.Mod {
                         }
 
                         TextMenu.Item subMenuItem = CreateItem(subTypeProp, settingsObject: propObject);
-                        if (subMenuItem != null)
-                            subMenu.Add(subMenuItem);
+                        if (subMenuItem == null)
+                            continue;
+
+                        string subsubheader = subTypeProp.GetCustomAttribute<SettingSubHeaderAttribute>()?.SubHeader;
+                        if (subsubheader != null)
+                            subMenu.Add(new TextMenu.SubHeader(subsubheader.DialogCleanOrNull() ?? subsubheader, false));
+
+                        subMenu.Add(subMenuItem);
+
+                        string subdescription = subTypeProp.GetCustomAttribute<SettingSubTextAttribute>()?.Description;
+                        if (subdescription != null)
+                            subMenuItem.AddDescription(subMenu, menu, subdescription.DialogCleanOrNull() ?? subdescription);
                     }
                     item = subMenu;
                 }
@@ -844,11 +854,11 @@ namespace Celeste.Mod {
                 menu.Add(item);
 
                 if (prop.GetCustomAttribute<SettingNeedsRelaunchAttribute>() != null)
-                    item = item.NeedsRelaunch(menu);
+                    item.NeedsRelaunch(menu);
 
                 string description = prop.GetCustomAttribute<SettingSubTextAttribute>()?.Description;
                 if (description != null)
-                    item = item.AddDescription(menu, description.DialogCleanOrNull() ?? description);
+                    item.AddDescription(menu, description.DialogCleanOrNull() ?? description);
             }
 
             foreach (PropertyInfo prop in type.GetProperties()) {

--- a/Celeste.Mod.mm/Mod/UI/TextMenuExt.cs
+++ b/Celeste.Mod.mm/Mod/UI/TextMenuExt.cs
@@ -591,6 +591,16 @@ namespace Celeste {
                 }
             }
 
+            public bool ContainsDelayedAddItem(TextMenu.Item item) {
+                return Container == null && delayedAddItems.Contains(item);
+            }
+
+            public SubMenu InsertDelayedAddItem(TextMenu.Item item, TextMenu.Item after) {
+                if (Container == null && delayedAddItems.Contains(after))
+                    delayedAddItems.Insert(delayedAddItems.IndexOf(after) + 1, item);
+                return this;
+            }
+
             /// <summary>
             /// Remove any non-submenu <see cref="TextMenu.Item"/> from the Submenu
             /// </summary>


### PR DESCRIPTION
As it says in the title, I was a bit sad to see that within SubMenus in the Mod Options, the various Settings Attributes weren't processed.

Adding **SettingSubHeaderAttribute** to `SubMenu` properties was very straight-forward, it's pretty much three additional lines in here copied into the sub-loop that processes the sub-properties.

**SettingSubTextAttribute** on the other hand got a bit weird, because a `SubMenu` is just a `TextMenu.Item` itself instead of being a `TextMenu`. 
And the `TextMenu.Item AddDescription()` extension doesn't work like that:
 - it creates a `TextMenuExt.EaseInSubHeaderExt` which takes a `TextMenu` reference in its constructor, but seemingly tracks that solely to get the proper `float TextMenu.ItemSpacing` from its parent container... so I passed the parent container along into my `AddDescription()` overload
- in contrast to TextMenu, `SubMenu` has its `public Items` list, but also has `private delayedAddItems` which is a list that solely tracks items added to the submenu when its `Container` is null, i.e. the SubMenu itself hasn't been added to its parent TextMenu yet. In this case, `Add()` will get called on these within the Submenu's `Added()`, i.e. when it "knows" its Container...

I didn't really want to change the `delayedAddItems` list's visibility from private, so I added two helper functions `bool ContainsDelayedAddItem(...)` and `SubMenu InsertDelayedAddItem(...)` so that the overloaded extension can check for and insert into this list instead.

I haven't tested this too extensively yet, because I'm really not sure if this is too much of a hack w/r/t the above inserting changes... but I'm equally unsure what a better solution would look like at the moment. 🐈 

Example Screenshot from my CelesteNet options re-organization work-in-progress
![image](https://user-images.githubusercontent.com/1682215/225171779-8cd3e3be-cab6-4cf3-9046-b0072e355463.png)
