### PR TITLE
Add favorites support in enable or disable mods menu

### DIFF
--- a/Celeste.Mod.mm/Content/Dialog/English.txt
+++ b/Celeste.Mod.mm/Content/Dialog/English.txt
@@ -260,6 +260,9 @@
 	MODOPTIONS_MODTOGGLE_TOGGLEDEPS=	Toggle Dependencies Automatically
 	MODOPTIONS_MODTOGGLE_TOGGLEDEPS_MESSAGE1=	When you enable a mod, all its dependencies will be enabled.
 	MODOPTIONS_MODTOGGLE_TOGGLEDEPS_MESSAGE2=	When you disable a mod, all mods that depend on it will be disabled.
+	MODOPTIONS_MODTOGGLE_TOGGLEFAVORITES=			Toggle Favorites
+	MODOPTIONS_MODTOGGLE_TOGGLEFAVORITES_MESSAGE1=	Press
+	MODOPTIONS_MODTOGGLE_TOGGLEFAVORITES_MESSAGE2=	to add or remove items from the favorite list.
 	MODOPTIONS_MODTOGGLE_MESSAGE_1=		If you enable or disable mods, your blacklist.txt will be replaced,
 	MODOPTIONS_MODTOGGLE_MESSAGE_2=		and Celeste will restart to apply changes.
 	MODOPTIONS_MODTOGGLE_MESSAGE_3=		Highlighted mods are used by other enabled mods as a dependency.

--- a/Celeste.Mod.mm/Content/Dialog/English.txt
+++ b/Celeste.Mod.mm/Content/Dialog/English.txt
@@ -260,9 +260,8 @@
 	MODOPTIONS_MODTOGGLE_TOGGLEDEPS=	Toggle Dependencies Automatically
 	MODOPTIONS_MODTOGGLE_TOGGLEDEPS_MESSAGE1=	When you enable a mod, all its dependencies will be enabled.
 	MODOPTIONS_MODTOGGLE_TOGGLEDEPS_MESSAGE2=	When you disable a mod, all mods that depend on it will be disabled.
-	MODOPTIONS_MODTOGGLE_TOGGLEFAVORITES=			Toggle Favorites
-	MODOPTIONS_MODTOGGLE_TOGGLEFAVORITES_MESSAGE1=	Press
-	MODOPTIONS_MODTOGGLE_TOGGLEFAVORITES_MESSAGE2=	to add or remove items from the favorite list.
+	MODOPTIONS_MODTOGGLE_TOGGLEFAVORITES=			Disable All ignores favorites
+	MODOPTIONS_MODTOGGLE_TOGGLEFAVORITES_MESSAGE=	Press {0} to add or remove items from the favorite list.
 	MODOPTIONS_MODTOGGLE_MESSAGE_1=		If you enable or disable mods, your blacklist.txt will be replaced,
 	MODOPTIONS_MODTOGGLE_MESSAGE_2=		and Celeste will restart to apply changes.
 	MODOPTIONS_MODTOGGLE_MESSAGE_3=		Highlighted mods are used by other enabled mods as a dependency.

--- a/Celeste.Mod.mm/Content/Dialog/English.txt
+++ b/Celeste.Mod.mm/Content/Dialog/English.txt
@@ -258,23 +258,23 @@
 	OOBE_SETTINGS_OK=			OK
 
 # Mod Toggle Menu
-	MODOPTIONS_MODTOGGLE=				TOGGLE MODS
-	MODOPTIONS_MODTOGGLE_LOADING=		Loading mod information...
-	MODOPTIONS_MODTOGGLE_TOGGLEDEPS=	Toggle Dependencies Automatically
-	MODOPTIONS_MODTOGGLE_TOGGLEDEPS_MESSAGE1=	When you enable a mod, all its dependencies will be enabled.
-	MODOPTIONS_MODTOGGLE_TOGGLEDEPS_MESSAGE2=	When you disable a mod, all mods that depend on it will be disabled.
-	MODOPTIONS_MODTOGGLE_TOGGLEFAVORITES=			'Disable All' ignores favorites
-	MODOPTIONS_MODTOGGLE_TOGGLEFAVORITES_MESSAGE=	Press {0} to add or remove mods from the favorite list.
-	MODOPTIONS_MODTOGGLE_MESSAGE_1=		If you enable or disable mods, your blacklist.txt will be replaced,
-	MODOPTIONS_MODTOGGLE_MESSAGE_2=		and Celeste will restart to apply changes.
-	MODOPTIONS_MODTOGGLE_MESSAGE_3=		Highlighted mods are used by other enabled mods as a dependency.
-	MODOPTIONS_MODTOGGLE_WHITELISTWARN= Disable your whitelist for these settings to be applied properly.
-	MODOPTIONS_MODTOGGLE_ENABLEALL=		Enable All
-	MODOPTIONS_MODTOGGLE_DISABLEALL=	Disable All
-	MODOPTIONS_MODTOGGLE_CANCEL=		Cancel
-	MODOPTIONS_MODTOGGLE_ZIPS=			Zip Files
-	MODOPTIONS_MODTOGGLE_DIRECTORIES=	Directories
-	MODOPTIONS_MODTOGGLE_BINS=			Map Bin Files
+	MODOPTIONS_MODTOGGLE=							TOGGLE MODS
+	MODOPTIONS_MODTOGGLE_LOADING=					Loading mod information...
+	MODOPTIONS_MODTOGGLE_TOGGLEDEPS=				Toggle Dependencies Automatically
+	MODOPTIONS_MODTOGGLE_TOGGLEDEPS_MESSAGE1=		When you enable a mod, all its dependencies will be enabled.
+	MODOPTIONS_MODTOGGLE_TOGGLEDEPS_MESSAGE2=		When you disable a mod, all mods that depend on it will be disabled.
+	MODOPTIONS_MODTOGGLE_PROTECTFAVORITES=			Protect Favorites
+	MODOPTIONS_MODTOGGLE_PROTECTFAVORITES_MESSAGE=	Press {0} to add or remove mods from the favorite list.
+	MODOPTIONS_MODTOGGLE_MESSAGE_1=					If you enable or disable mods, your blacklist.txt will be replaced,
+	MODOPTIONS_MODTOGGLE_MESSAGE_2=					and Celeste will restart to apply changes.
+	MODOPTIONS_MODTOGGLE_MESSAGE_3=					Highlighted mods are used by other enabled mods as a dependency.
+	MODOPTIONS_MODTOGGLE_WHITELISTWARN= 			Disable your whitelist for these settings to be applied properly.
+	MODOPTIONS_MODTOGGLE_ENABLEALL=					Enable All
+	MODOPTIONS_MODTOGGLE_DISABLEALL=				Disable All
+	MODOPTIONS_MODTOGGLE_CANCEL=					Cancel
+	MODOPTIONS_MODTOGGLE_ZIPS=						Zip Files
+	MODOPTIONS_MODTOGGLE_DIRECTORIES=				Directories
+	MODOPTIONS_MODTOGGLE_BINS=						Map Bin Files
 
 # Asset Reload Helper
 	ASSETRELOADHELPER_RELOADINGMAP=			Reloading map

