### PR TITLE
Fix ambience volume trigger resetting audio state on every frame

### DIFF
--- a/Celeste.Mod.mm/Mod/Entities/AmbienceVolumeTrigger.cs
+++ b/Celeste.Mod.mm/Mod/Entities/AmbienceVolumeTrigger.cs
@@ -19,10 +19,9 @@ namespace Celeste.Mod.Entities {
         }
 
         public override void OnStay(Player player) {
-            patch_AudioState audioState = (patch_AudioState) SceneAs<Level>().Session.Audio;
-
-            audioState.AmbienceVolume = Calc.ClampedMap(GetPositionLerp(player, positionMode), 0f, 1f, from, to);
-            audioState.Apply();
+            float ambienceVolume = Calc.ClampedMap(GetPositionLerp(player, positionMode), 0f, 1f, from, to);
+            ((patch_AudioState) SceneAs<Level>().Session.Audio).AmbienceVolume = ambienceVolume;
+            Audio.CurrentAmbienceEventInstance?.setVolume(ambienceVolume);
         }
     }
 }


### PR DESCRIPTION
Changes the ambience volume trigger to make it set the ambience volume directly and updating the audio state **without applying it**. This avoids resetting music params like progress that are set by music fade triggers.