### PR TITLE
Fixed FNA color patch

### DIFF
--- a/Celeste.Mod.mm/Patches/FNA/Color.cs
+++ b/Celeste.Mod.mm/Patches/FNA/Color.cs
@@ -6,11 +6,19 @@ namespace Microsoft.Xna.Framework {
 
         // The following signatures existed in older versions of FNA when they shouldn't have.
 
-        [MonoModLinkFrom("System.Void Microsoft.Xna.Framework.Color::.ctor(Microsoft.Xna.Framework.Color,System.Int32)")]
-        public static Color NewColor(Color color, int alpha) => new Color(color.R, color.G, color.B, alpha);
+        [MonoModConstructor] // we want to call the original constructor
+        [MonoModIgnore] // this is necessary to prevent Monomod from generating redundant orig_ctor
+        public extern void ctor(int r, int g, int b, int alpha);
 
-        [MonoModLinkFrom("System.Void Microsoft.Xna.Framework.Color::.ctor(Microsoft.Xna.Framework.Color,System.Single)")]
-        public static Color NewColor(Color color, float alpha) => new Color(color.R, color.G, color.B, (byte) alpha * 255);
+        [MonoModConstructor]
+        public void ctor(Color color, int alpha) {
+            ctor(color.R, color.G, color.B, alpha);
+        }
+
+        [MonoModConstructor]
+        public void ctor(Color color, float alpha) {
+            ctor(color.R, color.G, color.B, (byte) alpha * 255);
+        }
 
     }
 }

--- a/Celeste.Mod.mm/Patches/FNA/Color.cs
+++ b/Celeste.Mod.mm/Patches/FNA/Color.cs
@@ -6,7 +6,10 @@ namespace Microsoft.Xna.Framework {
 
         // The following signatures existed in older versions of FNA when they shouldn't have.
 
+        [MonoModLinkFrom("System.Void Microsoft.Xna.Framework.Color::.ctor(Microsoft.Xna.Framework.Color,System.Int32)")]
         public static Color NewColor(Color color, int alpha) => new Color(color.R, color.G, color.B, alpha);
+
+        [MonoModLinkFrom("System.Void Microsoft.Xna.Framework.Color::.ctor(Microsoft.Xna.Framework.Color,System.Single)")]
         public static Color NewColor(Color color, float alpha) => new Color(color.R, color.G, color.B, (byte) alpha * 255);
 
     }


### PR DESCRIPTION
Old versions of [FNA](https://github.com/FNA-XNA/FNA/blob/d53f53a202e44f217e620aa02e3cce7fedf13b43/src/Color.cs#L1607) and [XNA](https://learn.microsoft.com/en-us/previous-versions/windows/xna/dd231958(v=xnagamestudio.30)) supported a `Color` contractor that receives a `Color` and a `float` or an `int` like so:
```c#
public Color(Color color, int alpha) {
...
}
```
And it [seems](https://discord.com/channels/403698615446536203/429775439423209472/1122140394331848814) that [winter collab](https://gamebanana.com/mods/150789) is relying on it.

This PR fixes the issue by patching in the missing `Color` constructors.