### PR TITLE
Lowercase debug command names upon registration

### DIFF
--- a/Celeste.Mod.mm/Patches/Monocle/Commands.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Commands.cs
@@ -544,7 +544,7 @@ namespace MonoMod {
             ILCursor cursor = new ILCursor(il);
 
             TypeDefinition t_String = MonoModRule.Modder.FindType("System.String").Resolve();
-            // import string.ToStringInvariant() as it's not in the Celeste assembly
+            // import string.ToLowerInvariant() as it's not in the Celeste assembly
             MethodReference m_ToLowerInvariant = MonoModRule.Modder.Module.ImportReference(t_String.FindMethod("System.String ToLowerInvariant()"));
 
             cursor.GotoNext(MoveType.After, instr => instr.MatchLdloc(1), instr => instr.MatchLdfld("Monocle.Command", "Name"));

--- a/Celeste.Mod.mm/Patches/Monocle/Commands.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Commands.cs
@@ -543,19 +543,14 @@ namespace MonoMod {
         public static void PatchCommandsProcessMethod(ILContext il, CustomAttribute attrib) {
             ILCursor cursor = new ILCursor(il);
 
-            TypeDefinition t_CultureInfo = MonoModRule.Modder.FindType("System.Globalization.CultureInfo").Resolve();
-            // import CultureInfo.InvariantCulture's getter as it's not in the Celeste assembly
-            MethodReference m_InvariantCulture_get = MonoModRule.Modder.Module.ImportReference(t_CultureInfo.FindProperty("InvariantCulture").GetMethod);
-
             TypeDefinition t_String = MonoModRule.Modder.FindType("System.String").Resolve();
-            // import string.ToString(CultureInfo) as it's not in the Celeste assembly
-            MethodReference m_ToLower = MonoModRule.Modder.Module.ImportReference(t_String.FindMethod("System.String ToLower(System.Globalization.CultureInfo)"));
+            // import string.ToStringInvariant() as it's not in the Celeste assembly
+            MethodReference m_ToLowerInvariant = MonoModRule.Modder.Module.ImportReference(t_String.FindMethod("System.String ToLowerInvariant()"));
 
             cursor.GotoNext(MoveType.After, instr => instr.MatchLdloc(1), instr => instr.MatchLdfld("Monocle.Command", "Name"));
 
-            // call Command.Name.ToLower() with the invariant culture
-            cursor.Emit(OpCodes.Call, m_InvariantCulture_get);
-            cursor.Emit(OpCodes.Callvirt, m_ToLower);
+            // call Command.Name.ToLowerInvariant()
+            cursor.Emit(OpCodes.Callvirt, m_ToLowerInvariant);
         }
 
     }


### PR DESCRIPTION
If a debug command has a name with an uppercase character, the command will show up in the list, but will be impossible to call, due to `Monocle.Commands.EnterCommand()` lowercasing the command name.

![Attempting to run "resetTSwitch", but the command doesn't exist, despite showing up in the command list.](https://github.com/EverestAPI/Everest/assets/49392266/d8f6dfe3-184c-4fce-9a05-a3b8f56920d5)

---

This patch lowercases the command name upon registration to prevent confusion in the future.

![Registering a "testmod_TEST" command, with uppercase "TEST"](https://github.com/EverestAPI/Everest/assets/49392266/d7b7e67b-f482-48d5-a75e-8f8fd701cfbb)
![In-game command list, showing the "testmod_test" command, with lowercase "test"](https://github.com/EverestAPI/Everest/assets/49392266/1162d762-dade-419a-9b17-c16c34bd972e)
