### PR TITLE
Fix puffer boosts a different way

### DIFF
--- a/Celeste.Mod.mm/Patches/Level.cs
+++ b/Celeste.Mod.mm/Patches/Level.cs
@@ -41,8 +41,6 @@ namespace Celeste {
 
         private float unpauseTimer;
 
-        internal bool playerWasExplodeLaunchedThisFrame;
-
         /// <summary>
         /// If in vanilla levels, gets the spawnpoint closest to the bottom left of the level.<br/>
         /// Otherwise, get the default spawnpoint from the level data if present, falling back to
@@ -699,7 +697,6 @@ namespace MonoMod {
             MethodReference m_Everest_CoreModule_Settings = MonoModRule.Modder.Module.GetType("Celeste.Mod.Core.CoreModule").FindProperty("Settings").GetMethod;
             TypeDefinition t_Everest_CoreModuleSettings = MonoModRule.Modder.Module.GetType("Celeste.Mod.Core.CoreModuleSettings");
             MethodReference m_ButtonBinding_Pressed = MonoModRule.Modder.Module.GetType("Celeste.Mod.ButtonBinding").FindProperty("Pressed").GetMethod;
-            FieldDefinition f_playerWasExplodeLaunchedThisFrame = context.Method.DeclaringType.FindField("playerWasExplodeLaunchedThisFrame");
 
             ILCursor cursor = new ILCursor(context);
 
@@ -708,12 +705,6 @@ namespace MonoMod {
 
             // insert FixChaserStatesTimeStamp()
             cursor.Emit(OpCodes.Ldarg_0).Emit(OpCodes.Call, m_FixChaserStatesTimeStamp);
-
-            // insert playerWasExplodeLaunchedThisFrame = false after base.Update() call
-            cursor.GotoNext(MoveType.After, instr => instr.MatchCall("Monocle.Scene", "Update"));
-            cursor.Emit(OpCodes.Ldarg_0);
-            cursor.Emit(OpCodes.Ldc_I4_0);
-            cursor.Emit(OpCodes.Stfld, f_playerWasExplodeLaunchedThisFrame);
 
             /* We expect something similar enough to the following:
             call class Monocle.MInput/KeyboardData Monocle.MInput::get_Keyboard() // We're here

--- a/Celeste.Mod.mm/Patches/Player.cs
+++ b/Celeste.Mod.mm/Patches/Player.cs
@@ -184,20 +184,6 @@ namespace Celeste {
             return ExplodeLaunch(from, snapUp, false);
         }
 
-        [MonoModIgnore]
-        [PatchPlayerExplodeLaunch]
-        public extern new Vector2 ExplodeLaunch(Vector2 from, bool snapUp, bool sidesOnly);
-
-        private bool _SkipExplodeLaunchBoostCheck() {
-            return Scene is patch_Level lvl && lvl.Session.Area.GetLevelSet() != "Celeste" && lvl.playerWasExplodeLaunchedThisFrame;
-        }
-
-        private void _SetPlayerWasExplodeLaunchedThisFrame() {
-            if (Scene is patch_Level lvl) {
-                lvl.playerWasExplodeLaunchedThisFrame = true;
-            }
-        }
-
         private extern bool orig_Pickup(Holdable pickup);
         private bool Pickup(Holdable pickup) {
             // Madeline cannot grab something if she is dead...
@@ -305,9 +291,7 @@ namespace MonoMod {
     static partial class MonoModRules {
 
         public static void PatchPlayerOrigUpdate(ILContext context, CustomAttribute attrib) {
-            TypeDefinition t_Player = context.Method.DeclaringType;
-            MethodDefinition m_IsOverWater = t_Player.FindMethod("System.Boolean _IsOverWater()");
-            MethodDefinition m_SkipExplodeLaunchBoostCheck = t_Player.FindMethod("System.Boolean _SkipExplodeLaunchBoostCheck()");
+            MethodDefinition m_IsOverWater = context.Method.DeclaringType.FindMethod("System.Boolean _IsOverWater()");
 
             Mono.Collections.Generic.Collection<Instruction> instrs = context.Body.Instructions;
             ILProcessor il = context.Body.GetILProcessor();
@@ -333,16 +317,6 @@ namespace MonoMod {
                     instrs.Insert(instri + 7, il.Create(OpCodes.Brfalse, instrs[instri + 4].Operand));
                 }
             }
-            
-            // delay the explode launch boost leniency check by one frame if ExplodeLaunch was called earlier in the same frame
-            ILCursor cursor = new ILCursor(context);
-            cursor.GotoNext(MoveType.After, instr => instr.MatchLdarg(0), instr => instr.MatchLdfld("Celeste.Player", "explodeLaunchBoostTimer"), instr => instr.MatchLdcR4(0f), instr => instr.MatchBleUn(out _));
-            cursor.Emit(OpCodes.Ldarg_0);
-            cursor.Emit(OpCodes.Callvirt, m_SkipExplodeLaunchBoostCheck);
-            ILLabel afterLaunchBoostCheck = cursor.DefineLabel();
-            cursor.Emit(OpCodes.Brtrue_S, afterLaunchBoostCheck);
-            cursor.GotoNext(instr => instr.MatchLdarg(0), instr => instr.MatchLdarg(0), instr => instr.MatchLdfld("Celeste.Player", "StrawberryCollectResetTimer"));
-            cursor.MarkLabel(afterLaunchBoostCheck);
         }
 
         public static void PatchPlayerBeforeUpTransition(ILContext context, CustomAttribute attrib) {

--- a/Celeste.Mod.mm/Patches/Puffer.cs
+++ b/Celeste.Mod.mm/Patches/Puffer.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.Xna.Framework;
+using Monocle;
+using MonoMod;
+
+namespace Celeste {
+    class patch_Puffer : Puffer {
+        public patch_Puffer(EntityData data, Vector2 offset) : base(data, offset) {
+            // ignored by MonoMod
+        }
+
+        [MonoModLinkTo("Monocle.Entity", "Added")]
+        [MonoModIgnore]
+        public extern void base_Added(Scene scene);
+
+        public override void Added(Scene scene) {
+            base_Added(scene);
+            if ((scene as Level).Session.Area.GetLevelSet() != "Celeste") {
+                Depth = -1; // makes puffer boosts work after player respawn or other depth reset
+            }
+        }
+    }
+}


### PR DESCRIPTION
The previous attempt at making ExplodeLaunch leniency frames consistent had unforeseen circumstances (delaying the boost check in Player.Update can cause it to be applied when the player has already entered a different state, notably StPickup). This version of the fix instead sets Puffer depth to -1 in custom maps, which ensures they will update after the player under normal circumstances.