### PR TITLE
Fix TextMenu.Option right side is too wide

### DIFF
--- a/Celeste.Mod.mm/Patches/TextMenu.cs
+++ b/Celeste.Mod.mm/Patches/TextMenu.cs
@@ -382,7 +382,7 @@ namespace Celeste {
                 List<string> currentContent = Values.Select(val => val.Item1).ToList();
                 if (!cachedRightWidthContent.SequenceEqual(currentContent)) {
                     // contents changed, or the width wasn't computed yet.
-                    cachedRightWidth = orig_RightWidth();
+                    cachedRightWidth = orig_RightWidth() * 0.8f + 44f;
                     cachedRightWidthContent = currentContent;
                 }
                 return cachedRightWidth;
@@ -558,7 +558,7 @@ namespace MonoMod {
             cursor.Next.OpCode = OpCodes.Ldfld;
             cursor.Next.Operand = f_UnselectedColor;
         }
-    
+
         public static void PatchTextMenuSettingUpdate(ILContext il, CustomAttribute _) {
             MethodReference m_MouseButtonsHash = il.Method.DeclaringType.FindMethod("_MouseButtonsHash");
             FieldReference f_Binding_Mouse = MonoModRule.Modder.FindType("Monocle.Binding").Resolve().FindField("Mouse");


### PR DESCRIPTION
TextMenu.Option render the right side with font size of 80%, but uses 100% when calculating the width, so the more characters, the bigger the error. This pr fixes the issue.

before:
![8T2T8TW@(IYR_TWNEW_IJ I](https://user-images.githubusercontent.com/181192/232445197-e3ca5479-6941-4f52-a52f-afc7099c1f76.png)

after:
![)OO4PQZ%1AHRX7BUR~X8JP3](https://user-images.githubusercontent.com/181192/232445248-4bc4d828-85cd-4c9c-88c3-3814a9a2f43b.png)
