### PR TITLE
Fix crash when updating mod after re-entering update scene

### DIFF
--- a/Celeste.Mod.mm/Mod/Helpers/ModUpdaterHelper.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/ModUpdaterHelper.cs
@@ -195,8 +195,8 @@ namespace Celeste.Mod.Helpers {
             }
         }
 
-        public static Task updateCheckTask = null;
-        public static SortedDictionary<ModUpdateInfo, EverestModuleMetadata> availableUpdates = null;
+        private static Task updateCheckTask = null;
+        private static SortedDictionary<ModUpdateInfo, EverestModuleMetadata> availableUpdates = null;
 
         /// <summary>
         /// Run a check for mod updates asynchronously.

--- a/Celeste.Mod.mm/Mod/Helpers/ModUpdaterHelper.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/ModUpdaterHelper.cs
@@ -195,8 +195,8 @@ namespace Celeste.Mod.Helpers {
             }
         }
 
-        private static Task updateCheckTask = null;
-        private static SortedDictionary<ModUpdateInfo, EverestModuleMetadata> availableUpdates = null;
+        public static Task updateCheckTask = null;
+        public static SortedDictionary<ModUpdateInfo, EverestModuleMetadata> availableUpdates = null;
 
         /// <summary>
         /// Run a check for mod updates asynchronously.

--- a/Celeste.Mod.mm/Mod/UI/OuiModUpdateList.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiModUpdateList.cs
@@ -34,7 +34,7 @@ namespace Celeste.Mod.UI {
 
         private static bool ongoingUpdateCancelled = false;
 
-        private static bool isFetchingDone => ModUpdaterHelper.updateCheckTask.IsCompleted;
+        private static bool isFetchingDone => ModUpdaterHelper.IsAsyncUpdateCheckingDone();
 
         private bool menuOnScreen = false;
 
@@ -193,10 +193,11 @@ namespace Celeste.Mod.UI {
         private void generateAllButtons() {
             // 3. Render on screen
             Logger.Log(LogLevel.Verbose, "OuiModUpdateList", "Rendering updates");
-            ModUpdaterHelper.updateCheckTask.Wait();
+            SortedDictionary<ModUpdateInfo, EverestModuleMetadata> availableUpdates =
+                ModUpdaterHelper.GetAsyncLoadedModUpdates();
             if (menu == null) return;
             
-            if (ModUpdaterHelper.availableUpdates == null) {
+            if (availableUpdates == null) {
                 // display an error message
                 renderButtonsTask = new Task(() => {
                     menu.Remove(fetchingButton);
@@ -209,7 +210,7 @@ namespace Celeste.Mod.UI {
                 return;
             }
             
-            if (ModUpdaterHelper.availableUpdates.Count == 0) {
+            if (availableUpdates.Count == 0) {
                 // display a dummy "no update available" button
                 renderButtonsTask = new Task(() => {
                     menu.Remove(fetchingButton);
@@ -224,7 +225,7 @@ namespace Celeste.Mod.UI {
             List<TextMenu.Button> queuedItems = new List<TextMenu.Button>();
 
             // if there are multiple updates...
-            if (ModUpdaterHelper.availableUpdates.Count > 1) {
+            if (availableUpdates.Count > 1) {
                 // display an "update all" button at the top of the list
                 updateAllButton = new TextMenu.Button(Dialog.Clean("MODUPDATECHECKER_UPDATE_ALL"));
                 updateAllButton.Pressed(() => downloadAllMods());
@@ -233,8 +234,8 @@ namespace Celeste.Mod.UI {
             }
 
             // then, display one button per update
-            foreach (ModUpdateInfo update in ModUpdaterHelper.availableUpdates.Keys) {
-                EverestModuleMetadata metadata = ModUpdaterHelper.availableUpdates[update];
+            foreach (ModUpdateInfo update in availableUpdates.Keys) {
+                EverestModuleMetadata metadata = availableUpdates[update];
 
                 string versionUpdate = metadata.VersionString;
                 if (metadata.VersionString != update.Version)


### PR DESCRIPTION
Introduced by #621.
When opening the update scene, closing it, loading a map, and then opening it again (which is more common than it seems) it will have created some button generator lambdas which will have captured an already disposed instance of the scene, causing a null reference exception when trying to access its `menu` field.
This pr too de-duplicates the code for checking updates since it is already done by `ModUpdateHelper` to show how many updates are available on the title screen. This change contributes to fixing the main issue, that's why its included in the same commit.