### PR TITLE
Add helper methods for registering `StateMachine` states + names

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Events.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Events.cs
@@ -7,6 +7,8 @@ using _Level = Celeste.Level;
 using _OuiJournal = Celeste.OuiJournal;
 using _OuiMainMenu = Celeste.OuiMainMenu;
 using _Player = Celeste.Player;
+using _Seeker = Celeste.Seeker;
+using _AngryOshiro = Celeste.AngryOshiro;
 
 namespace Celeste.Mod {
     public static partial class Everest {
@@ -168,6 +170,22 @@ namespace Celeste.Mod {
                 public static event Action<_Player> OnDie;
                 internal static void Die(_Player player)
                     => OnDie?.Invoke(player);
+
+                public static event Action<_Player> OnRegisterStates;
+                internal static void RegisterStates(_Player player)
+                    => OnRegisterStates?.Invoke(player);
+            }
+
+            public static class Seeker {
+                public static event Action<_Seeker> OnRegisterStates;
+                internal static void RegisterStates(_Seeker seeker)
+                    => OnRegisterStates?.Invoke(seeker);
+            }
+
+            public static class AngryOshiro {
+                public static event Action<_AngryOshiro> OnRegisterStates;
+                internal static void RegisterStates(_AngryOshiro oshiro)
+                    => OnRegisterStates?.Invoke(oshiro);
             }
 
             public static class Input {

--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -315,6 +315,10 @@ namespace Celeste.Mod {
                     if (Enum.TryParse(queue.Dequeue(), ignoreCase: true, out LogLevel level))
                         Logger.SetLogLevelFromSettings("", level);
                 }
+                
+                else if (arg == "--use-scancodes") {
+                    Environment.SetEnvironmentVariable("FNA_KEYBOARD_USE_SCANCODES", "1");
+                }
             }
         }
 

--- a/Celeste.Mod.mm/Mod/Module/EverestModuleMetadata.cs
+++ b/Celeste.Mod.mm/Mod/Module/EverestModuleMetadata.cs
@@ -88,7 +88,7 @@ namespace Celeste.Mod {
         /// Perform a few basic post-parsing operations. For example, make the DLL path absolute if the mod is in a directory.
         /// </summary>
         public void PostParse() {
-            if (!string.IsNullOrEmpty(DLL) && !string.IsNullOrEmpty(PathDirectory) && !File.Exists(DLL))
+            if (!string.IsNullOrEmpty(DLL) && !string.IsNullOrEmpty(PathDirectory))
                 DLL = Path.Combine(PathDirectory, DLL.Replace('/', Path.DirectorySeparatorChar).Replace('\\', Path.DirectorySeparatorChar));
 
             // Add dependency to API 1.0 if missing.

--- a/Celeste.Mod.mm/Patches/AngryOshiro.cs
+++ b/Celeste.Mod.mm/Patches/AngryOshiro.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Xna.Framework;
+﻿#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value null
+
+using Microsoft.Xna.Framework;
 using Monocle;
 using System;
 using System.Collections;

--- a/Celeste.Mod.mm/Patches/AngryOshiro.cs
+++ b/Celeste.Mod.mm/Patches/AngryOshiro.cs
@@ -8,7 +8,7 @@ using MonoMod;
 using System;
 using System.Collections;
 
-namespace Celeste.Patches {
+namespace Celeste {
     public class patch_AngryOshiro : AngryOshiro {
 
         // We're effectively in AngryOshiro, but still need to "expose" private fields to our mod.

--- a/Celeste.Mod.mm/Patches/AngryOshiro.cs
+++ b/Celeste.Mod.mm/Patches/AngryOshiro.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.Xna.Framework;
+using Monocle;
+using System;
+using System.Collections;
+
+namespace Celeste.Patches {
+    public class patch_AngryOshiro : AngryOshiro {
+
+        // We're effectively in AngryOshiro, but still need to "expose" private fields to our mod.
+        private StateMachine state;
+
+        public patch_AngryOshiro(EntityData data, Vector2 offset)
+            : base(data, offset) {
+            // no-op. MonoMod ignores this - we only need this to make the compiler shut up.
+        }
+
+        /// <summary>
+        /// Adds a new state to this oshiro with the given behaviour, and returns the index of the new state.
+        ///
+        /// States should always be added at the end of the <c>AngryOshiro(Vector2, bool)</c> constructor.
+        /// </summary>
+        /// <param name="name">The name of this state, for display purposes by mods only.</param>
+        /// <param name="onUpdate">A function to run every frame during this state, returning the index of the state that should be switched to next frame.</param>
+        /// <param name="coroutine">A function that creates a coroutine to run when this state is switched to.</param>
+        /// <param name="begin">An action to run when this state is switched to.</param>
+        /// <param name="end">An action to run when this state ends.</param>
+        /// <returns>The index of the new state.</returns>
+        public int AddState(string name, Func<AngryOshiro, int> onUpdate, Func<AngryOshiro, IEnumerator> coroutine = null, Action<AngryOshiro> begin = null, Action<AngryOshiro> end = null){
+            return ((patch_StateMachine)state).AddState(name, onUpdate, coroutine, begin, end);
+        }
+    }
+}

--- a/Celeste.Mod.mm/Patches/Audio.cs
+++ b/Celeste.Mod.mm/Patches/Audio.cs
@@ -33,8 +33,11 @@ namespace Celeste {
         private static HashSet<string> ingestedModBankPaths = new HashSet<string>();
         public static bool AudioInitialized { get; private set; } = false;
 
-        [MonoModIgnore]
-        internal static extern void CheckFmod(RESULT result);
+        [MonoModReplace]
+        internal static void CheckFmod(RESULT result) {
+            if (result != RESULT.OK)
+                throw new Exception($"FMOD Failed: {result} ({Error.String(result)})");
+        }
 
         public static extern void orig_Init();
         public static void Init() {

--- a/Celeste.Mod.mm/Patches/Monocle/Engine.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Engine.cs
@@ -7,7 +7,6 @@ using MonoMod;
 using MonoMod.Cil;
 using MonoMod.Utils;
 using System;
-using System.Linq;
 
 namespace Monocle {
     class patch_Engine : Engine {
@@ -59,12 +58,16 @@ namespace Monocle {
         protected override extern void Update(GameTime gameTime);
 
         private static float GetTimeRateComponentMultiplier(Scene scene) {
-            return scene?.Tracker.GetComponents<TimeRateModifier>()
-                                 .Cast<TimeRateModifier>()
-                                 .Where(trm => trm.Enabled)
-                                 .Select(trm => trm.Multiplier)
-                                 .Aggregate(1f, (acc, val) => acc * val)
-                   ?? 1;
+            if (scene == null)
+                return 1f;
+
+            float result = 1f;
+            foreach (TimeRateModifier trm in scene.Tracker.GetComponents<TimeRateModifier>()) {
+                if (trm.Enabled)
+                    result *= trm.Multiplier;
+            }
+
+            return result;
         }
 
     }
@@ -104,19 +107,19 @@ namespace Monocle {
 }
 
 namespace MonoMod {
-    
+
     /// <summary>
     /// Patch the method to apply TimeRateModifier multipliers.
     /// </summary>
     [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchEngineUpdate))]
     class PatchEngineUpdateAttribute : Attribute { }
-    
+
     static partial class MonoModRules {
         public static void PatchEngineUpdate(ILContext context, CustomAttribute attrib) {
             TypeDefinition t_Engine = context.Method.DeclaringType;
             FieldReference f_scene = t_Engine.FindField("scene");
             MethodReference m_GetTimeRateComponentMultiplier = t_Engine.FindMethod("GetTimeRateComponentMultiplier");
-            
+
             ILCursor cursor = new ILCursor(context);
             // multiply time rate with GetTimeRateComponentMultiplier(scene)
             cursor.GotoNext(MoveType.After, instr => instr.MatchLdsfld("Monocle.Engine", "TimeRateB"),

--- a/Celeste.Mod.mm/Patches/Monocle/StateMachine.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/StateMachine.cs
@@ -1,4 +1,6 @@
-﻿using MonoMod;
+﻿#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
+
+using MonoMod;
 using System;
 using System.Collections;
 

--- a/Celeste.Mod.mm/Patches/Monocle/StateMachine.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/StateMachine.cs
@@ -23,44 +23,94 @@ namespace Monocle {
         
         private int Expand() {
             int nextIdx = begins.Length;
-            
-            Array.Resize(ref begins, begins.Length + 1);
-            Array.Resize(ref updates, updates.Length + 1);
-            Array.Resize(ref ends, ends.Length + 1);
-            Array.Resize(ref coroutines, coroutines.Length + 1);
-            Array.Resize(ref names, names.Length + 1);
+
+            int newLength = begins.Length + 1;
+            Array.Resize(ref begins, newLength);
+            Array.Resize(ref updates, newLength);
+            Array.Resize(ref ends, newLength);
+            Array.Resize(ref coroutines, newLength);
+            Array.Resize(ref names, newLength);
 
             return nextIdx;
         }
-
-        private extern void orig_SetCallbacks(int state, Func<int> onUpdate, Func<IEnumerator> coroutine = null, Action begin = null, Action end = null);
-        public void SetCallbacks(
-            int state,
-            Func<int> onUpdate,
-            Func<IEnumerator> coroutine = null,
-            Action begin = null,
-            Action end = null) {
-            orig_SetCallbacks(state, onUpdate, coroutine, begin, end);
-            names[state] ??= state.ToString();
+        
+        /// <summary>
+        /// Adds a new state to this state machine with the given behaviour, and returns the index of the new state.
+        /// </summary>
+        /// <param name="name">The name of this state, for display purposes by mods only.</param>
+        /// <param name="onUpdate">A function to run every frame during this state, returning the index of the state that should be switched to next frame.</param>
+        /// <param name="coroutine">A function that creates a coroutine to run when this state is switched to.</param>
+        /// <param name="begin">An action to run when this state is switched to.</param>
+        /// <param name="end">An action to run when this state ends.</param>
+        /// <returns>The index of the new state.</returns>
+        public int AddState(string name, Func<int> onUpdate, Func<IEnumerator> coroutine = null, Action begin = null, Action end = null){
+            int nextIdx = Expand();
+            SetCallbacks(nextIdx, onUpdate, coroutine, begin, end);
+            names[nextIdx] = name;
+            return nextIdx;
         }
         
         /// <summary>
-        /// Adds a state to this StateMachine.
+        /// Adds a new state to this state machine with the given behaviour, providing access to the entity running this state machine.
+        ///
+        /// It's preferable to use the <c>AddState</c> methods provided in <c>Player</c>, <c>AngryOshiro</c>, and <c>Seeker</c> than to use this directly, as
+        /// they ensure the correct type is used. If the entity has the wrong type, then these functions are given <c>null</c>.
         /// </summary>
+        /// <param name="name">The name of this state, for display purposes by mods only.</param>
+        /// <param name="onUpdate">A function to run every frame during this state, returning the index of the state that should be switched to next frame.</param>
+        /// <param name="coroutine">A function that creates a coroutine to run when this state is switched to.</param>
+        /// <param name="begin">An action to run when this state is switched to.</param>
+        /// <param name="end">An action to run when this state ends.</param>
+        /// <typeparam name="E">The type of the entity that these functions run on. If the entity has the wrong type, the functions are given <c>null</c>.</typeparam>
         /// <returns>The index of the new state.</returns>
-        public int AddState(string name, Func<Entity, int> onUpdate, Func<Entity, IEnumerator> coroutine = null, Action<Entity> begin = null, Action<Entity> end = null){
+        public int AddState<E>(string name, Func<E, int> onUpdate, Func<E, IEnumerator> coroutine = null, Action<E> begin = null, Action<E> end = null)
+            where E : Entity
+        {
             int nextIdx = Expand();
-            SetCallbacks(nextIdx, () => onUpdate(Entity),
-                coroutine == null ? null : () =>  coroutine(Entity),
-                begin == null ? null : () => begin(Entity),
-                end == null ? null : () => end(Entity));
+            SetCallbacks(nextIdx, () => onUpdate(Entity as E),
+                coroutine == null ? null : () =>  coroutine(Entity as E),
+                begin == null ? null : () => begin(Entity as E),
+                end == null ? null : () => end(Entity as E));
             names[nextIdx] = name;
             return nextIdx;
         }
 
-        public string GetStateName(int state) => names[state];
-        public void SetStateName(int state, string name) => names[state] = name;
-        
-        public string GetCurrentStateName() => names[State];
+        // Mods that expand the state machine manually won't increase the size of `names`, so we need to bounds-check
+        // accesses ourselves, both against `begins` ("is it an actual valid state") and `names` ("does it have a coherent name")
+        private void CheckBounds(int state) {
+            if (!(state < begins.Length && state >= 0))
+                throw new IndexOutOfRangeException($"State {state} is out of range, maximum is {begins.Length}.");
+        }
+
+        /// <summary>
+        /// Returns the name of the state with the given index, which defaults to the index in string form.
+        /// These names are for display purposes by mods only.
+        /// </summary>
+        /// <param name="state">The index of the state.</param>
+        /// <returns>The display name of that state.</returns>
+        public string GetStateName(int state) {
+            CheckBounds(state);
+            return (state < names.Length ? names[state] : null) ?? state.ToString();
+        }
+
+        /// <summary>
+        /// Sets the name of the state with the given index.
+        /// These names are for display purposes by mods only.
+        /// </summary>
+        /// <param name="state">The index of the state.</param>
+        /// <param name="name">The new display name it should use.</param>
+        public void SetStateName(int state, string name) {
+            CheckBounds(state);
+            if (state >= names.Length)
+                Array.Resize(ref names, state + 1);
+            names[state] = name;
+        }
+
+        /// <summary>
+        /// Returns the name of the current state, which defaults to the index in string form.
+        /// These names are for display purposes by mods only.
+        /// </summary>
+        /// <returns>The display name of the current state.</returns>
+        public string GetCurrentStateName() => GetStateName(State);
     }
 }

--- a/Celeste.Mod.mm/Patches/Monocle/StateMachine.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/StateMachine.cs
@@ -41,7 +41,7 @@ namespace Monocle {
             Action begin = null,
             Action end = null) {
             orig_SetCallbacks(state, onUpdate, coroutine, begin, end);
-            names[state] = state.ToString();
+            names[state] ??= state.ToString();
         }
         
         /// <summary>

--- a/Celeste.Mod.mm/Patches/Monocle/StateMachine.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/StateMachine.cs
@@ -1,9 +1,8 @@
-﻿using Monocle;
-using MonoMod;
+﻿using MonoMod;
 using System;
 using System.Collections;
 
-namespace Celeste {
+namespace Monocle {
     public class patch_StateMachine : StateMachine {
 
         // We're effectively in StateMachine, but still need to "expose" private fields to our mod.
@@ -51,10 +50,10 @@ namespace Celeste {
         /// <returns>The index of the new state.</returns>
         public int AddState(string name, Func<Entity, int> onUpdate, Func<Entity, IEnumerator> coroutine = null, Action<Entity> begin = null, Action<Entity> end = null){
             int nextIdx = Expand();
-            SetCallbacks(nextIdx, Helper.WrapFunc(onUpdate, this),
-                Helper.WrapFunc(coroutine, this),
-                Helper.WrapAction(begin, this),
-                Helper.WrapAction(end, this));
+            SetCallbacks(nextIdx, () => onUpdate(Entity),
+                coroutine == null ? null : () =>  coroutine(Entity),
+                begin == null ? null : () => begin(Entity),
+                end == null ? null : () => end(Entity));
             names[nextIdx] = name;
             return nextIdx;
         }
@@ -63,10 +62,5 @@ namespace Celeste {
         public void SetStateName(int state, string name) => names[state] = name;
         
         public string GetCurrentStateName() => names[State];
-    }
-
-    internal static class Helper {
-        internal static Func<T> WrapFunc<T>(Func<Entity, T> f, Component c) => f == null ? null : () => f(c.Entity);
-        internal static Action WrapAction(Action<Entity> a, Component c) => a == null ? null : () => a(c.Entity);
     }
 }

--- a/Celeste.Mod.mm/Patches/Monocle/StateMachine.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/StateMachine.cs
@@ -14,7 +14,7 @@ namespace Monocle {
         // Keep track of state's names.
         private string[] names;
 
-        public extern void orig_ctor(int maxStates = 10);
+        private extern void orig_ctor(int maxStates = 10);
         [MonoModConstructor]
         public void ctor(int maxStates = 10) {
             orig_ctor(maxStates);
@@ -33,7 +33,7 @@ namespace Monocle {
             return nextIdx;
         }
 
-        public extern void orig_SetCallbacks(int state, Func<int> onUpdate, Func<IEnumerator> coroutine = null, Action begin = null, Action end = null);
+        private extern void orig_SetCallbacks(int state, Func<int> onUpdate, Func<IEnumerator> coroutine = null, Action begin = null, Action end = null);
         public void SetCallbacks(
             int state,
             Func<int> onUpdate,
@@ -58,7 +58,7 @@ namespace Monocle {
             return nextIdx;
         }
 
-        public string GetState(int state) => names[state];
+        public string GetStateName(int state) => names[state];
         public void SetStateName(int state, string name) => names[state] = name;
         
         public string GetCurrentStateName() => names[State];

--- a/Celeste.Mod.mm/Patches/Player.cs
+++ b/Celeste.Mod.mm/Patches/Player.cs
@@ -14,6 +14,7 @@ using Mono.Cecil.Cil;
 using MonoMod.Cil;
 using MonoMod.InlineRT;
 using MonoMod.Utils;
+using System.Collections;
 
 namespace Celeste {
     class patch_Player : Player {
@@ -178,6 +179,21 @@ namespace Celeste {
             if (Sprite.Mode == PlayerSpriteMode.MadelineAsBadeline)
                 return wasDashB ? NormalBadelineHairColor : UsedBadelineHairColor;
             return wasDashB ? NormalHairColor : UsedHairColor;
+        }
+        
+        /// <summary>
+        /// Adds a new state to this player with the given behaviour, and returns the index of the new state.
+        ///
+        /// States should always be added at the end of the <c>Player</c> constructor.
+        /// </summary>
+        /// <param name="name">The name of this state, for display purposes by mods only.</param>
+        /// <param name="onUpdate">A function to run every frame during this state, returning the index of the state that should be switched to next frame.</param>
+        /// <param name="coroutine">A function that creates a coroutine to run when this state is switched to.</param>
+        /// <param name="begin">An action to run when this state is switched to.</param>
+        /// <param name="end">An action to run when this state ends.</param>
+        /// <returns>The index of the new state.</returns>
+        public int AddState(string name, Func<Player, int> onUpdate, Func<Player, IEnumerator> coroutine = null, Action<Player> begin = null, Action<Player> end = null){
+            return ((patch_StateMachine)StateMachine).AddState(name, onUpdate, coroutine, begin, end);
         }
 
         public Vector2 ExplodeLaunch(Vector2 from, bool snapUp = true) {

--- a/Celeste.Mod.mm/Patches/Seeker.cs
+++ b/Celeste.Mod.mm/Patches/Seeker.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.Xna.Framework;
+using Monocle;
+using System;
+using System.Collections;
+
+namespace Celeste.Patches {
+    public class patch_Seeker : Seeker {
+        
+        // We're effectively in Seeker, but still need to "expose" private fields to our mod.
+        private StateMachine State;
+        
+        // no-op - only here to make
+        public patch_Seeker(EntityData data, Vector2 offset)
+            : base(data, offset) {
+            // no-op. MonoMod ignores this - we only need this to make the compiler shut up.
+        }
+        
+        /// <summary>
+        /// Adds a new state to this seeker with the given behaviour, and returns the index of the new state.
+        ///
+        /// States should always be added at the end of the <c>Seeker(Vector2, Vector2[])</c> constructor.
+        /// </summary>
+        /// <param name="name">The name of this state, for display purposes by mods only.</param>
+        /// <param name="onUpdate">A function to run every frame during this state, returning the index of the state that should be switched to next frame.</param>
+        /// <param name="coroutine">A function that creates a coroutine to run when this state is switched to.</param>
+        /// <param name="begin">An action to run when this state is switched to.</param>
+        /// <param name="end">An action to run when this state ends.</param>
+        /// <returns>The index of the new state.</returns>
+        public int AddState(string name, Func<Seeker, int> onUpdate, Func<Seeker, IEnumerator> coroutine = null, Action<Seeker> begin = null, Action<Seeker> end = null){
+            return ((patch_StateMachine)State).AddState(name, onUpdate, coroutine, begin, end);
+        }
+    }
+}

--- a/Celeste.Mod.mm/Patches/Seeker.cs
+++ b/Celeste.Mod.mm/Patches/Seeker.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Xna.Framework;
+﻿#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value null
+
+using Microsoft.Xna.Framework;
 using Monocle;
 using System;
 using System.Collections;

--- a/Celeste.Mod.mm/Patches/Seeker.cs
+++ b/Celeste.Mod.mm/Patches/Seeker.cs
@@ -8,7 +8,7 @@ using MonoMod;
 using System;
 using System.Collections;
 
-namespace Celeste.Patches {
+namespace Celeste {
     public class patch_Seeker : Seeker {
 
         // We're effectively in Seeker, but still need to "expose" private fields to our mod.

--- a/Celeste.Mod.mm/Patches/Seeker.cs
+++ b/Celeste.Mod.mm/Patches/Seeker.cs
@@ -1,22 +1,43 @@
-﻿#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value null
+﻿#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
+#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value null
 
+using Celeste.Mod;
 using Microsoft.Xna.Framework;
 using Monocle;
+using MonoMod;
 using System;
 using System.Collections;
 
 namespace Celeste.Patches {
     public class patch_Seeker : Seeker {
-        
+
         // We're effectively in Seeker, but still need to "expose" private fields to our mod.
         private StateMachine State;
-        
+
         // no-op - only here to make
         public patch_Seeker(EntityData data, Vector2 offset)
             : base(data, offset) {
             // no-op. MonoMod ignores this - we only need this to make the compiler shut up.
         }
-        
+
+        public extern void orig_ctor(Vector2 position, Vector2[] patrolPoints);
+        [MonoModConstructor]
+        public void ctor(Vector2 position, Vector2[] patrolPoints) {
+            orig_ctor(position, patrolPoints);
+
+            // setup vanilla state names
+            ((patch_StateMachine) State).SetStateName(0, "Idle");
+            ((patch_StateMachine) State).SetStateName(1, "Patrol");
+            ((patch_StateMachine) State).SetStateName(2, "Spotted");
+            ((patch_StateMachine) State).SetStateName(3, "Attack");
+            ((patch_StateMachine) State).SetStateName(4, "Stunned");
+            ((patch_StateMachine) State).SetStateName(5, "Skidding");
+            ((patch_StateMachine) State).SetStateName(6, "Regenerate");
+            ((patch_StateMachine) State).SetStateName(7, "Returned");
+            // then allow mods to register new ones
+            Everest.Events.Seeker.RegisterStates(this);
+        }
+
         /// <summary>
         /// Adds a new state to this seeker with the given behaviour, and returns the index of the new state.
         ///

--- a/Celeste.Mod.mm/Patches/StateMachine.cs
+++ b/Celeste.Mod.mm/Patches/StateMachine.cs
@@ -51,10 +51,10 @@ namespace Celeste {
         /// <returns>The index of the new state.</returns>
         public int AddState(string name, Func<Entity, int> onUpdate, Func<Entity, IEnumerator> coroutine = null, Action<Entity> begin = null, Action<Entity> end = null){
             int nextIdx = Expand();
-            SetCallbacks(nextIdx, () => onUpdate(Entity),
-                () => coroutine?.Invoke(Entity),
-                () => begin?.Invoke(Entity),
-                () => end?.Invoke(Entity));
+            SetCallbacks(nextIdx, Helper.WrapFunc(onUpdate, this),
+                Helper.WrapFunc(coroutine, this),
+                Helper.WrapAction(begin, this),
+                Helper.WrapAction(end, this));
             names[nextIdx] = name;
             return nextIdx;
         }
@@ -63,5 +63,10 @@ namespace Celeste {
         public void SetStateName(int state, string name) => names[state] = name;
         
         public string GetCurrentStateName() => names[State];
+    }
+
+    internal static class Helper {
+        internal static Func<T> WrapFunc<T>(Func<Entity, T> f, Component c) => f == null ? null : () => f(c.Entity);
+        internal static Action WrapAction(Action<Entity> a, Component c) => a == null ? null : () => a(c.Entity);
     }
 }

--- a/Celeste.Mod.mm/Patches/StateMachine.cs
+++ b/Celeste.Mod.mm/Patches/StateMachine.cs
@@ -1,0 +1,67 @@
+﻿using Monocle;
+using MonoMod;
+using System;
+using System.Collections;
+
+namespace Celeste {
+    public class patch_StateMachine : StateMachine {
+
+        // We're effectively in StateMachine, but still need to "expose" private fields to our mod.
+        private Action[] begins;
+        private Func<int>[] updates;
+        private Action[] ends;
+        private Func<IEnumerator>[] coroutines;
+        
+        // Keep track of state's names.
+        private string[] names;
+
+        public extern void orig_ctor(int maxStates = 10);
+        [MonoModConstructor]
+        public void ctor(int maxStates = 10) {
+            orig_ctor(maxStates);
+            names = new string[maxStates];
+        }
+        
+        private int Expand() {
+            int nextIdx = begins.Length;
+            
+            Array.Resize(ref begins, begins.Length + 1);
+            Array.Resize(ref updates, updates.Length + 1);
+            Array.Resize(ref ends, ends.Length + 1);
+            Array.Resize(ref coroutines, coroutines.Length + 1);
+            Array.Resize(ref names, names.Length + 1);
+
+            return nextIdx;
+        }
+
+        public extern void orig_SetCallbacks(int state, Func<int> onUpdate, Func<IEnumerator> coroutine = null, Action begin = null, Action end = null);
+        public void SetCallbacks(
+            int state,
+            Func<int> onUpdate,
+            Func<IEnumerator> coroutine = null,
+            Action begin = null,
+            Action end = null) {
+            orig_SetCallbacks(state, onUpdate, coroutine, begin, end);
+            names[state] = state.ToString();
+        }
+        
+        /// <summary>
+        /// Adds a state to this StateMachine.
+        /// </summary>
+        /// <returns>The index of the new state.</returns>
+        public int AddState(string name, Func<Entity, int> onUpdate, Func<Entity, IEnumerator> coroutine = null, Action<Entity> begin = null, Action<Entity> end = null){
+            int nextIdx = Expand();
+            SetCallbacks(nextIdx, () => onUpdate(Entity),
+                () => coroutine?.Invoke(Entity),
+                () => begin?.Invoke(Entity),
+                () => end?.Invoke(Entity));
+            names[nextIdx] = name;
+            return nextIdx;
+        }
+
+        public string GetState(int state) => names[state];
+        public void SetStateName(int state, string name) => names[state] = name;
+        
+        public string GetCurrentStateName() => names[State];
+    }
+}


### PR DESCRIPTION
This adds methods for adding states to `StateMachine`s without using reflection (on `StateMachine` itself or `Seeker`/`AngryOshiro`). It also allows you to give names to states, so mods don't need mod-specific interop for that.

Example usage:
```cs
public static int StSpin;

public override void Load(){
	On.Celeste.Player.ctor += OnPlayerConstruct;
}

public override void Unload(){
	On.Celeste.Player.ctor -= OnPlayerConstruct;
}

private static void OnPlayerConstruct(On.Celeste.Player.orig_ctor orig, Player self, Vector2 position, PlayerSpriteMode spritemode){
	orig(self, position, spritemode);
	StSpin = self.AddState("StateMachineTest:spin", PlayerSpinUpdate);
}

private static int PlayerSpinUpdate(Player p){
	p.Sprite.Rotation += Engine.DeltaTime;
	return StSpin;
}

[Command("smt_start_spin", "Enter StateMachineTest's spin state")]
public static void StartSpinCommand(){
	if(Engine.Scene is not Level scene)
		return;
	Player entity = scene.Tracker.GetEntity<Player>();
	if(entity == null)
		return;

	entity.StateMachine.State = StSpin;
}

[Command("smt_log_state", "Log the player's current state ID & name")]
public static void LogStateCommand(){
	if(Engine.Scene is not Level scene)
		return;
	Player entity = scene.Tracker.GetEntity<Player>();
	if(entity == null)
		return;

	Engine.Commands.Log("state id: " + (int)entity.StateMachine);
	Engine.Commands.Log("state name: " + entity.StateMachine.GetCurrentStateName());
}
```

A few open questions:
- Should vanilla states be given names?
- Originally I wanted to include a way to add "tags" or some metadata to states, so mods could ask e.g. "should I treat this state like a feather, dash, booster, dream dash..." uniformly. But there's already ways of checking specific information (like dash attacking) that's more relevant, and it added a lot of complexity. Would anything similar still be wanted?
- Currently, you still need to hook constructors to add states; for `Seeker`/`AngryOshiro`, you need to make sure you hook the right one. Should an event be added to let you avoid hooks entirely?
- Is the generic version of `AddState` necessary? Are any of the specialized versions necessary?