### PR TITLE
add toggle option to core mode trigger

### DIFF
--- a/Celeste.Mod.mm/Mod/Entities/CoreModeTrigger.cs
+++ b/Celeste.Mod.mm/Mod/Entities/CoreModeTrigger.cs
@@ -3,20 +3,41 @@
 namespace Celeste.Mod.Entities {
     [CustomEntity("everest/coreModeTrigger", "cavern/coremodetrigger")]
     public class CoreModeTrigger : Trigger {
-        private readonly Session.CoreModes mode;
+        private enum Modes {
+            None,
+            Hot,
+            Cold,
+            Toggle
+        }
+
+        private readonly Modes mode;
         private readonly bool playEffects;
 
-        public CoreModeTrigger(EntityData data, Vector2 offset) 
+        public CoreModeTrigger(EntityData data, Vector2 offset)
             : base(data, offset) {
-            mode = data.Enum("mode", Session.CoreModes.None);
+            mode = data.Enum("mode", Modes.None);
             playEffects = data.Bool("playEffects", true);
         }
 
         public override void OnEnter(Player player) {
             Level level = Scene as Level;
-            if (level.CoreMode == mode)
+
+            Session.CoreModes newMode = Session.CoreModes.None;
+
+            if (mode == Modes.Toggle) {
+                if (level.CoreMode == Session.CoreModes.Hot)
+                    newMode = Session.CoreModes.Cold;
+                else if (level.CoreMode == Session.CoreModes.Cold)
+                    newMode = Session.CoreModes.Hot;
+            } else {
+                newMode = (Session.CoreModes) mode;
+            }
+
+            if (level.CoreMode == newMode)
                 return;
-            level.CoreMode = mode;
+
+            level.CoreMode = newMode;
+
             if (playEffects) {
                 Input.Rumble(RumbleStrength.Medium, RumbleLength.Medium);
                 level.Flash(Color.White * 0.15f, true);


### PR DESCRIPTION
this adds an `CoreModeTrigger.Modes` enum, which is the same as `Session.CoreModes` but with an extra `Toggle` option at the end.
this is used for the `mode` attribute, and when it is set to `Toggle`, the trigger toggles the core mode.
this means that when it is cold, it becomes hot, and vice versa; nothing happens if the core mode is `None`.