### PR TITLE
Fix strawberry seed crash when player collects the last seed and dies at the same frame

### DIFF
--- a/Celeste.Mod.mm/Mod/Entities/GenericStrawberrySeed.cs
+++ b/Celeste.Mod.mm/Mod/Entities/GenericStrawberrySeed.cs
@@ -197,7 +197,7 @@ namespace Celeste.Mod.Entities {
 
         public void OnAllCollected() {
             finished = true;
-            follower.Leader.LoseFollower(follower);
+            follower.Leader?.LoseFollower(follower);
             Depth = -2000002;
             Tag = Tags.FrozenUpdate;
             wiggler.Start();

--- a/Celeste.Mod.mm/Patches/StrawberrySeed.cs
+++ b/Celeste.Mod.mm/Patches/StrawberrySeed.cs
@@ -1,5 +1,10 @@
 ﻿using Microsoft.Xna.Framework;
 using System.Linq;
+using MonoMod;
+using System;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using MonoMod.Cil;
 
 namespace Celeste {
     public class patch_StrawberrySeed : StrawberrySeed {
@@ -23,6 +28,10 @@ namespace Celeste {
         private extern void orig_OnPlayer(Player player);
 #pragma warning restore CS0626
 
+        [MonoModIgnore]
+        [PatchPatchStrawberrySeedOnAllCollected]
+        private extern new void OnAllCollected();
+
         private void OnPlayer(Player player) {
             orig_OnPlayer(player);
 
@@ -36,5 +45,44 @@ namespace Celeste {
                 }
             }
         }
+    }
+}
+namespace MonoMod {
+    /// <summary>
+    /// Patches OnAllCollected to add a check if this.follower.Leader is null.
+    /// </summary>
+    [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchStrawberrySeedOnAllCollected))]
+    class PatchPatchStrawberrySeedOnAllCollectedAttribute : Attribute { }
+
+    static partial class MonoModRules {
+
+        public static void PatchStrawberrySeedOnAllCollected(ILContext context, CustomAttribute attrib) {
+            ILCursor cursor = new(context);
+            ILLabel beforeLoseFollower = cursor.DefineLabel();
+            ILLabel afterLoseFollower = cursor.DefineLabel();
+
+            // we want to add a null check on Leader before calling LoseFollower so we change:
+            // this.follower.Leader.LoseFollower(this.follower);
+            // to
+            // this.follower.Leader?.LoseFollower(this.follower);
+
+            // move cursor to the point where Leader is on top of the stack, and then duplicate it for the branch true
+            cursor.GotoNext(MoveType.After, inst => inst.MatchLdfld("Celeste.Follower", "Leader"));
+            cursor.Emit(OpCodes.Dup);
+            
+            // brach to the calling path if we are not null
+            cursor.Emit(OpCodes.Brtrue, beforeLoseFollower);
+            // on null discard duplicated value and jump over the calling path
+            cursor.Emit(OpCodes.Pop);
+            cursor.Emit(OpCodes.Br, afterLoseFollower);
+            
+            cursor.GotoNext(MoveType.Before, inst => inst.MatchLdarg(0));
+            cursor.MarkLabel(beforeLoseFollower);
+            
+            cursor.GotoNext(MoveType.After, inst => inst.MatchCallvirt("Celeste.Leader", "LoseFollower"));
+            cursor.GotoNext();
+            cursor.MarkLabel(afterLoseFollower);
+        }
+
     }
 }

--- a/Celeste.Mod.mm/Patches/StrawberrySeed.cs
+++ b/Celeste.Mod.mm/Patches/StrawberrySeed.cs
@@ -80,7 +80,6 @@ namespace MonoMod {
             cursor.MarkLabel(beforeLoseFollower);
             
             cursor.GotoNext(MoveType.After, inst => inst.MatchCallvirt("Celeste.Leader", "LoseFollower"));
-            cursor.GotoNext();
             cursor.MarkLabel(afterLoseFollower);
         }
 

--- a/Celeste.Mod.mm/Patches/StrawberrySeed.cs
+++ b/Celeste.Mod.mm/Patches/StrawberrySeed.cs
@@ -30,7 +30,7 @@ namespace Celeste {
 
         [MonoModIgnore]
         [PatchPatchStrawberrySeedOnAllCollected]
-        private extern new void OnAllCollected();
+        public new extern void OnAllCollected();
 
         private void OnPlayer(Player player) {
             orig_OnPlayer(player);


### PR DESCRIPTION
This issue was posted on [Discord](https://discord.com/channels/403698615446536203/1142608955831492799/1142608955831492799),  after an investigation it seems that `StrawberrySeed.Leader` could be null when `OnAllCollected` is called.
This can happen when `Player.Die` gets called and then `this.Leader.LoseFollowers()` gets called which nulls the `Leader` value of all followers, and on the same tick the game detects that the player has all the strawberry seeds and start a `CSGEN_StrawberrySeeds` cutscene, then in the next game tick the cutscene progresses and calls `OnAllCollected` and then  we get a NRE due to the nulled `Leader` value.

This PR fixes the issue by adding a null check before using `Leader` in `OnAllCollected`.