### PR TITLE
Use RawDeltaTime for the asset reload animation on Core

### DIFF
--- a/Celeste.Mod.mm/Mod/Helpers/AssetReloadHelper.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/AssetReloadHelper.cs
@@ -428,10 +428,10 @@ namespace Celeste.Mod {
             base.Update();
 
             // Update the cogwheel rotation
-            cogwheelRot += 4 * Engine.DeltaTime;
+            cogwheelRot += 4 * Engine.RawDeltaTime;
 
             // Update the in-out lerp timer
-            transitionTimer += Engine.DeltaTime;
+            transitionTimer += Engine.RawDeltaTime;
             if (transitionTimer > (outTransition ? TimeOut : TimeIn))
                 transitionTimer = (outTransition ? TimeOut : TimeIn);
 


### PR DESCRIPTION
The non-Core version of the asset reload animation already uses RawDeltaTime, this just changes Core to match (so that it's not affected by TimeRate adjustments).