### PR TITLE
Fix update notification not showing on older installs

### DIFF
--- a/Celeste.Mod.mm/Mod/Core/CoreModuleSettings.cs
+++ b/Celeste.Mod.mm/Mod/Core/CoreModuleSettings.cs
@@ -288,8 +288,13 @@ namespace Celeste.Mod.Core {
         [SettingIgnore]
         public string CurrentVersion { get; set; }
 
+        private string _CurrentBranch;
+
         [SettingIgnore]
-        public string CurrentBranch { get; set; }
+        public string CurrentBranch {
+            get => _CurrentBranch;
+            set => _CurrentBranch = value is "dev" or "beta" or "stable" ? "updater_src_" + value : value; // branch names were changed at some point
+        }
 
         [SettingIgnore]
         public Dictionary<string, LogLevel> LogLevels { get; set; } = new Dictionary<string, LogLevel>();


### PR DESCRIPTION
The recent updater rework changed the internal names of the updater sources, thus obsoleting the saved settings and preventing the updater notification from showing up until the branch name is updated by an in-game Everest update. This PR fixes that by translating the old branch names into their new versions when deserializing the settings.