### PR TITLE
Remove redundant WallJump patch

### DIFF
--- a/Celeste.Mod.mm/Patches/Player.cs
+++ b/Celeste.Mod.mm/Patches/Player.cs
@@ -162,20 +162,10 @@ namespace Celeste {
         [PatchPlayerClimbBegin]
         private extern void ClimbBegin();
 
-        [MonoModIgnore]
         [PatchPlayerOrigWallJump]
         private extern void orig_WallJump(int dir);
         private void WallJump(int dir) {
-            if ((Scene as Level).Session.Area.GetLevelSet() != "Celeste") {
-                // Fix vertical boost from upwards-moving solids not being applied correctly when dir != -1
-                if (LiftSpeed == Vector2.Zero) {
-                    Solid solid = CollideFirst<Solid>(Position + Vector2.UnitX * 3f * -dir);
-                    if (solid != null) {
-                        LiftSpeed = solid.LiftSpeed;
-                    }
-                }
-            }
-            orig_WallJump(dir);
+            orig_WallJump(dir); // for backwards compatibility with hooks
         }
 
         /// <summary>


### PR DESCRIPTION
This patch was introduced by #80 to fix a vanilla bug that has since been fixed in vanilla 1.4.0.0. This patch is therefore not necessary anymore. The indirection through the orig_ method is maintained for hook backwards compatibility, since I'm not aware of a way to forcibly redirect those hooks to WallJump instead.