### PR TITLE
Make the debug camera controls also control the slight camera movemen…

### DIFF
--- a/Celeste.Mod.mm/Mod/Core/CoreModuleSettings.cs
+++ b/Celeste.Mod.mm/Mod/Core/CoreModuleSettings.cs
@@ -312,19 +312,19 @@ namespace Celeste.Mod.Core {
 
         [SettingSubHeader("MODOPTIONS_COREMODULE_MOUNTAINCAM_SUBHEADER")]
         [SettingInGame(false)]
-        [DefaultButtonBinding(0, Keys.W)]
+        [DefaultButtonBinding(Buttons.RightThumbstickUp, Keys.W)]
         public ButtonBinding CameraForward { get; set; }
 
         [SettingInGame(false)]
-        [DefaultButtonBinding(0, Keys.S)]
+        [DefaultButtonBinding(Buttons.RightThumbstickDown, Keys.S)]
         public ButtonBinding CameraBackward { get; set; }
 
         [SettingInGame(false)]
-        [DefaultButtonBinding(0, Keys.D)]
+        [DefaultButtonBinding(Buttons.RightThumbstickRight, Keys.D)]
         public ButtonBinding CameraRight { get; set; }
 
         [SettingInGame(false)]
-        [DefaultButtonBinding(0, Keys.A)]
+        [DefaultButtonBinding(Buttons.RightThumbstickLeft, Keys.A)]
         public ButtonBinding CameraLeft { get; set; }
 
         [SettingInGame(false)]

--- a/Celeste.Mod.mm/Patches/Input.cs
+++ b/Celeste.Mod.mm/Patches/Input.cs
@@ -2,6 +2,7 @@
 #pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
 
 using Celeste.Mod;
+using Celeste.Mod.Core;
 using Microsoft.Xna.Framework.Input;
 using Monocle;
 using MonoMod;
@@ -22,6 +23,15 @@ namespace Celeste {
                 mod.OnInputInitialize();
 
             Everest.Events.Input.Initialize();
+
+            //Sets the slight camera movement on the map to the set debug camera movement keys in Everest mod settings
+            Input.MountainAim = new VirtualJoystick(
+                CoreModule.Settings.CameraForward.Binding,
+                CoreModule.Settings.CameraBackward.Binding,
+                CoreModule.Settings.CameraLeft.Binding,
+                CoreModule.Settings.CameraRight.Binding,
+                Input.Gamepad, 0.1f
+            );
         }
 
         public static extern void orig_Deregister();

--- a/Celeste.Mod.mm/Patches/Input.cs
+++ b/Celeste.Mod.mm/Patches/Input.cs
@@ -19,11 +19,6 @@ namespace Celeste {
         public static void Initialize() {
             orig_Initialize();
 
-            foreach (EverestModule mod in Everest._Modules)
-                mod.OnInputInitialize();
-
-            Everest.Events.Input.Initialize();
-
             //Sets the slight camera movement on the map to the set debug camera movement keys in Everest mod settings
             Input.MountainAim = new VirtualJoystick(
                 CoreModule.Settings.CameraForward.Binding,
@@ -32,6 +27,11 @@ namespace Celeste {
                 CoreModule.Settings.CameraRight.Binding,
                 Input.Gamepad, 0.1f
             );
+
+            foreach (EverestModule mod in Everest._Modules)
+                mod.OnInputInitialize();
+
+            Everest.Events.Input.Initialize();
         }
 
         public static extern void orig_Deregister();


### PR DESCRIPTION
…t on the map.

The slight camera rotation on the map is hardcoded to use WASD. This can get annoying for people who have menu buttons bound to WASD. This changes those buttons to be set by the debug camera controls in the Everest mod settings. It also adds default controller controls for the camera movement so that it will still behave like normal if you don't change settings from default.

https://github.com/EverestAPI/Everest/issues/597