--- a/Celeste.Mod.mm/Content/Dialog/English.txt
+++ b/Celeste.Mod.mm/Content/Dialog/English.txt
@@ -263,8 +263,8 @@
 	MODOPTIONS_MODTOGGLE_TOGGLEDEPS=	Toggle Dependencies Automatically
 	MODOPTIONS_MODTOGGLE_TOGGLEDEPS_MESSAGE1=	When you enable a mod, all its dependencies will be enabled.
 	MODOPTIONS_MODTOGGLE_TOGGLEDEPS_MESSAGE2=	When you disable a mod, all mods that depend on it will be disabled.
-	MODOPTIONS_MODTOGGLE_TOGGLEFAVORITES=			Disable All ignores favorites
-	MODOPTIONS_MODTOGGLE_TOGGLEFAVORITES_MESSAGE=	Press {0} to add or remove items from the favorite list.
+	MODOPTIONS_MODTOGGLE_TOGGLEFAVORITES=			'Disable All' ignores favorites
+	MODOPTIONS_MODTOGGLE_TOGGLEFAVORITES_MESSAGE=	Press {0} to add or remove mods from the favorite list.
 	MODOPTIONS_MODTOGGLE_MESSAGE_1=		If you enable or disable mods, your blacklist.txt will be replaced,
 	MODOPTIONS_MODTOGGLE_MESSAGE_2=		and Celeste will restart to apply changes.
 	MODOPTIONS_MODTOGGLE_MESSAGE_3=		Highlighted mods are used by other enabled mods as a dependency.

--- a/Celeste.Mod.mm/Content/Dialog/English.txt
+++ b/Celeste.Mod.mm/Content/Dialog/English.txt
@@ -264,7 +264,7 @@
 	MODOPTIONS_MODTOGGLE_TOGGLEDEPS_MESSAGE1=		When you enable a mod, all its dependencies will be enabled.
 	MODOPTIONS_MODTOGGLE_TOGGLEDEPS_MESSAGE2=		When you disable a mod, all mods that depend on it will be disabled.
 	MODOPTIONS_MODTOGGLE_PROTECTFAVORITES=			Protect Favorites
-	MODOPTIONS_MODTOGGLE_PROTECTFAVORITES_MESSAGE=	Press {0} to add or remove mods from the favorite list.
+	MODOPTIONS_MODTOGGLE_PROTECTFAVORITES_MESSAGE=	Press {0} to add or remove mods from your favorite list.
 	MODOPTIONS_MODTOGGLE_MESSAGE_1=					If you enable or disable mods, your blacklist.txt will be replaced,
 	MODOPTIONS_MODTOGGLE_MESSAGE_2=					and Celeste will restart to apply changes.
 	MODOPTIONS_MODTOGGLE_MESSAGE_3=					Highlighted mods are used by other enabled mods as a dependency.

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
@@ -35,6 +35,12 @@ namespace Celeste.Mod {
             public static ReadOnlyCollection<string> Blacklist => _Blacklist?.AsReadOnly();
 
             /// <summary>
+            /// The path to the Everest /Mods/favorites.txt file.
+            /// </summary>
+            public static string PathFavorites { get; internal set; }
+            internal static HashSet<string> Favorites = new HashSet<string>();
+
+            /// <summary>
             /// The path to the Everest /Mods/temporaryblacklist.txt file.
             /// </summary>
             public static string PathTemporaryBlacklist { get; internal set; }
@@ -149,6 +155,15 @@ namespace Celeste.Mod {
                         writer.WriteLine("# This is the Updater Blacklist. Lines starting with # are ignored.");
                         writer.WriteLine("# If you put the name of a mod zip in this file, it won't be auto-updated and it won't show update notifications on the title screen.");
                         writer.WriteLine("SomeMod.zip");
+                    }
+                }
+
+                PathFavorites = Path.Combine(PathMods, "favorites.txt");
+                if (File.Exists(PathFavorites)) {
+                    Favorites = new HashSet<string>(File.ReadAllLines(PathFavorites).Select(l => (l.StartsWith("#") ? "" : l).Trim()));
+                } else {
+                    using (StreamWriter writer = File.CreateText(PathFavorites)) {
+                        writer.WriteLine("# This is the favorites list. Lines starting with # are ignored.");
                     }
                 }
 
