### PR TITLE
write the savepath to a file during boot

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -415,6 +415,9 @@ namespace Celeste.Mod {
                     Directory.Move(modSettingsOld, modSettingsRIP);
             }
 
+            string savePathFile = Path.Combine(PathEverest, "everest-savepath.txt");
+            File.WriteAllBytes(savePathFile, Encoding.UTF8.GetBytes(PathSettings));
+
             _DetourModManager = new DetourModManager();
             _DetourModManager.OnILHook += (owner, from, to) => {
                 _DetourOwners.Add(owner);

--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -416,7 +416,7 @@ namespace Celeste.Mod {
             }
 
             string savePathFile = Path.Combine(PathEverest, "everest-savepath.txt");
-            File.WriteAllBytes(savePathFile, Encoding.UTF8.GetBytes(PathSettings));
+            File.WriteAllBytes(savePathFile, Encoding.UTF8.GetBytes(Path.GetFullPath(PathSettings)));
 
             _DetourModManager = new DetourModManager();
             _DetourModManager.OnILHook += (owner, from, to) => {


### PR DESCRIPTION
closes #612 by writing the path to the Saves folder to `everest-savepath.txt` in the Celeste folder.