### PR TITLE
Fix crash setting the map camera movement bindings too early

### DIFF
--- a/Celeste.Mod.mm/Patches/Input.cs
+++ b/Celeste.Mod.mm/Patches/Input.cs
@@ -19,6 +19,9 @@ namespace Celeste {
         public static void Initialize() {
             orig_Initialize();
 
+            foreach (EverestModule mod in Everest._Modules)
+                mod.OnInputInitialize();
+
             //Sets the slight camera movement on the map to the set debug camera movement keys in Everest mod settings
             Input.MountainAim = new VirtualJoystick(
                 CoreModule.Settings.CameraForward.Binding,
@@ -27,9 +30,6 @@ namespace Celeste {
                 CoreModule.Settings.CameraRight.Binding,
                 Input.Gamepad, 0.1f
             );
-
-            foreach (EverestModule mod in Everest._Modules)
-                mod.OnInputInitialize();
 
             Everest.Events.Input.Initialize();
         }


### PR DESCRIPTION
When trying to start Celeste without the save files (specifically the button bindings section) created a NullReference crash will appear. 
This was introduced by #600.
The `CoreModule.Settings.CameraForward` and the other directions will be null when they are passed into the `VirtualJoystick` thus getting a null reference exception when trying to retrieve the `Binding` property. 

https://github.com/EverestAPI/Everest/blob/7acf2db2e2bedc4704f858e1f9b669d62d1e592c/Celeste.Mod.mm/Patches/Input.cs#L23-L29

Calling `EveresteModule.OnInputInitialize` before that is done ensures that the default values for those fields will have already been set, thus preventing the crash.