@@ -560,10 +575,10 @@ namespace Celeste.Mod {
                         Logger.Log(LogLevel.Warn, "loader", $"Skipping type '{type.FullName}' likely depending on optional dependency: {e}");
                     }
 
-                   if (mod != null) {
+                    if (mod != null) {
                         mod.Metadata = meta;
                         mod.Register();
-                   }
+                    }
                 }
 
                 // Warn if we didn't find a module, as that could indicate an oversight from the developer

--- a/Celeste.Mod.mm/Mod/UI/OuiModToggler.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiModToggler.cs
@@ -28,7 +28,7 @@ namespace Celeste.Mod.UI {
 
         private bool toggleDependencies = true;
 
-        private bool DisableAllIgnoresFavorites = true;
+        private bool disableAllIgnoresFavorites = true;
 
         private TextMenuExt.SubHeaderExt restartMessage1;
         private TextMenuExt.SubHeaderExt restartMessage2;
@@ -229,7 +229,7 @@ namespace Celeste.Mod.UI {
                         blacklistedMods.Clear();
                         foreach (KeyValuePair<string, TextMenu.OnOff> toggle in modToggles) {
                             bool isFavorite = favoritedMods.Contains(toggle.Key) || favoritesDependenciesMods.ContainsKey(toggle.Key);
-                            if (DisableAllIgnoresFavorites && isFavorite) {
+                            if (disableAllIgnoresFavorites && isFavorite) {
                                 continue;
                             }
 
@@ -247,11 +247,8 @@ namespace Celeste.Mod.UI {
                     toggleDependenciesButton.AddDescription(menu, Dialog.Clean("MODOPTIONS_MODTOGGLE_TOGGLEDEPS_MESSAGE1"));
 
                     TextMenu.Item toggleFavoritesButton;
-                    menu.Add(toggleFavoritesButton = new TextMenu.OnOff(Dialog.Clean("MODOPTIONS_MODTOGGLE_TOGGLEFAVORITES"), DisableAllIgnoresFavorites)
-                        .Change(value => DisableAllIgnoresFavorites = value));
-
-
-
+                    menu.Add(toggleFavoritesButton = new TextMenu.OnOff(Dialog.Clean("MODOPTIONS_MODTOGGLE_TOGGLEFAVORITES"), disableAllIgnoresFavorites)
+                        .Change(value => disableAllIgnoresFavorites = value));
 
                     TextMenuExt.EaseInDecorator<TextMenuExt.SubMenuWithInputs> favoriteToolTip =
                         new TextMenuExt.EaseInDecorator<TextMenuExt.SubMenuWithInputs>(
@@ -653,7 +650,7 @@ namespace Celeste.Mod.UI {
             modToggles = null;
             modLoadingTask = null;
             toggleDependencies = true;
-            DisableAllIgnoresFavorites = false;
+            disableAllIgnoresFavorites = false;
             favoritedMods = null;
             favoritedModsOriginal = null;
             favoritesDependenciesMods = null;

--- a/Celeste.Mod.mm/Mod/UI/OuiModToggler.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiModToggler.cs
@@ -28,7 +28,7 @@ namespace Celeste.Mod.UI {
 
         private bool toggleDependencies = true;
 
-        private bool toggleFavorites = false;
+        private bool DisableAllIgnoresFavorites = true;
 
         private TextMenuExt.SubHeaderExt restartMessage1;
         private TextMenuExt.SubHeaderExt restartMessage2;
@@ -229,9 +229,7 @@ namespace Celeste.Mod.UI {
                         blacklistedMods.Clear();
                         foreach (KeyValuePair<string, TextMenu.OnOff> toggle in modToggles) {
                             bool isFavorite = favoritedMods.Contains(toggle.Key) || favoritesDependenciesMods.ContainsKey(toggle.Key);
-                            if (!toggleFavorites && isFavorite) {
-                                // TODO: I don't like the continue keywords but the logic statement we want is kinda odd so for now it will do
-                                //       toggleFavorites || (!toggleFavorites && !isFavorite)
+                            if (DisableAllIgnoresFavorites && isFavorite) {
                                 continue;
                             }
 
@@ -249,13 +247,18 @@ namespace Celeste.Mod.UI {
                     toggleDependenciesButton.AddDescription(menu, Dialog.Clean("MODOPTIONS_MODTOGGLE_TOGGLEDEPS_MESSAGE1"));
 
                     TextMenu.Item toggleFavoritesButton;
-                    menu.Add(toggleFavoritesButton = new TextMenu.OnOff(Dialog.Clean("MODOPTIONS_MODTOGGLE_TOGGLEFAVORITES"), toggleFavorites)
-                        .Change(value => toggleFavorites = value));
+                    menu.Add(toggleFavoritesButton = new TextMenu.OnOff(Dialog.Clean("MODOPTIONS_MODTOGGLE_TOGGLEFAVORITES"), DisableAllIgnoresFavorites)
+                        .Change(value => DisableAllIgnoresFavorites = value));
 
-                    TextMenuExt.EaseInSubMenuWithInputs favoriteToolTip = new TextMenuExt.EaseInSubMenuWithInputs(
-                        new object[] { Dialog.Clean("MODOPTIONS_MODTOGGLE_TOGGLEFAVORITES_MESSAGE1") + " ",
-                        Input.MenuJournal, " " + Dialog.Clean("MODOPTIONS_MODTOGGLE_TOGGLEFAVORITES_MESSAGE2") },
-                        Input.GuiInputController(), false, menu) { TextColor = Color.Gray };
+
+
+
+                    TextMenuExt.EaseInDecorator<TextMenuExt.SubMenuWithInputs> favoriteToolTip =
+                        new TextMenuExt.EaseInDecorator<TextMenuExt.SubMenuWithInputs>(
+                            new TextMenuExt.SubMenuWithInputs(
+                                string.Format(Dialog.Get("MODOPTIONS_MODTOGGLE_TOGGLEFAVORITES_MESSAGE"), "|"), '|',
+                                new Monocle.VirtualButton[] { Input.MenuJournal }, () => Input.GuiInputController()) { TextColor = Color.Gray }
+                        , false, menu);
 
                     menu.Add(favoriteToolTip);
 
@@ -650,7 +653,7 @@ namespace Celeste.Mod.UI {
             modToggles = null;
             modLoadingTask = null;
             toggleDependencies = true;
-            toggleFavorites = false;
+            DisableAllIgnoresFavorites = false;
             favoritedMods = null;
             favoritedModsOriginal = null;
             favoritesDependenciesMods = null;

--- a/Celeste.Mod.mm/Mod/UI/OuiModToggler.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiModToggler.cs
@@ -251,7 +251,8 @@ namespace Celeste.Mod.UI {
                     // TODO: add localization support
                     menu.Add(toggleDependenciesButton = new TextMenu.OnOff("Toggle Favorites", toggleFavorites)
                         .Change(value => toggleFavorites = value));
-
+                    // TODO: Add an better indecation for how to use the favorite system
+                    toggleDependenciesButton.AddDescription(menu, "Press the 'Journal key' in order to add or remove items from the favorite list.");
 
 
                     // "cancel" button to leave the screen without saving

--- a/Celeste.Mod.mm/Mod/UI/OuiModToggler.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiModToggler.cs
@@ -248,11 +248,13 @@ namespace Celeste.Mod.UI {
                     toggleDependenciesButton.AddDescription(menu, Dialog.Clean("MODOPTIONS_MODTOGGLE_TOGGLEDEPS_MESSAGE2"));
                     toggleDependenciesButton.AddDescription(menu, Dialog.Clean("MODOPTIONS_MODTOGGLE_TOGGLEDEPS_MESSAGE1"));
 
+                    TextMenu.Item toggleFavoritesButton;
                     // TODO: add localization support
-                    menu.Add(toggleDependenciesButton = new TextMenu.OnOff("Toggle Favorites", toggleFavorites)
+                    menu.Add(toggleFavoritesButton = new TextMenu.OnOff("Toggle Favorites", toggleFavorites)
                         .Change(value => toggleFavorites = value));
-                    // TODO: Add an better indecation for how to use the favorite system
-                    toggleDependenciesButton.AddDescription(menu, "Press the 'Journal key' in order to add or remove items from the favorite list.");
+                    // TODO: Add a better indication for how to use the favorite system
+                    toggleFavoritesButton.AddDescription(menu, "Press the 'Journal key' in order to add or remove items from the favorite list.");
+
 
 
                     // "cancel" button to leave the screen without saving

--- a/Celeste.Mod.mm/Mod/UI/OuiModToggler.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiModToggler.cs
@@ -647,7 +647,7 @@ namespace Celeste.Mod.UI {
             modToggles = null;
             modLoadingTask = null;
             toggleDependencies = true;
-            protectFavorites = false;
+            protectFavorites = true;
             favoriteMods = null;
             favoriteModsOriginal = null;
             favoriteModDependencies = null;

--- a/Celeste.Mod.mm/Mod/UI/OuiModToggler.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiModToggler.cs
@@ -249,12 +249,24 @@ namespace Celeste.Mod.UI {
                     toggleDependenciesButton.AddDescription(menu, Dialog.Clean("MODOPTIONS_MODTOGGLE_TOGGLEDEPS_MESSAGE1"));
 
                     TextMenu.Item toggleFavoritesButton;
-                    // TODO: add localization support
-                    menu.Add(toggleFavoritesButton = new TextMenu.OnOff("Toggle Favorites", toggleFavorites)
+                    menu.Add(toggleFavoritesButton = new TextMenu.OnOff(Dialog.Clean("MODOPTIONS_MODTOGGLE_TOGGLEFAVORITES"), toggleFavorites)
                         .Change(value => toggleFavorites = value));
-                    // TODO: Add a better indication for how to use the favorite system
-                    toggleFavoritesButton.AddDescription(menu, "Press the 'Journal key' in order to add or remove items from the favorite list.");
 
+                    TextMenuExt.EaseInSubMenuWithInputs favoriteToolTip = new TextMenuExt.EaseInSubMenuWithInputs(
+                        new object[] { Dialog.Clean("MODOPTIONS_MODTOGGLE_TOGGLEFAVORITES_MESSAGE1") + " ",
+                        Input.MenuJournal, " " + Dialog.Clean("MODOPTIONS_MODTOGGLE_TOGGLEFAVORITES_MESSAGE2") },
+                        Input.GuiInputController(), false, menu) { TextColor = Color.Gray };
+
+                    menu.Add(favoriteToolTip);
+
+                    toggleFavoritesButton.OnEnter += delegate {
+                        // make the description appear.
+                        favoriteToolTip.FadeVisible = true;
+                    };
+                    toggleFavoritesButton.OnLeave += delegate {
+                        // make the description disappear.
+                        favoriteToolTip.FadeVisible = false;
+                    };
 
 
                     // "cancel" button to leave the screen without saving

--- a/Celeste.Mod.mm/Mod/UI/OuiModToggler.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiModToggler.cs
@@ -357,28 +357,34 @@ namespace Celeste.Mod.UI {
         }
 
         private void addFileToMenu(TextMenu menu, string file) {
-            TextMenu.OnOff option;
-
             bool enabled = !Everest.Loader.Blacklist.Contains(file);
             bool favorite = Everest.Loader.Favorites.Contains(file);
-            menu.Add(option = (TextMenu.OnOff) new TextMenu.OnOff(file.Length > 40 ? file.Substring(0, 40) + "..." : file, enabled)
-                .Change(b => {
-                    if (b) {
-                        removeFromBlacklist(file);
-                    } else {
-                        addToBlacklist(file);
-                    }
 
-                    updateHighlightedMods();
-                }).AltPressed(() => {
-                    if (favoritedMods.Contains(file)) {
-                        removeFromFavorites(file);
-                    } else {
-                        addToFavorites(file);
-                    }
+            TextMenu.OnOff option = new TextMenu.OnOff(file.Length > 40 ? file.Substring(0, 40) + "..." : file, enabled);
 
-                    updateHighlightedMods();
-                }));
+            option.Change(b => {
+                if (b) {
+                    removeFromBlacklist(file);
+                } else {
+                    addToBlacklist(file);
+                }
+
+                updateHighlightedMods();
+            }).AltPressed(() => {
+                if (!favoritedMods.Contains(file)) {
+                    Audio.Play(SFX.ui_main_button_toggle_on);
+                    addToFavorites(file);
+                } else {
+                    Audio.Play(SFX.ui_main_button_toggle_off);
+                    removeFromFavorites(file);
+                }
+
+                option.SelectWiggler.Start();
+
+                updateHighlightedMods();
+            });
+
+            menu.Add(option);
 
             allMods.Add(file);
             if (!enabled) {

--- a/Celeste.Mod.mm/Mod/UI/OuiModToggler.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiModToggler.cs
@@ -477,13 +477,14 @@ namespace Celeste.Mod.UI {
         }
 
         private void addToFavoritesDependencies(string modFileName, string dependentModFileName) {
-            if (!favoritesDependenciesMods.ContainsKey(modFileName)) {
-                favoritesDependenciesMods[modFileName] = new HashSet<string>();
+            // If we have a cyclical dependencies we want to stop after the first occurrence of a mod, or if somehow we reach ourself.
+            if ((favoritesDependenciesMods.ContainsKey(modFileName) && favoritesDependenciesMods[modFileName].Contains(dependentModFileName))
+                    || modFileName.Equals(dependentModFileName)) {
+                return;
             }
 
-            // If we have a cyclical dependencies we want to stop after the first occurrence of a mod, or if somehow we reach ourself.
-            if (favoritesDependenciesMods[modFileName].Contains(dependentModFileName) || modFileName.Equals(dependentModFileName)) {
-                return;
+            if (!favoritesDependenciesMods.ContainsKey(modFileName)) {
+                favoritesDependenciesMods[modFileName] = new HashSet<string>();
             }
 
             // Add dependent mod

--- a/Celeste.Mod.mm/Mod/UI/OuiModToggler.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiModToggler.cs
@@ -319,7 +319,7 @@ namespace Celeste.Mod.UI {
 
                     // sort the mods list alphabetically, for output in the blacklist.txt file later.
                     allMods.Sort((a, b) => a.ToLowerInvariant().CompareTo(b.ToLowerInvariant()));
-                    
+
                     // clone the list to be able to check if the list changed when leaving the menu.
                     blacklistedModsOriginal = new HashSet<string>(blacklistedMods);
                     favoritedModsOriginal = new HashSet<string>(favoritedMods);
@@ -473,12 +473,17 @@ namespace Celeste.Mod.UI {
             }
         }
 
-        private void addToFavoritesDependencies(string modFileName, string dependentmodFileName) {
+        private void addToFavoritesDependencies(string modFileName, string dependentModFileName) {
             if (!favoritesDependenciesMods.ContainsKey(modFileName)) {
                 favoritesDependenciesMods[modFileName] = new HashSet<string>();
             }
 
-            favoritesDependenciesMods[modFileName].Add(dependentmodFileName);
+            // If we have a cyclical dependencies we want to stop after the first occurrence of a mod.
+            if (favoritesDependenciesMods[modFileName].Contains(dependentModFileName)) {
+                return;
+            }
+
+            favoritesDependenciesMods[modFileName].Add(dependentModFileName);
 
             // I guess we silently fail?
             if (TryGetModDependenciesFileNames(modFileName, out List<string> dependenciesFileNames)) {
@@ -498,17 +503,17 @@ namespace Celeste.Mod.UI {
             }
         }
 
-        private void removeFromFavoritesDependencies(string modFileName, string dependentmodFileName) {
+        private void removeFromFavoritesDependencies(string modFileName, string dependentModFileName) {
             if (favoritesDependenciesMods.ContainsKey(modFileName)) {
-                favoritesDependenciesMods[modFileName].Remove(dependentmodFileName);
+                favoritesDependenciesMods[modFileName].Remove(dependentModFileName);
                 if (favoritesDependenciesMods[modFileName].Count == 0) {
                     favoritesDependenciesMods.Remove(modFileName);
                 }
-            }
 
-            if (TryGetModDependenciesFileNames(modFileName, out List<string> dependenciesFileNames)) {
-                foreach (string dependenciesFileName in dependenciesFileNames) {
-                    removeFromFavoritesDependencies(dependenciesFileName, modFileName);
+                if (TryGetModDependenciesFileNames(modFileName, out List<string> dependenciesFileNames)) {
+                    foreach (string dependenciesFileName in dependenciesFileNames) {
+                        removeFromFavoritesDependencies(dependenciesFileName, modFileName);
+                    }
                 }
             }
         }

--- a/Celeste.Mod.mm/Mod/UI/OuiModToggler.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiModToggler.cs
@@ -16,6 +16,8 @@ namespace Celeste.Mod.UI {
         private List<string> allMods;
         // list of currently blacklisted mods
         private HashSet<string> blacklistedMods;
+        // list of currently favorited mods
+        private HashSet<string> favoritedMods;
         // list of blacklisted mods when the menu was open
         private HashSet<string> blacklistedModsOriginal;
 
@@ -240,7 +242,8 @@ namespace Celeste.Mod.UI {
                     // reset the mods list
                     allMods = new List<string>();
                     blacklistedMods = new HashSet<string>();
-
+                    favoritedMods = new HashSet<string>();
+                    
                     string[] files;
                     bool headerInserted;
 
@@ -325,6 +328,15 @@ namespace Celeste.Mod.UI {
                     }
 
                     updateHighlightedMods();
+                }).AltPressed(() => {
+                    if (favoritedMods.Contains(file)) {
+                        favoritedMods.Remove(file);
+                    } else {
+                        favoritedMods.Add(file);
+                    }
+
+                    modToggles[file].Container.HighlightColor = Color.Pink;
+                    
                 }));
 
             allMods.Add(file);

--- a/Celeste.Mod.mm/Mod/UI/OuiModToggler.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiModToggler.cs
@@ -473,12 +473,12 @@ namespace Celeste.Mod.UI {
             }
         }
 
-        private void addToFavoritesDependencies(string modFileName, string dependentModeFileName) {
+        private void addToFavoritesDependencies(string modFileName, string dependentmodFileName) {
             if (!favoritesDependenciesMods.ContainsKey(modFileName)) {
                 favoritesDependenciesMods[modFileName] = new HashSet<string>();
             }
 
-            favoritesDependenciesMods[modFileName].Add(dependentModeFileName);
+            favoritesDependenciesMods[modFileName].Add(dependentmodFileName);
 
             // I guess we silently fail?
             if (TryGetModDependenciesFileNames(modFileName, out List<string> dependenciesFileNames)) {
@@ -498,9 +498,9 @@ namespace Celeste.Mod.UI {
             }
         }
 
-        private void removeFromFavoritesDependencies(string modFileName, string dependentModeFileName) {
+        private void removeFromFavoritesDependencies(string modFileName, string dependentmodFileName) {
             if (favoritesDependenciesMods.ContainsKey(modFileName)) {
-                favoritesDependenciesMods[modFileName].Remove(dependentModeFileName);
+                favoritesDependenciesMods[modFileName].Remove(dependentmodFileName);
                 if (favoritesDependenciesMods[modFileName].Count == 0) {
                     favoritesDependenciesMods.Remove(modFileName);
                 }
@@ -560,7 +560,7 @@ namespace Celeste.Mod.UI {
                 dependenciesFileNames = new List<string>();
 
                 foreach (EverestModuleMetadata metadata in metadatas) {
-                    // iterate over each loaded mode to ensure its present
+                    // iterate over each loaded mod to ensure its present
                     foreach (string dependencyName in metadata.Dependencies.Select((dep) => dep.Name)) {
                         KeyValuePair<string, EverestModuleMetadata>? found = null;
                         foreach (KeyValuePair<string, EverestModuleMetadata[]> candidateMetadatas in modYamls) {

--- a/Celeste.Mod.mm/Mod/UI/TextMenuExt.cs
+++ b/Celeste.Mod.mm/Mod/UI/TextMenuExt.cs
@@ -1354,7 +1354,6 @@ namespace Celeste {
         }
 
         public class SubMenuWithInputs : TextMenu.Item, IItemExt {
-            public object[] Items { get; set; }
             public Color TextColor { get; set; } = Color.Gray;
             public Color ButtonColor { get; set; } = Color.White;
             public Color StrokeColor { get; set; } = Color.White;
@@ -1364,6 +1363,7 @@ namespace Celeste {
             public float? IconWidth { get; set; }
             public bool IconOutline { get; set; }
             public Vector2 Offset { get; set; }
+            private readonly object[] Items;
 
             public SubMenuWithInputs(string text, char separator, VirtualButton[] buttons) {
 
@@ -1387,7 +1387,7 @@ namespace Celeste {
 
             public override void Render(Vector2 position, bool highlighted) {
                 Vector2 lineOffset = position;
-                Vector2 justify = new Vector2(0f, 0.5f);
+                Vector2 justify = new(0f, 0.5f);
                 float strokeAlpha = Alpha * Alpha * Alpha;
 
 
@@ -1397,7 +1397,7 @@ namespace Celeste {
                         lineOffset.X += ActiveFont.Measure(item as string).X * Scale;
                     } else if (item is VirtualButton) {
                         VirtualButton virtualButton = item as VirtualButton;
-                        MTexture buttonTexture = null;
+                        MTexture buttonTexture;
 
                         if (Input.GuiInputController()) {
                             buttonTexture = Input.GuiButton(virtualButton, Input.PrefixMode.Attached);
@@ -1436,7 +1436,6 @@ namespace Celeste {
                 } else {
                     return base.Height();
                 }
-
             }
 
             public override void Update() {

--- a/Celeste.Mod.mm/Mod/UI/TextMenuExt.cs
+++ b/Celeste.Mod.mm/Mod/UI/TextMenuExt.cs
@@ -1355,7 +1355,6 @@ namespace Celeste {
 
         public class SubMenuWithInputs : TextMenu.Item, IItemExt {
             public object[] Items { get; set; }
-            private Func<bool> ControllerModeCallback;
             public Color TextColor { get; set; } = Color.Gray;
             public Color ButtonColor { get; set; } = Color.White;
             public Color StrokeColor { get; set; } = Color.White;
@@ -1366,12 +1365,10 @@ namespace Celeste {
             public bool IconOutline { get; set; }
             public Vector2 Offset { get; set; }
 
-            public override float Height() {
-                return ActiveFont.LineHeight;
-            }
+            private Func<bool> controllerModeCallback;
 
             public SubMenuWithInputs(string text, char separator, VirtualButton[] buttons, Func<bool> controllerModeCallback) {
-                this.ControllerModeCallback = controllerModeCallback;
+                this.controllerModeCallback = controllerModeCallback;
 
                 string[] parts = text.Split(separator);
                 Items = new object[parts.Length * 2 - 1];
@@ -1387,6 +1384,9 @@ namespace Celeste {
                 }
             }
 
+            public override float Height() {
+                return ActiveFont.LineHeight;
+            }
 
             public override void Render(Vector2 position, bool highlighted) {
                 Vector2 lineOffset = position;
@@ -1402,7 +1402,7 @@ namespace Celeste {
                         VirtualButton virtualButton = item as VirtualButton;
                         MTexture buttonTexture = null;
 
-                        if (this.ControllerModeCallback()) {
+                        if (controllerModeCallback()) {
                             buttonTexture = Input.GuiButton(virtualButton, Input.PrefixMode.Attached);
                         } else if (virtualButton.Binding.Keyboard.Count > 0) {
                             buttonTexture = Input.GuiKey(virtualButton.Binding.Keyboard[0]);
@@ -1411,7 +1411,7 @@ namespace Celeste {
                         }
 
                         buttonTexture.DrawJustified(lineOffset, justify, ButtonColor * strokeAlpha, Scale);
-                        lineOffset.X += (float) buttonTexture.Width * Scale;
+                        lineOffset.X += buttonTexture.Width * Scale;
                     }
                 }
             }
@@ -1420,111 +1420,111 @@ namespace Celeste {
         // this is full of boilerplate code might be replaceable with DispatchProxy once we upgrade .NET
         // https://learn.microsoft.com/en-us/dotnet/api/system.reflection.dispatchproxy?view=net-7.0
         public class EaseInDecorator<T> : TextMenu.Item, IItemExt where T : TextMenu.Item, IItemExt {
-            private T Inner;
+            private T inner;
+            private float uneasedAlpha;
+            private TextMenu containingMenu;
+
             public bool FadeVisible { get; set; } = true;
 
-            private float UneasedAlpha;
-            private TextMenu ContainingMenu;
-
             public EaseInDecorator(T inner, bool initiallyVisible, TextMenu containingMenu) {
-                this.Inner = inner;
-                this.ContainingMenu = containingMenu;
+                this.inner = inner;
+                this.containingMenu = containingMenu;
 
                 FadeVisible = initiallyVisible;
                 Alpha = FadeVisible ? 1 : 0;
-                UneasedAlpha = Alpha;
+                uneasedAlpha = Alpha;
             }
 
-            public Color TextColor { get => Inner.TextColor; set => Inner.TextColor = value; }
-            public string Icon { get => Inner.Icon; set => Inner.Icon = value; }
-            public float? IconWidth { get => Inner.IconWidth; set => Inner.IconWidth = value; }
-            public bool IconOutline { get => Inner.IconOutline; set => Inner.IconOutline = value; }
-            public Vector2 Offset { get => Inner.Offset; set => Inner.Offset = value; }
-            public float Alpha { get => Inner.Alpha; set => Inner.Alpha = value; }
-            new public bool Selectable { get => Inner.Selectable; set => Inner.Selectable = value; }
-            new public bool Visible { get => Inner.Visible; set => Inner.Visible = value; }
+            public Color TextColor { get => inner.TextColor; set => inner.TextColor = value; }
+            public string Icon { get => inner.Icon; set => inner.Icon = value; }
+            public float? IconWidth { get => inner.IconWidth; set => inner.IconWidth = value; }
+            public bool IconOutline { get => inner.IconOutline; set => inner.IconOutline = value; }
+            public Vector2 Offset { get => inner.Offset; set => inner.Offset = value; }
+            public float Alpha { get => inner.Alpha; set => inner.Alpha = value; }
+            new public bool Selectable { get => inner.Selectable; set => inner.Selectable = value; }
+            new public bool Visible { get => inner.Visible; set => inner.Visible = value; }
 
-            new public bool Disabled { get => Inner.Disabled; set => Inner.Disabled = value; }
-            new public bool IncludeWidthInMeasurement { get => Inner.IncludeWidthInMeasurement; set => Inner.IncludeWidthInMeasurement = value; }
-            new public bool AboveAll { get => Inner.AboveAll; set => Inner.AboveAll = value; }
-            new public TextMenu Container { get => Inner.Container; set => Inner.Container = value; }
-            new public Wiggler SelectWiggler { get => Inner.SelectWiggler; set => Inner.SelectWiggler = value; }
-            new public Wiggler ValueWiggler { get => Inner.ValueWiggler; set => Inner.ValueWiggler = value; }
-            new public Action OnEnter { get => Inner.OnEnter; set => Inner.OnEnter = value; }
-            new public Action OnLeave { get => Inner.OnLeave; set => Inner.OnLeave = value; }
-            new public Action OnPressed { get => Inner.OnPressed; set => Inner.OnPressed = value; }
-            new public Action OnAltPressed { get => Inner.OnAltPressed; set => Inner.OnAltPressed = value; }
-            new public Action OnUpdate { get => Inner.OnUpdate; set => Inner.OnUpdate = value; }
+            new public bool Disabled { get => inner.Disabled; set => inner.Disabled = value; }
+            new public bool IncludeWidthInMeasurement { get => inner.IncludeWidthInMeasurement; set => inner.IncludeWidthInMeasurement = value; }
+            new public bool AboveAll { get => inner.AboveAll; set => inner.AboveAll = value; }
+            new public TextMenu Container { get => inner.Container; set => inner.Container = value; }
+            new public Wiggler SelectWiggler { get => inner.SelectWiggler; set => inner.SelectWiggler = value; }
+            new public Wiggler ValueWiggler { get => inner.ValueWiggler; set => inner.ValueWiggler = value; }
+            new public Action OnEnter { get => inner.OnEnter; set => inner.OnEnter = value; }
+            new public Action OnLeave { get => inner.OnLeave; set => inner.OnLeave = value; }
+            new public Action OnPressed { get => inner.OnPressed; set => inner.OnPressed = value; }
+            new public Action OnAltPressed { get => inner.OnAltPressed; set => inner.OnAltPressed = value; }
+            new public Action OnUpdate { get => inner.OnUpdate; set => inner.OnUpdate = value; }
 
 
-            new public float Width { get => Inner.Width; }
+            new public float Width => inner.Width;
 
-            new public bool Hoverable { get => Inner.Hoverable; }
+            new public bool Hoverable => inner.Hoverable;
 
 
             public override void Added() {
-                Inner.Added();
+                inner.Added();
             }
 
             public new TextMenu.Item AltPressed(Action onPressed) {
-                return Inner.AltPressed(onPressed);
+                return inner.AltPressed(onPressed);
             }
 
             public override void ConfirmPressed() {
-                Inner.ConfirmPressed();
+                inner.ConfirmPressed();
             }
 
             public new TextMenu.Item Enter(Action onEnter) {
-                return Inner.Enter(onEnter);
+                return inner.Enter(onEnter);
             }
 
             public override float Height() {
-                return MathHelper.Lerp(-ContainingMenu.ItemSpacing, Inner.Height(), Inner.Alpha);
+                return MathHelper.Lerp(-containingMenu.ItemSpacing, inner.Height(), inner.Alpha);
             }
 
             public new TextMenu.Item Leave(Action onLeave) {
-                return Inner.Leave(onLeave);
+                return inner.Leave(onLeave);
             }
 
             public override void LeftPressed() {
-                Inner.LeftPressed();
+                inner.LeftPressed();
             }
 
             public override float LeftWidth() {
-                return Inner.LeftWidth();
+                return inner.LeftWidth();
             }
 
             public new TextMenu.Item Pressed(Action onPressed) {
-                return Inner.Pressed(onPressed);
+                return inner.Pressed(onPressed);
             }
 
             public override void Render(Vector2 position, bool highlighted) {
-                Inner.Render(position, highlighted);
+                inner.Render(position, highlighted);
             }
 
             public override void RightPressed() {
-                Inner.RightPressed();
+                inner.RightPressed();
             }
 
             public override float RightWidth() {
-                return Inner.RightWidth();
+                return inner.RightWidth();
             }
 
             public override void Update() {
-                Inner.Update();
+                inner.Update();
 
                 // gradually make the sub-header fade in or out. (~333ms fade)
                 float targetAlpha = FadeVisible ? 1 : 0;
-                if (UneasedAlpha != targetAlpha) {
-                    UneasedAlpha = Calc.Approach(UneasedAlpha, targetAlpha, Engine.RawDeltaTime * 3f);
+                if (uneasedAlpha != targetAlpha) {
+                    uneasedAlpha = Calc.Approach(uneasedAlpha, targetAlpha, Engine.RawDeltaTime * 3f);
 
                     if (FadeVisible)
-                        Alpha = Ease.SineOut(UneasedAlpha);
+                        Alpha = Ease.SineOut(uneasedAlpha);
                     else
-                        Alpha = Ease.SineIn(UneasedAlpha);
+                        Alpha = Ease.SineIn(uneasedAlpha);
                 }
 
-                Visible = (Alpha != 0);
+                Visible = Alpha != 0;
             }
         }
     }


### PR DESCRIPTION
Accidently closed #620 
This change adds the ability to select mods as favorites by pressing the journal key in the enable or disable mods menu.
This could help players who want keep some mods always on while toggling other mods, as suggested at #501. 

My main concern was dealing with cyclical mod dependencies, so here are some dependencies graph I tested (all of them work):

```mermaid
graph TD;
    A-->B;
    B-->C;
```

```mermaid
graph TD;
    A-->B;
    B-->C;
C-->A;
```

```mermaid
graph TD;
    D-->B;
    A-->B;
    B-->C;
    B-->E;
    F-->C;
```

```mermaid
graph TD;
    A-->C;
    B-->D;
    C-->D;
    D-->E;
    E-->C;
    E-->G;
    G-->H;
    H-->G;
    C-->F;
```

Basic functionalities are done, but this is a huge mess because I am new to celeste modding.
I would love if someone could review this.