### PR TITLE
Fix LoadLevel crashing on missing level

### DIFF
--- a/Celeste.Mod.mm/Patches/Level.cs
+++ b/Celeste.Mod.mm/Patches/Level.cs
@@ -225,7 +225,7 @@ namespace Celeste {
                     }
                 }
 
-                Logger.Log(LogLevel.Warn, "LoadLevel", $"Failed loading room {Session.LevelData.Name} of {Session.Area.GetSID()}");
+                Logger.Log(LogLevel.Warn, "LoadLevel", $"Failed loading room {Session.Level} of {Session.Area.GetSID()}");
                 e.LogDetailed();
                 return;
             }

--- a/Celeste.Mod.mm/Patches/LevelLoader.cs
+++ b/Celeste.Mod.mm/Patches/LevelLoader.cs
@@ -195,7 +195,7 @@ namespace Celeste {
 
         [MonoModIgnore] // We don't want to change anything about the method...
         [PatchLoadingThreadAddEvent] // ... except for manually manipulating the method via MonoModRules
-        [PatchLoadingThreadAddSubHudRenderer] 
+        [PatchLoadingThreadAddSubHudRenderer]
         private extern void LoadingThread();
 
         private void LoadingThread_Safe() {
@@ -214,14 +214,14 @@ namespace Celeste {
                                 break;
                             }
                         }
-                        
+
                         string type = "";
                         if (e.TypeInStacktrace(typeof(SolidTiles))) {
                             type = "fg";
                         } else if (e.TypeInStacktrace(typeof(BackgroundTiles))) {
                             type = "bg";
                         }
-                        
+
                         patch_LevelEnter.ErrorMessage = Dialog.Get("postcard_badtileid")
                             .Replace("((type))", type).Replace("((id))", ex.ID.ToString()).Replace("((x))", ex.X.ToString())
                             .Replace("((y))", ex.Y.ToString()).Replace("((room))", room).Replace("((sid))", sid);
@@ -248,9 +248,16 @@ namespace Celeste {
             base_Update();
             if (Loaded && !started) {
                 if (patch_LevelEnter.ErrorMessage == null) {
-                    StartLevel();
-                }
-                else {
+                    try {
+                        StartLevel();
+                    } catch (Exception e) {
+                        string SID = session.Area.GetSID();
+                        patch_LevelEnter.ErrorMessage = Dialog.Get("postcard_levelloadfailed").Replace("((sid))", SID);
+                        Logger.Log(LogLevel.Warn, "LevelLoader", $"Failed Starting Level at room {session.Level} of {SID}");
+                        e.LogDetailed();
+                        LevelEnter.Go(session, false);
+                    }
+                } else {
                     LevelEnter.Go(session, false); // We encountered an error, so display the error screen
                 }
             }

--- a/Celeste.Mod.mm/Patches/LevelLoader.cs
+++ b/Celeste.Mod.mm/Patches/LevelLoader.cs
@@ -195,7 +195,7 @@ namespace Celeste {
 
         [MonoModIgnore] // We don't want to change anything about the method...
         [PatchLoadingThreadAddEvent] // ... except for manually manipulating the method via MonoModRules
-        [PatchLoadingThreadAddSubHudRenderer] 
+        [PatchLoadingThreadAddSubHudRenderer]
         private extern void LoadingThread();
 
         private void LoadingThread_Safe() {
@@ -214,14 +214,14 @@ namespace Celeste {
                                 break;
                             }
                         }
-                        
+
                         string type = "";
                         if (e.TypeInStacktrace(typeof(SolidTiles))) {
                             type = "fg";
                         } else if (e.TypeInStacktrace(typeof(BackgroundTiles))) {
                             type = "bg";
                         }
-                        
+
                         patch_LevelEnter.ErrorMessage = Dialog.Get("postcard_badtileid")
                             .Replace("((type))", type).Replace("((id))", ex.ID.ToString()).Replace("((x))", ex.X.ToString())
                             .Replace("((y))", ex.Y.ToString()).Replace("((room))", room).Replace("((sid))", sid);
@@ -240,8 +240,19 @@ namespace Celeste {
         [MonoModLinkTo("Monocle.Scene", "System.Void Update()")]
         public extern void base_Update();
 
-        [MonoModIgnore]
-        private extern void StartLevel();
+        private extern void orig_StartLevel();
+
+        private void StartLevel() {
+            try {
+                orig_StartLevel();
+            } catch (Exception e) {
+                string SID = session.Area.GetSID();
+                patch_LevelEnter.ErrorMessage = Dialog.Get("postcard_levelloadfailed").Replace("((sid))", SID);
+                Logger.Log(LogLevel.Warn, "LevelLoader", $"Failed Starting Level at room {session.Level} of {SID}");
+                e.LogDetailed();
+                LevelEnter.Go(session, false);
+            }
+        }
 
         [MonoModReplace]
         public override void Update() {
@@ -249,8 +260,7 @@ namespace Celeste {
             if (Loaded && !started) {
                 if (patch_LevelEnter.ErrorMessage == null) {
                     StartLevel();
-                }
-                else {
+                } else {
                     LevelEnter.Go(session, false); // We encountered an error, so display the error screen
                 }
             }

--- a/Celeste.Mod.mm/Patches/LevelLoader.cs
+++ b/Celeste.Mod.mm/Patches/LevelLoader.cs
@@ -195,7 +195,7 @@ namespace Celeste {
 
         [MonoModIgnore] // We don't want to change anything about the method...
         [PatchLoadingThreadAddEvent] // ... except for manually manipulating the method via MonoModRules
-        [PatchLoadingThreadAddSubHudRenderer]
+        [PatchLoadingThreadAddSubHudRenderer] 
         private extern void LoadingThread();
 
         private void LoadingThread_Safe() {
@@ -214,14 +214,14 @@ namespace Celeste {
                                 break;
                             }
                         }
-
+                        
                         string type = "";
                         if (e.TypeInStacktrace(typeof(SolidTiles))) {
                             type = "fg";
                         } else if (e.TypeInStacktrace(typeof(BackgroundTiles))) {
                             type = "bg";
                         }
-
+                        
                         patch_LevelEnter.ErrorMessage = Dialog.Get("postcard_badtileid")
                             .Replace("((type))", type).Replace("((id))", ex.ID.ToString()).Replace("((x))", ex.X.ToString())
                             .Replace("((y))", ex.Y.ToString()).Replace("((room))", room).Replace("((sid))", sid);
@@ -240,19 +240,8 @@ namespace Celeste {
         [MonoModLinkTo("Monocle.Scene", "System.Void Update()")]
         public extern void base_Update();
 
-        private extern void orig_StartLevel();
-
-        private void StartLevel() {
-            try {
-                orig_StartLevel();
-            } catch (Exception e) {
-                string SID = session.Area.GetSID();
-                patch_LevelEnter.ErrorMessage = Dialog.Get("postcard_levelloadfailed").Replace("((sid))", SID);
-                Logger.Log(LogLevel.Warn, "LevelLoader", $"Failed Starting Level at room {session.Level} of {SID}");
-                e.LogDetailed();
-                LevelEnter.Go(session, false);
-            }
-        }
+        [MonoModIgnore]
+        private extern void StartLevel();
 
         [MonoModReplace]
         public override void Update() {
@@ -260,7 +249,8 @@ namespace Celeste {
             if (Loaded && !started) {
                 if (patch_LevelEnter.ErrorMessage == null) {
                     StartLevel();
-                } else {
+                }
+                else {
                     LevelEnter.Go(session, false); // We encountered an error, so display the error screen
                 }
             }


### PR DESCRIPTION
As requested at #626.
In: https://github.com/EverestAPI/Everest/blob/fdc6ddbf3f897799cff2a5e3c0ac72514621d64e/Celeste.Mod.mm/Patches/Level.cs#L228 
we took the name of the level from `Session.LevelData.Name`, but we fail because the level name was changed, now we take the level name directly from the `Session` object.