### PR TITLE
Fixed Badeline last node crash

### DIFF
--- a/Celeste.Mod.mm/Content/Dialog/English.txt
+++ b/Celeste.Mod.mm/Content/Dialog/English.txt
@@ -27,7 +27,7 @@
 	POSTCARD_MISSINGTUTORIAL=	{big}Oops!{/big}{n}The playback tutorial {#ff1144}((tutorial)){#} could not be found.{n}Check your {#44adf7}log.txt{#} for more info.
 	POSTCARD_TILEXMLERROR=		{big}Oops!{/big}{n}There was an error parsing a tileset in {#ff1144}((path)){#}{n}Check your {#44adf7}log.txt{#} for more info.
 	POSTCARD_XMLERROR=			{big}Oops!{/big}{n}{#ff1144}((path)){#} has a syntax error.{n}Check your {#44adf7}log.txt{#} for more info.
-	POSTCARD_BOSSLASTNODEHIT=	{big}Oops!{/big}{n}FinalBoss entity was hit on its last node, please add an additional node outside of the current room to ensure the player never hits it.
+	POSTCARD_BOSSLASTNODEHIT=	{big}Oops!{/big}{n}{#ff1144}Badeline Boss{#} entity was hit on its last node, please add an additional node outside of the current room to ensure the player never hits it.
 
 # Main Menu
 	MENU_TITLETOUCH= 		TOUCH

--- a/Celeste.Mod.mm/Content/Dialog/English.txt
+++ b/Celeste.Mod.mm/Content/Dialog/English.txt
@@ -27,6 +27,7 @@
 	POSTCARD_MISSINGTUTORIAL=	{big}Oops!{/big}{n}The playback tutorial {#ff1144}((tutorial)){#} could not be found.{n}Check your {#44adf7}log.txt{#} for more info.
 	POSTCARD_TILEXMLERROR=		{big}Oops!{/big}{n}There was an error parsing a tileset in {#ff1144}((path)){#}{n}Check your {#44adf7}log.txt{#} for more info.
 	POSTCARD_XMLERROR=			{big}Oops!{/big}{n}{#ff1144}((path)){#} has a syntax error.{n}Check your {#44adf7}log.txt{#} for more info.
+	POSTCARD_BOSSLASTNODEHIT=	{big}Oops!{/big}{n}FinalBoss entity was hit on its last node, please add an additional node outside of the current room to ensure the player never hits it.
 
 # Main Menu
 	MENU_TITLETOUCH= 		TOUCH

--- a/Celeste.Mod.mm/Patches/FinalBoss.cs
+++ b/Celeste.Mod.mm/Patches/FinalBoss.cs
@@ -1,4 +1,5 @@
 ﻿#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
+﻿#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
 
 using System;
 using Celeste.Mod;

--- a/Celeste.Mod.mm/Patches/FinalBoss.cs
+++ b/Celeste.Mod.mm/Patches/FinalBoss.cs
@@ -35,9 +35,9 @@ namespace Celeste {
         [PatchBadelineBossOnPlayer] // ... except for manually manipulating the method via MonoModRules
         public new extern void OnPlayer(Player player);
 
-        public extern void orig_PushPlayer(Player player);
+        private extern void orig_PushPlayer(Player player);
 
-        public void PushPlayer(Player player) {
+        private void PushPlayer(Player player) {
             // ensure we are not hitting the last node
             if (nodeIndex >= nodes.Length) {
                 Logger.Log(LogLevel.Warn, "FinalBoss",

--- a/Celeste.Mod.mm/Patches/FinalBoss.cs
+++ b/Celeste.Mod.mm/Patches/FinalBoss.cs
@@ -1,7 +1,6 @@
 ﻿#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
 
 using System;
-using Celeste.Mod;
 using Microsoft.Xna.Framework;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
@@ -13,10 +12,6 @@ namespace Celeste {
     class patch_FinalBoss : FinalBoss {
 
         private bool canChangeMusic;
-
-        private int nodeIndex;
-
-        private Vector2[] nodes;
 
         public patch_FinalBoss(EntityData e, Vector2 offset)
             : base(e, offset) {
@@ -31,22 +26,9 @@ namespace Celeste {
             canChangeMusic = data.Bool("canChangeMusic", true);
         }
 
-        [PatchBadelineBossOnPlayer]
-        public extern void orig_OnPlayer(Player player);
-
-        public void OnPlayer(Player player) {
-            // ensure we are not hitting the last node, we run before nodeIndex is incremented so we need to do it ourself
-            if (nodeIndex + 1 >= nodes.Length) {
-                Logger.Log(LogLevel.Warn, "FinalBoss",
-                    "FinalBoss entity was hit on its last node, please add an additional node outside of the current room to ensure the player never hits it.");
-                patch_LevelEnter.ErrorMessage = Dialog.Get("postcard_bosslastnodehit");
-
-                // we want to call LevelEnter.Go explicitly instant of letting CheckForErrors call it to prevent double triggers of postcard
-                LevelEnter.Go((Scene as Level).Session, false);
-            } else {
-                orig_OnPlayer(player);
-            }
-        }
+        [MonoModIgnore] // We don't want to change anything about the method...
+        [PatchBadelineBossOnPlayer] // ... except for manually manipulating the method via MonoModRules
+        public new extern void OnPlayer(Player player);
 
         public bool CanChangeMusic(bool value) {
             Level level = Scene as Level;
@@ -55,6 +37,7 @@ namespace Celeste {
 
             return canChangeMusic;
         }
+
     }
 }
 


### PR DESCRIPTION
This PR fixes an issue where if the player this the last node of `FinalBoss` (Badeline) the game crashes.

Additinal details:
https://discord.com/channels/403698615446536203/1137280308887175178
