### PR TITLE
Patch FNA float behaviour to behave like XNA

### DIFF
--- a/Celeste.Mod.mm/Patches/Actor.cs
+++ b/Celeste.Mod.mm/Patches/Actor.cs
@@ -1,15 +1,12 @@
 ﻿#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
 
-using Celeste.Mod;
 using Microsoft.Xna.Framework;
-using Monocle;
 using MonoMod;
-using System;
-using System.Collections.Generic;
-using System.Xml;
 
 namespace Celeste {
     class patch_Actor : Actor {
+
+        private Vector2 movementCounter;
 
         public patch_Actor(Vector2 position)
             : base(position) {
@@ -19,6 +16,18 @@ namespace Celeste {
         // Legacy Support
         protected bool TrySquishWiggle(CollisionData data) {
             return TrySquishWiggle(data, 3, 3);
+        }
+
+        // Patch MoveToX/Y to replicate XNA's behaviour on FNA
+
+        [MonoModReplace]
+        public new void MoveToX(float toX, Collision onCollide = null) {
+            MoveH((float) ((double) toX - Position.X - movementCounter.X), onCollide);
+        }
+
+        [MonoModReplace]
+        public new void MoveToY(float toY, Collision onCollide = null) {
+            MoveV((float) ((double) toY - Position.Y - movementCounter.Y), onCollide);
         }
 
     }

--- a/Celeste.Mod.mm/Patches/Actor.cs
+++ b/Celeste.Mod.mm/Patches/Actor.cs
@@ -6,7 +6,7 @@ using MonoMod;
 namespace Celeste {
     class patch_Actor : Actor {
 
-        private Vector2 movementCounter;
+        private Vector2 movementCounter = default;
 
         public patch_Actor(Vector2 position)
             : base(position) {

--- a/Celeste.Mod.mm/Patches/DreamBlock.cs
+++ b/Celeste.Mod.mm/Patches/DreamBlock.cs
@@ -8,8 +8,9 @@ using System.Runtime.CompilerServices;
 namespace Celeste {
     class patch_DreamBlock : DreamBlock {
 
-        [MonoModLinkTo("Celeste.Platform", "movementCounter")]
-        internal Vector2 movementCounter = default;
+        internal Vector2 movementCounter {
+            [MonoModLinkTo("Celeste.Platform", "get__movementCounter")] get;
+        }
 
         private bool playerHasDreamDash;
         private LightOcclude occlude;

--- a/Celeste.Mod.mm/Patches/DreamBlock.cs
+++ b/Celeste.Mod.mm/Patches/DreamBlock.cs
@@ -3,9 +3,14 @@ using Monocle;
 using MonoMod;
 using System;
 using System.Collections;
+using System.Runtime.CompilerServices;
 
 namespace Celeste {
     class patch_DreamBlock : DreamBlock {
+
+        [MonoModLinkTo("Celeste.Platform", "movementCounter")]
+        internal Vector2 movementCounter = default;
+
         private bool playerHasDreamDash;
         private LightOcclude occlude;
         private float whiteHeight;
@@ -185,5 +190,36 @@ namespace Celeste {
             }
             return pos;
         }
+
+        // Patch XNA/FNA jank in Tween.OnUpdate lambda
+        [MonoModPatch("<>c__DisplayClass22_0")]
+        class patch_AddedLambdas {
+            
+            [MonoModPatch("<>4__this")]
+            private patch_DreamBlock _this = default;
+            private Vector2 start = default, end = default;
+
+            [MonoModReplace]
+            [MonoModPatch("<Added>b__0")]
+            public void TweenUpdateLambda(Tween t) {
+                // Patch this to always behave like XNA
+                // This is absolutely hecking ridiculous and a perfect example of why we want to switch to .NET Core
+                // The Y member gets downcast but not the X one because of JIT jank
+                double lerpX = start.X + ((double) end.X - start.X) * t.Eased, lerpY = start.Y + ((double) end.Y - start.Y) * t.Eased;
+                float moveHDelta = (float) (lerpX - _this.Position.X - _this.movementCounter.X), moveVDelta = (float) ((double) JITBarrier((float) lerpY) - _this.Position.Y - _this.movementCounter.Y);
+                if (_this.Collidable) {
+                    _this.MoveH(moveHDelta);
+                    _this.MoveV(moveVDelta);
+                } else {
+                    _this.MoveHNaive(moveHDelta);
+                    _this.MoveVNaive(moveVDelta);
+                }
+            }
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            private static float JITBarrier(float v) => v;
+
+        }
+
     }
 }

--- a/Celeste.Mod.mm/Patches/FinalBossMovingBlock.cs
+++ b/Celeste.Mod.mm/Patches/FinalBossMovingBlock.cs
@@ -1,0 +1,38 @@
+﻿#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
+
+using Microsoft.Xna.Framework;
+using Monocle;
+using MonoMod;
+
+namespace Celeste {
+    class patch_FinalBossMovingBlock : FinalBossMovingBlock {
+
+        private Vector2 movementCounter = default;
+
+        public patch_FinalBossMovingBlock(EntityData data, Vector2 offset)
+            : base(data, offset) {
+            // no-op. MonoMod ignores this - we only need this to make the compiler shut up.
+        }
+
+        [MonoModPatch("<>c__DisplayClass14_0")]
+        class patch_MoveSequenceLambdas {
+
+            [MonoModPatch("<>4__this")]
+            private patch_FinalBossMovingBlock _this = default;
+            private Vector2 from = default, to = default;
+
+            [MonoModReplace]
+            [MonoModPatch("<MoveSequence>b__0")]
+            public void TweenUpdateLambda(Tween t) {
+                // Patch this to always behave like XNA
+                // This is absolutely hecking ridiculous and a perfect example of why we want to switch to .NET Core
+                // The Y member gets downcast but not the X one because of JIT jank
+                double lerpX = from.X + ((double) to.X - from.X) * t.Eased, lerpY = from.Y + ((double) to.Y - from.Y) * t.Eased;
+                _this.MoveH((float) (lerpX - _this.Position.X - _this.movementCounter.X));
+                _this.MoveV((float) ((double) (float) lerpY - _this.Position.Y - _this.movementCounter.Y));
+            }
+
+        }
+
+    }
+}

--- a/Celeste.Mod.mm/Patches/FinalBossMovingBlock.cs
+++ b/Celeste.Mod.mm/Patches/FinalBossMovingBlock.cs
@@ -1,13 +1,13 @@
-﻿#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
-
-using Microsoft.Xna.Framework;
+﻿using Microsoft.Xna.Framework;
 using Monocle;
 using MonoMod;
+using System.Runtime.CompilerServices;
 
 namespace Celeste {
     class patch_FinalBossMovingBlock : FinalBossMovingBlock {
 
-        private Vector2 movementCounter = default;
+        [MonoModLinkTo("Celeste.Platform", "movementCounter")]
+        internal Vector2 movementCounter = default;
 
         public patch_FinalBossMovingBlock(EntityData data, Vector2 offset)
             : base(data, offset) {

--- a/Celeste.Mod.mm/Patches/FinalBossMovingBlock.cs
+++ b/Celeste.Mod.mm/Patches/FinalBossMovingBlock.cs
@@ -6,8 +6,9 @@ using System.Runtime.CompilerServices;
 namespace Celeste {
     class patch_FinalBossMovingBlock : FinalBossMovingBlock {
 
-        [MonoModLinkTo("Celeste.Platform", "movementCounter")]
-        internal Vector2 movementCounter = default;
+        internal Vector2 movementCounter {
+            [MonoModLinkTo("Celeste.Platform", "get__movementCounter")] get;
+        }
 
         public patch_FinalBossMovingBlock(EntityData data, Vector2 offset)
             : base(data, offset) {

--- a/Celeste.Mod.mm/Patches/FinalBossMovingBlock.cs
+++ b/Celeste.Mod.mm/Patches/FinalBossMovingBlock.cs
@@ -29,8 +29,11 @@ namespace Celeste {
                 // The Y member gets downcast but not the X one because of JIT jank
                 double lerpX = from.X + ((double) to.X - from.X) * t.Eased, lerpY = from.Y + ((double) to.Y - from.Y) * t.Eased;
                 _this.MoveH((float) (lerpX - _this.Position.X - _this.movementCounter.X));
-                _this.MoveV((float) ((double) (float) lerpY - _this.Position.Y - _this.movementCounter.Y));
+                _this.MoveV((float) ((double) JITBarrier((float) lerpY) - _this.Position.Y - _this.movementCounter.Y));
             }
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            private static float JITBarrier(float v) => v;
 
         }
 

--- a/Celeste.Mod.mm/Patches/Monocle/Calc.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Calc.cs
@@ -53,5 +53,27 @@ namespace Monocle {
             return MathHelper.Clamp((num - zeroAt) / (oneAt - zeroAt), 0f, 1f);
         }
 
+        [MonoModReplace]
+        public static Vector2 Approach(Vector2 val, Vector2 target, float maxMove) {
+            if (maxMove == 0f || val == target)
+                return val;
+
+            Vector2 delta = target - val;
+            if (delta.Length() < maxMove)
+                return target;
+
+            delta.Normalize();
+            return new Vector2((float) (val.X + (double) delta.X * maxMove), (float) (val.Y + (double) delta.Y * maxMove)); // Patch in XNA float jank
+        }
+
+        [MonoModReplace]
+        public static Vector3 Approach(this Vector3 v, Vector3 target, float amount) {
+            if (amount > (target - v).Length())
+                return target;
+
+            Vector3 delta = (target - v).SafeNormalize();
+            return new Vector3((float) (v.X + (double) delta.X * amount), (float) (v.Y + (double) delta.Y * amount), (float) (v.Z + (double) delta.Z * amount)); // Patch in XNA float jank
+        }
+
     }
 }

--- a/Celeste.Mod.mm/Patches/Monocle/SimpleCurve.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/SimpleCurve.cs
@@ -30,7 +30,7 @@ namespace Monocle {
             float num = 0f;
             for (int i = 1; i <= resolution; i++) {
                 Vector2 point = GetPoint((float) i / resolution);
-                num += Vector2.Distance(point, vector);
+                num += (point - vector).Length();
                 vector = point;
             }
             return num;

--- a/Celeste.Mod.mm/Patches/Monocle/SimpleCurve.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/SimpleCurve.cs
@@ -1,5 +1,6 @@
 using Microsoft.Xna.Framework;
 using MonoMod;
+using System.Runtime.CompilerServices;
 
 namespace Monocle {
     // Patch XNA/FNA float jank differences
@@ -19,8 +20,8 @@ namespace Monocle {
         public Vector2 GetPoint(float percent) {
             double num = 1.0 - percent;
             return new Vector2(
-                (float) ((double) (float) (num * num) * Begin.X + (float) (2.0 * num * percent) * Control.X + (float) (percent * percent) * End.X),
-                (float) ((double) (float) (num * num) * Begin.Y + (float) (2.0 * num * percent) * Control.Y + (float) (percent * percent) * End.Y)
+                (float) ((double) JITBarrier((float) (num * num)) * Begin.X + (double) JITBarrier((float) (2.0 * num * percent)) * Control.X + (double) JITBarrier((float) ((double) percent * percent)) * End.X),
+                (float) ((double) JITBarrier((float) (num * num)) * Begin.Y + (double) JITBarrier((float) (2.0 * num * percent)) * Control.Y + (double) JITBarrier((float) ((double) percent * percent)) * End.Y)
             );
         }
 
@@ -35,6 +36,9 @@ namespace Monocle {
             }
             return num;
         }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private float JITBarrier(float v) => v;
 
     }
 }

--- a/Celeste.Mod.mm/Patches/Monocle/SimpleCurve.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/SimpleCurve.cs
@@ -1,0 +1,45 @@
+using Microsoft.Xna.Framework;
+using MonoMod;
+using System;
+
+namespace Monocle {
+    // Patch XNA/FNA float jank differences
+    struct patch_SimpleCurve {
+
+        public Vector2 Begin, End, Control;
+
+        [MonoModReplace]
+        public void DoubleControl() {
+            Control = new Vector2(
+                (float) ((double) Control.X + Control.X - (Begin.X + ((double) End.X - Begin.X) / 2.0)),
+                (float) ((double) Control.Y + Control.Y - (Begin.Y + ((double) End.Y - Begin.Y) / 2.0))
+            );
+        }
+
+        // Separate high-precision calculation method as to not have to inline this into LengthParametric
+        private void __GetPoint(double percent, out double outX, out double outY) {
+            double num = 1.0 - percent;
+            outX = num * num * Begin.X + 2.0 * num * percent * Control.X + percent * percent * End.X;
+            outY = num * num * Begin.Y + 2.0 * num * percent * Control.Y + percent * percent * End.Y;
+        }
+
+        [MonoModReplace]
+        public Vector2 GetPoint(float percent) {
+            __GetPoint(percent, out double x, out double y);
+            return new Vector2((float) x, (float) y);
+        }
+
+        [MonoModReplace]
+        public float GetLengthParametric(int resolution) {
+            Vector2 vector = Begin;
+            float num = 0f;
+            for (int i = 1; i <= resolution; i++) {
+                __GetPoint((double) i / resolution, out double pointX, out double pointY);
+                num += (float) Math.Sqrt((pointX - vector.X)*(pointX - vector.X) + (pointY - vector.Y)*(pointY - vector.Y));
+                vector = new Vector2((float) pointX, (float) pointY);
+            }
+            return num;
+        }
+
+    }
+}

--- a/Celeste.Mod.mm/Patches/Platform.cs
+++ b/Celeste.Mod.mm/Patches/Platform.cs
@@ -5,7 +5,7 @@ using System;
 namespace Celeste {
     abstract class patch_Platform : Platform {
 
-        private Vector2 movementCounter;
+        private Vector2 movementCounter = default;
 
         public patch_Platform(Vector2 position, bool safe)
             : base(position, safe) {

--- a/Celeste.Mod.mm/Patches/Platform.cs
+++ b/Celeste.Mod.mm/Patches/Platform.cs
@@ -1,8 +1,11 @@
 ﻿using Microsoft.Xna.Framework;
+using MonoMod;
 using System;
 
 namespace Celeste {
     abstract class patch_Platform : Platform {
+
+        private Vector2 movementCounter;
 
         public patch_Platform(Vector2 position, bool safe)
             : base(position, safe) {
@@ -11,6 +14,28 @@ namespace Celeste {
 
         public bool MoveVCollideSolidsAndBounds(Level level, float moveV, bool thruDashBlocks, Action<Vector2, Vector2, Platform> onCollide = null) {
             return MoveVCollideSolidsAndBounds(level, moveV, thruDashBlocks, onCollide, true);
+        }
+
+        // Patch MoveToX/Y to replicate XNA's behaviour on FNA
+
+        [MonoModReplace]
+        public new void MoveToX(float toX) {
+            MoveH((float) ((double) toX - Position.X - movementCounter.X));
+        }
+
+        [MonoModReplace]
+        public new void MoveToX(float toX, float liftSpeedX) {
+            MoveH((float) ((double) toX - Position.X - movementCounter.X), liftSpeedX);
+        }
+
+        [MonoModReplace]
+        public new void MoveToY(float toY) {
+            MoveV((float) ((double) toY - Position.Y - movementCounter.Y));
+        }
+
+        [MonoModReplace]
+        public new void MoveToY(float toY, float liftSpeedY) {
+            MoveV((float) ((double) toY - Position.Y - movementCounter.Y), liftSpeedY);
         }
 
     }

--- a/Celeste.Mod.mm/Patches/Platform.cs
+++ b/Celeste.Mod.mm/Patches/Platform.cs
@@ -5,9 +5,8 @@ using System;
 namespace Celeste {
     abstract class patch_Platform : Platform {
 
-        // internal has the same BindingFlags as private, so this is safe to do
-        [MonoModReplace]
-        internal Vector2 movementCounter = default;
+        private Vector2 movementCounter = default;
+        internal Vector2 _movementCounter => movementCounter; // proxy for Solid patches to link against
 
         public patch_Platform(Vector2 position, bool safe)
             : base(position, safe) {

--- a/Celeste.Mod.mm/Patches/Platform.cs
+++ b/Celeste.Mod.mm/Patches/Platform.cs
@@ -31,6 +31,11 @@ namespace Celeste {
         }
 
         [MonoModReplace]
+        public new void MoveToXNaive(float toX) {
+            MoveHNaive((float) ((double) toX - Position.X - movementCounter.X));
+        }
+
+        [MonoModReplace]
         public new void MoveToY(float toY) {
             MoveV((float) ((double) toY - Position.Y - movementCounter.Y));
         }
@@ -38,6 +43,11 @@ namespace Celeste {
         [MonoModReplace]
         public new void MoveToY(float toY, float liftSpeedY) {
             MoveV((float) ((double) toY - Position.Y - movementCounter.Y), liftSpeedY);
+        }
+
+        [MonoModReplace]
+        public new void MoveToYNaive(float toY) {
+            MoveVNaive((float) ((double) toY - Position.Y - movementCounter.Y));
         }
 
     }

--- a/Celeste.Mod.mm/Patches/Platform.cs
+++ b/Celeste.Mod.mm/Patches/Platform.cs
@@ -5,7 +5,9 @@ using System;
 namespace Celeste {
     abstract class patch_Platform : Platform {
 
-        private Vector2 movementCounter = default;
+        // internal has the same BindingFlags as private, so this is safe to do
+        [MonoModReplace]
+        internal Vector2 movementCounter = default;
 
         public patch_Platform(Vector2 position, bool safe)
             : base(position, safe) {


### PR DESCRIPTION
As decided by [this poll](https://discord.com/channels/403698615446536203/1068379326589976596/1089278990105182238), this patches FNA versions of the game to behave like XNA installs in terms of floating point behavior. It does so by patching the `MoveToX/Y` methods of `Actor` and `Platform`, as these are affected by a slight JIT optimization difference causing them to calculate values with more precision on XNA than on FNA. Additionally, it patches `Calc.Approach` for vector types as well as `FinalBossMovingBlock`. XNA's behavior is emulated using `double`s for relevant calculations on all platforms.