### PR TITLE
Disable chaser state pause fix in vanilla

### DIFF
--- a/Celeste.Mod.mm/Patches/Level.cs
+++ b/Celeste.Mod.mm/Patches/Level.cs
@@ -487,7 +487,7 @@ namespace Celeste {
         }
 
         private void FixChaserStatesTimeStamp() {
-            if (unpauseTimer > 0f && Tracker.GetEntity<Player>()?.ChaserStates is { } chaserStates) {
+            if (Session.Area.GetLevelSet() != "Celeste" && unpauseTimer > 0f && Tracker.GetEntity<Player>()?.ChaserStates is { } chaserStates) {
                 float offset = Engine.DeltaTime;
 
                 // add one more frame at the end


### PR DESCRIPTION
This was originally not ignored in vanilla because it's (at least partially) a regression bug, but with the recent rise of TimeActive manipulation in TASing, there was some concern about Everest changing vanilla mechanics like this. This patch disables the fix in vanilla while preserving it in mods to prevent pausing throwing off badeline chasers in harder modded maps where frequent pausing in RTA play might be more likely.