### PR TITLE
when failing to load cached assemblies, mention that they're cached

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Relinker.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Relinker.cs
@@ -220,7 +220,7 @@ namespace Celeste.Mod {
                 if (File.Exists(cachedPath) && File.Exists(cachedChecksumPath) &&
                     ChecksumsEqual(checksums, File.ReadAllLines(cachedChecksumPath))) {
                     Logger.Log(LogLevel.Verbose, "relinker", $"Loading cached assembly for {meta} - {asmname}");
-                    
+
                     // Load the assembly and the module definition
                     ModuleDefinition mod = ModuleDefinition.ReadModule(cachedPath);
                     try {
@@ -235,7 +235,7 @@ namespace Celeste.Mod {
 
                         return asm;
                     } catch (Exception e) {
-                        Logger.Log(LogLevel.Warn, "relinker", $"Failed loading {meta} - {asmname}");
+                        Logger.Log(LogLevel.Warn, "relinker", $"Failed loading cached assembly {meta} - {asmname}");
                         e.LogDetailed();
                         return null;
                     } finally {


### PR DESCRIPTION
currently the warning doesn't mention that the assembly is from the cache. this fixes that, by adding the words "cached assembly" to the warning.