### PR TITLE
Add Farewell intros to IsIntroState

### DIFF
--- a/Celeste.Mod.mm/Patches/Player.cs
+++ b/Celeste.Mod.mm/Patches/Player.cs
@@ -43,7 +43,7 @@ namespace Celeste {
         public bool IsIntroState {
             get {
                 int state = StateMachine.State;
-                return StIntroWalk <= state && state <= StIntroWakeUp;
+                return state is >= StIntroWalk and <= StIntroWakeUp or StIntroMoonJump or StIntroThinkForABit;
             }
         }
 


### PR DESCRIPTION
More random stuff I noticed while looking at the Player patch: the IsIntroState property added by Everest was missing the new intro states StIntroMoonJump and StIntroThinkForABit added with Farewell.