### PR TITLE
Better support for transitive dependencies

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.DiscordSDK.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.DiscordSDK.cs
@@ -1,4 +1,5 @@
 ﻿using Celeste.Mod.Core;
+using Celeste.Mod.Helpers;
 using Microsoft.Xna.Framework;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -34,7 +35,10 @@ namespace Celeste.Mod {
 
             internal static void LoadRichPresenceIcons() {
                 new Task(() => {
-                    JArray list = JsonConvert.DeserializeObject<JArray>(new WebClient().DownloadString(IconBaseURL + "/rich-presence-icons/list.json"));
+                    JArray list;
+                    using (WebClient webClient = new CompressedWebClient()) {
+                        list = JsonConvert.DeserializeObject<JArray>(webClient.DownloadString(IconBaseURL + "/rich-presence-icons/list.json"));
+                    }
                     foreach (string element in list.Children<JValue>()) {
                         RichPresenceIcons.Add(element);
                     }

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Updater.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Updater.cs
@@ -81,8 +81,7 @@ namespace Celeste.Mod {
                     string data;
                     try {
                         Logger.Log(LogLevel.Debug, "updater", "Attempting to download update list from source: " + Index);
-                        using (WebClient wc = new WebClient()) {
-                            wc.Headers.Add("User-Agent", "Everest/" + Everest.VersionString);
+                        using (WebClient wc = new CompressedWebClient()) {
                             data = wc.DownloadString(Index());
                         }
                     } catch (Exception e) {
@@ -198,7 +197,7 @@ namespace Celeste.Mod {
             private static string _everestUpdaterDatabaseURL;
             private static string GetEverestUpdaterDatabaseURL() {
                 if (string.IsNullOrEmpty(_everestUpdaterDatabaseURL)) {
-                    using (WebClient wc = new WebClient()) {
+                    using (WebClient wc = new CompressedWebClient()) {
                         Logger.Log(LogLevel.Verbose, "updater", "Fetching everest updater database URL");
                         _everestUpdaterDatabaseURL = wc.DownloadString("https://everestapi.github.io/everestupdater.txt").Trim();
                     }

--- a/Celeste.Mod.mm/Mod/Helpers/CompressedWebClient.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/CompressedWebClient.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Net;
+
+namespace Celeste.Mod.Helpers {
+    /// <summary>
+    /// A WebClient that supports gzip-compressed responses to save bandwidth.
+    /// </summary>
+    public class CompressedWebClient : WebClient {
+        protected override WebRequest GetWebRequest(Uri address) {
+            HttpWebRequest request = (HttpWebRequest) base.GetWebRequest(address);
+            request.AutomaticDecompression = DecompressionMethods.GZip;
+            request.UserAgent = "Everest/" + Everest.VersionString;
+            return request;
+        }
+    }
+}

--- a/Celeste.Mod.mm/Mod/Helpers/ModUpdaterHelper.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/ModUpdaterHelper.cs
@@ -29,7 +29,7 @@ namespace Celeste.Mod.Helpers {
 
                 Logger.Log(LogLevel.Verbose, "ModUpdaterHelper", $"Downloading last versions list from {modUpdaterDatabaseUrl}");
 
-                using (WebClient wc = new WebClient()) {
+                using (WebClient wc = new CompressedWebClient()) {
                     string yamlData = wc.DownloadString(modUpdaterDatabaseUrl);
                     updateCatalog = YamlHelper.Deserializer.Deserialize<Dictionary<string, ModUpdateInfo>>(yamlData);
                     foreach (string name in updateCatalog.Keys) {
@@ -62,7 +62,7 @@ namespace Celeste.Mod.Helpers {
 
                 Dictionary<string, EverestModuleMetadata> dependencyGraph = new Dictionary<string, EverestModuleMetadata>();
 
-                using (WebClient wc = new WebClient()) {
+                using (WebClient wc = new CompressedWebClient()) {
                     string yamlData = wc.DownloadString(modUpdaterDatabaseUrl);
                     Dictionary<string, DependencyGraphEntry> dependencyGraphUnparsed = YamlHelper.Deserializer.Deserialize<Dictionary<string, DependencyGraphEntry>>(yamlData);
 
@@ -189,7 +189,7 @@ namespace Celeste.Mod.Helpers {
         /// This should point to a running instance of https://github.com/maddie480/EverestUpdateCheckerServer.
         /// </summary>
         private static string getModUpdaterDatabaseUrl(string database) {
-            using (WebClient wc = new WebClient()) {
+            using (WebClient wc = new CompressedWebClient()) {
                 Logger.Log(LogLevel.Verbose, "ModUpdaterHelper", "Fetching mod updater database URL");
                 return wc.DownloadString("https://everestapi.github.io/" + database + ".txt").Trim();
             }

--- a/Celeste.Mod.mm/Mod/Helpers/ModUpdaterHelper.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/ModUpdaterHelper.cs
@@ -186,7 +186,7 @@ namespace Celeste.Mod.Helpers {
 
         /// <summary>
         /// Retrieves the mod updater database location from everestapi.github.io.
-        /// This should point to a running instance of https://github.com/max4805/EverestUpdateCheckerServer.
+        /// This should point to a running instance of https://github.com/maddie480/EverestUpdateCheckerServer.
         /// </summary>
         private static string getModUpdaterDatabaseUrl(string database) {
             using (WebClient wc = new WebClient()) {

--- a/Celeste.Mod.mm/Mod/Helpers/ModUpdaterHelper.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/ModUpdaterHelper.cs
@@ -7,18 +7,6 @@ using System.Threading.Tasks;
 
 namespace Celeste.Mod.Helpers {
     public class ModUpdaterHelper {
-        private class CompressedWebClient : WebClient {
-            protected override WebRequest GetWebRequest(Uri address) {
-                // In order to compress the response, Accept-Encoding and User-Agent both have to contain "gzip":
-                // https://cloud.google.com/appengine/docs/standard/java/how-requests-are-handled#response_compression
-                HttpWebRequest request = (HttpWebRequest) base.GetWebRequest(address);
-                request.AutomaticDecompression = DecompressionMethods.GZip;
-                request.UserAgent = "Everest/" + Everest.VersionString + "; gzip";
-
-                return request;
-            }
-        }
-
         private class MostRecentUpdatedFirst : IComparer<ModUpdateInfo> {
             public int Compare(ModUpdateInfo x, ModUpdateInfo y) {
                 if (x.LastUpdate != y.LastUpdate) {
@@ -37,11 +25,11 @@ namespace Celeste.Mod.Helpers {
             Dictionary<string, ModUpdateInfo> updateCatalog = null;
 
             try {
-                string modUpdaterDatabaseUrl = getModUpdaterDatabaseUrl();
+                string modUpdaterDatabaseUrl = getModUpdaterDatabaseUrl("modupdater");
 
                 Logger.Log(LogLevel.Verbose, "ModUpdaterHelper", $"Downloading last versions list from {modUpdaterDatabaseUrl}");
 
-                using (WebClient wc = new CompressedWebClient()) {
+                using (WebClient wc = new WebClient()) {
                     string yamlData = wc.DownloadString(modUpdaterDatabaseUrl);
                     updateCatalog = YamlHelper.Deserializer.Deserialize<Dictionary<string, ModUpdateInfo>>(yamlData);
                     foreach (string name in updateCatalog.Keys) {
@@ -55,6 +43,61 @@ namespace Celeste.Mod.Helpers {
             }
 
             return updateCatalog;
+        }
+
+        private class DependencyGraphEntry {
+            public List<ModUpdateInfo> Dependencies { get; set; }
+            public List<ModUpdateInfo> OptionalDependencies { get; set; }
+        }
+
+        /// <summary>
+        /// Downloads the mod dependency graph from the update checker server.
+        /// Returns null if the download fails for any reason.
+        /// </summary>
+        public static Dictionary<string, EverestModuleMetadata> DownloadModDependencyGraph() {
+            try {
+                string modUpdaterDatabaseUrl = getModUpdaterDatabaseUrl("modgraph");
+
+                Logger.Log(LogLevel.Verbose, "ModUpdaterHelper", $"Downloading mod dependency graph from {modUpdaterDatabaseUrl}");
+
+                Dictionary<string, EverestModuleMetadata> dependencyGraph = new Dictionary<string, EverestModuleMetadata>();
+
+                using (WebClient wc = new WebClient()) {
+                    string yamlData = wc.DownloadString(modUpdaterDatabaseUrl);
+                    Dictionary<string, DependencyGraphEntry> dependencyGraphUnparsed = YamlHelper.Deserializer.Deserialize<Dictionary<string, DependencyGraphEntry>>(yamlData);
+
+                    foreach (KeyValuePair<string, DependencyGraphEntry> entry in dependencyGraphUnparsed) {
+                        EverestModuleMetadata result = new EverestModuleMetadata { Name = entry.Key };
+
+                        // ArgumentExceptions may happen if any of the dependencies have invalid version numbers.
+
+                        foreach (ModUpdateInfo info in entry.Value.Dependencies) {
+                            try {
+                                result.Dependencies.Add(new EverestModuleMetadata { Name = info.Name, VersionString = info.Version });
+                            } catch (ArgumentException) {
+                                continue;
+                            }
+                        }
+
+                        foreach (ModUpdateInfo info in entry.Value.OptionalDependencies) {
+                            try {
+                                result.OptionalDependencies.Add(new EverestModuleMetadata { Name = info.Name, VersionString = info.Version });
+                            } catch (ArgumentException) {
+                                continue;
+                            }
+                        }
+
+                        dependencyGraph[entry.Key] = result;
+                    }
+
+                    Logger.Log(LogLevel.Verbose, "ModUpdaterHelper", $"Downloaded {dependencyGraph.Count} item(s)");
+                    return dependencyGraph;
+                }
+            } catch (Exception e) {
+                Logger.Log(LogLevel.Warn, "ModUpdaterHelper", $"Downloading dependency graph failed!");
+                Logger.LogDetailed(e);
+                return null;
+            }
         }
 
         /// <summary>
@@ -145,10 +188,10 @@ namespace Celeste.Mod.Helpers {
         /// Retrieves the mod updater database location from everestapi.github.io.
         /// This should point to a running instance of https://github.com/max4805/EverestUpdateCheckerServer.
         /// </summary>
-        private static string getModUpdaterDatabaseUrl() {
+        private static string getModUpdaterDatabaseUrl(string database) {
             using (WebClient wc = new WebClient()) {
                 Logger.Log(LogLevel.Verbose, "ModUpdaterHelper", "Fetching mod updater database URL");
-                return wc.DownloadString("https://everestapi.github.io/modupdater.txt").Trim();
+                return wc.DownloadString("https://everestapi.github.io/" + database + ".txt").Trim();
             }
         }
 


### PR DESCRIPTION
Using the mod dependency graph from the updater, we can check if any missing mod has dependencies that are also missing, and add them to the missing dependencies list. This way, we can install all transitive dependencies at once.

Here is a test mod: https://maddie480.ovh/celeste/dl?id=TransDependencies1&twoclick=1. It indirectly depends on TransDependencies2 through 4, Collab Utils, Extended Variants and Helping Hand.