### PR TITLE
Fixed priority getting overwritten by before/after patch

### DIFF
--- a/Celeste.Mod.mm/Mod/Helpers/LegacyMonoMod/DetourContext.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/LegacyMonoMod/DetourContext.cs
@@ -33,10 +33,13 @@ namespace Celeste.Mod.Helpers.LegacyMonoMod {
                         MonoModPolice.ReportMonoModCrime($"Conflicting wildcard '*' in both DetourContext '{LegacyDetourContext.ID}' Before/After");
                 }
 
-                if (prio != 0)
-                    Logger.Log("legacy-monomod", $"Discarding DetourContext '{LegacyDetourContext.ID}' priority {prio} in favor of Before/After wildcard emulation priority {wcPrio}");
+                if (wcPrio != 0) {
+                    prio = wcPrio;
+                    if (prio != 0) {
+                        Logger.Log("legacy-monomod", $"Discarding DetourContext '{LegacyDetourContext.ID}' priority {prio} in favor of Before/After wildcard emulation priority {wcPrio}");
+                    }
+                }
 
-                prio = wcPrio;
 
                 // Before / After are switched on reorg ._.
                 config = new DetourConfig(LegacyDetourContext.ID, prio, LegacyDetourContext.After, LegacyDetourContext.Before);
@@ -63,7 +66,7 @@ namespace Celeste.Mod.Helpers.LegacyMonoMod {
 
                 // Find the most recently added valid context, remove invalid ones after it
                 int valCtxIdx = Contexts.FindLastIndex(ctx => ctx.IsValid);
-                Contexts.RemoveRange(valCtxIdx+1, Contexts.Count - (valCtxIdx+1));
+                Contexts.RemoveRange(valCtxIdx + 1, Contexts.Count - (valCtxIdx + 1));
                 return Last = ((valCtxIdx >= 0) ? Contexts[valCtxIdx] : null);
             }
         }
@@ -141,9 +144,9 @@ namespace Celeste.Mod.Helpers.LegacyMonoMod {
             contextScope = new ReorgContext(this).Use();
         }
 
-        public LegacyDetourContext(string id) : this(0, id) {}
-        public LegacyDetourContext(int priority) : this(priority, null) {}
-        public LegacyDetourContext() : this(0, null) {}
+        public LegacyDetourContext(string id) : this(0, id) { }
+        public LegacyDetourContext(int priority) : this(priority, null) { }
+        public LegacyDetourContext() : this(0, null) { }
 
         public void Dispose() {
             if (IsDisposed)

--- a/Celeste.Mod.mm/Mod/Helpers/LegacyMonoMod/HookEndpointManager.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/LegacyMonoMod/HookEndpointManager.cs
@@ -10,7 +10,7 @@ namespace Celeste.Mod.Helpers.LegacyMonoMod {
     //This exists for two reasons:
     // - to give all hooks an (empty) config to bypass some hook ordering jank
     // - to "fix" the MonoMod crime of double hooks
-    [ExternalGameDependencyPatchAttribute("MMHOOK_Celeste")]
+    [ExternalGameDependencyPatch("MMHOOK_Celeste")]
     [RelinkLegacyMonoMod("MonoMod.RuntimeDetour.HookGen.HookEndpointManager")]
     public static class LegacyHookEndpointManager {
 


### PR DESCRIPTION
Currently if a `DetourContext` has a `DetourConfig` with a priority value, it would get overwritten even if `Before=*` or `After=*` isn't present on the `DetourConfig` , this PR fixes it by adding an addental check.