### PR TITLE
Fix game crashes when everest settings file is corrupted

### DIFF
--- a/Celeste.Mod.mm/Mod/Core/CoreModuleSettings.cs
+++ b/Celeste.Mod.mm/Mod/Core/CoreModuleSettings.cs
@@ -296,8 +296,13 @@ namespace Celeste.Mod.Core {
             set => _CurrentBranch = value is "dev" or "beta" or "stable" ? "updater_src_" + value : value; // branch names were changed at some point
         }
 
+        private Dictionary<string, LogLevel> _LogLevels = new Dictionary<string, LogLevel>();
+
         [SettingIgnore]
-        public Dictionary<string, LogLevel> LogLevels { get; set; } = new Dictionary<string, LogLevel>();
+        public Dictionary<string, LogLevel> LogLevels {
+            get => _LogLevels;
+            set => _LogLevels = value ?? new Dictionary<string, LogLevel>();
+        }
 
         [SettingSubHeader("MODOPTIONS_COREMODULE_MENUNAV_SUBHEADER")]
         [SettingInGame(false)]

--- a/Celeste.Mod.mm/Mod/Everest/ButtonBinding.cs
+++ b/Celeste.Mod.mm/Mod/Everest/ButtonBinding.cs
@@ -18,17 +18,17 @@ namespace Celeste.Mod {
 
         public List<Buttons> Buttons {
             get => Binding.Controller;
-            set => Binding.Controller = value;
+            set => Binding.Controller = value ?? new List<Buttons>();
         }
 
         public List<Keys> Keys {
             get => Binding.Keyboard;
-            set => Binding.Keyboard = value;
+            set => Binding.Keyboard = value ?? new List<Keys>();
         }
 
         public List<patch_MInput.patch_MouseData.MouseButtons> MouseButtons {
             get => ((patch_Binding) Binding).Mouse;
-            set => ((patch_Binding) Binding).Mouse = value;
+            set => ((patch_Binding) Binding).Mouse = value ?? new List<patch_MInput.patch_MouseData.MouseButtons>();
         }
 
         private Binding _Binding;


### PR DESCRIPTION
Sometimes everest settings file would get corrupted and crash when starting the game
this pr fixes the problem

related crash logs:
https://discord.com/channels/403698615446536203/1134878623996858408/1134878623996858408
https://discord.com/channels/403698615446536203/1132621142532816906/1132621142532816906

Can be reproduced by setting `LogLevels: null` or `Buttons: null` in the everest settings file.