### PR TITLE
Stop Level Update chain if CheckForErrors finds an error

### DIFF
--- a/Celeste.Mod.mm/Patches/FinalBoss.cs
+++ b/Celeste.Mod.mm/Patches/FinalBoss.cs
@@ -44,9 +44,6 @@ namespace Celeste {
                 Logger.Log(LogLevel.Warn, "FinalBoss",
                     "FinalBoss entity was hit on its last node, please add an additional node outside of the current room to ensure the player never hits it.");
                 patch_LevelEnter.ErrorMessage = Dialog.Get("postcard_bosslastnodehit");
-
-                // we want to call LevelEnter.Go explicitly instant of letting CheckForErrors call it to prevent double triggers of postcard
-                LevelEnter.Go((Scene as Level).Session, false);
             } else {
                 orig_PushPlayer(player);
             }

--- a/Celeste.Mod.mm/Patches/Level.cs
+++ b/Celeste.Mod.mm/Patches/Level.cs
@@ -502,10 +502,13 @@ namespace Celeste {
             }
         }
 
-        private void CheckForErrors() {
-            if (patch_LevelEnter.ErrorMessage != null) {
+        private bool CheckForErrors() {
+            bool errorPresent = patch_LevelEnter.ErrorMessage != null;
+            if (errorPresent) {
                 LevelEnter.Go(Session, false);
             }
+
+            return errorPresent;
         }
     }
 
@@ -704,6 +707,8 @@ namespace MonoMod {
 
             // Insert CheckForErrors() at the beginning so we can display an error screen if needed
             cursor.Emit(OpCodes.Ldarg_0).Emit(OpCodes.Call, m_CheckForErrors);
+            // Insert an if statement that returns if we find an error at CheckForErrors
+            cursor.Emit(OpCodes.Brfalse, cursor.Next).Emit(OpCodes.Ret);
 
             // insert FixChaserStatesTimeStamp()
             cursor.Emit(OpCodes.Ldarg_0).Emit(OpCodes.Call, m_FixChaserStatesTimeStamp);


### PR DESCRIPTION
Stumbled upon this one when I was working on #657.

My issue was that after `CheckForErrors` cleared `patch_LevelEnter.ErrorMessage`, it keep updating the whole scene and eventually reached `FinalBoss` which set `patch_LevelEnter.ErrorMessage` again.

This PR removes the redundant `LevelEnter.Go` in `FinalBoss` and stops `Level.Update` if `CheckForErrors` returns true.