### PR TITLE
Make EntityList Add(entity) and Remove(entity) methods to crash when entity is null

### DIFF
--- a/Celeste.Mod.mm/Patches/Monocle/EntityList.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/EntityList.cs
@@ -140,14 +140,12 @@ namespace MonoMod {
 
             ILCursor cursor = new ILCursor(context);
             ILLabel label = cursor.DefineLabel();
-            cursor.Emit(OpCodes.Ldarg_1);
-            cursor.Emit(OpCodes.Ldnull);
-            cursor.Emit(OpCodes.Ceq);
-            cursor.Emit(OpCodes.Brfalse_S, label);
-            cursor.Emit(OpCodes.Ldstr, "entity");
-            cursor.Emit(OpCodes.Newobj, ctor_ArgumentNullException);
-            cursor.Emit(OpCodes.Throw);
-            cursor.MarkLabel(label);
+            cursor.Emit(OpCodes.Ldarg_1)
+                .Emit(OpCodes.Brtrue_S, label)
+                .Emit(OpCodes.Ldstr, "entity")
+                .Emit(OpCodes.Newobj, ctor_ArgumentNullException)
+                .Emit(OpCodes.Throw)
+                .MarkLabel(label);
         }
 
     }

--- a/Celeste.Mod.mm/Patches/Monocle/EntityList.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/EntityList.cs
@@ -32,15 +32,15 @@ namespace Monocle {
 
         [MonoModIgnore]
         [PatchEntityListUpdateLists]
-        internal extern void UpdateLists();
+        public extern void UpdateLists();
 
         [MonoModIgnore]
         [PatchEntityListAddAndRemove]
-        internal extern void Add(Entity entity);
+        public extern void Add(Entity entity);
 
         [MonoModIgnore]
         [PatchEntityListAddAndRemove]
-        internal extern void Remove(Entity entity);
+        public extern void Remove(Entity entity);
     }
 
     public static class EntityListExt {


### PR DESCRIPTION
Currently if you invoke `level.Add(null as Entity)`, you will get the following useless crash logs
```
System.NullReferenceException: Object reference not set to an instance of an object.
   at Monocle.TagLists.EntityAdded(Entity entity)
   at DMD<Monocle.EntityList::UpdateLists>(EntityList this)
   at DMD<Monocle.Scene::BeforeUpdate>(Scene this)
```

Make EntityList `Add(entity)` and `Remove(entity)` methods to crash when entity is null, so modders can catch bugs in time