### PR TITLE
make extensions case insensitive for type guessing and texture reloading

### DIFF
--- a/Celeste.Mod.mm/Mod/Entities/CustomHeightDisplay.cs
+++ b/Celeste.Mod.mm/Mod/Entities/CustomHeightDisplay.cs
@@ -57,7 +57,7 @@ namespace Celeste.Mod.Entities {
                 Target = target;
                 Approach = from;
 
-                int idx = Text.IndexOf("{x}", StringComparison.InvariantCultureIgnoreCase);
+                int idx = Text.IndexOf("{x}", StringComparison.OrdinalIgnoreCase);
                 if (idx != -1) {
                     hasCount = true;
                     displaySound = SFX.game_07_altitudecount;

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Content.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Content.cs
@@ -747,7 +747,7 @@ namespace Celeste.Mod {
                     type = typeof(ObjModel);
                     file = file.Substring(0, file.Length - 4);
 
-                } else if (file.EndsWith(".obj.export", StringComparison.InvariantCultureIgnoreCase)) {
+                } else if (file.EndsWith(".obj.export", StringComparison.OrdinalIgnoreCase)) {
                     type = typeof(AssetTypeObjModelExport);
                     file = file.Substring(0, file.Length - 7);
 
@@ -768,7 +768,7 @@ namespace Celeste.Mod {
                     if (format == "txt") {
                         type = typeof(AssetTypeDialog);
                         file = file.Substring(0, file.Length - 4);
-                    } else if (file.EndsWith(".txt.export", StringComparison.InvariantCultureIgnoreCase)) {
+                    } else if (file.EndsWith(".txt.export", StringComparison.OrdinalIgnoreCase)) {
                         type = typeof(AssetTypeDialogExport);
                         file = file.Substring(0, file.Length - 7 - 4);
                         file += ".txt";
@@ -789,7 +789,7 @@ namespace Celeste.Mod {
                     if (format == "bank") {
                         type = typeof(AssetTypeBank);
                         file = file.Substring(0, file.Length - 5);
-                    } else if (file.EndsWith(".guids.txt", StringComparison.InvariantCultureIgnoreCase)) {
+                    } else if (file.EndsWith(".guids.txt", StringComparison.OrdinalIgnoreCase)) {
                         type = typeof(AssetTypeGUIDs);
                         file = file.Substring(0, file.Length - 4 - 6);
                         file += ".guids";

--- a/Celeste.Mod.mm/Patches/Monocle/VirtualTexture.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/VirtualTexture.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
+#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
 #pragma warning disable CS0649 // Field is never assigned to, and will always have its default value null
 
 // #define FTL_DEBUG
@@ -603,7 +603,7 @@ namespace Monocle {
                 byte[] buffer = null;
                 IntPtr bufferPtr = IntPtr.Zero;
                 bool bufferStolen = false;
-                switch (System.IO.Path.GetExtension(Path)) {
+                switch (System.IO.Path.GetExtension(Path).ToLowerInvariant()) {
                     case ".data":
                         using (FileStream stream = File.OpenRead(System.IO.Path.Combine(Engine.ContentDirectory, Path))) {
                             // Vanilla has got a static readonly byte[] bytes of fixed length - currently 524288
@@ -783,7 +783,7 @@ namespace Monocle {
         private bool CanPreload {
             get {
                 if (!string.IsNullOrEmpty(Path)) {
-                    string extension = System.IO.Path.GetExtension(Path);
+                    string extension = System.IO.Path.GetExtension(Path).ToLowerInvariant();
                     if (extension == ".data") {
                         return true;
                     } else if (extension == ".png") {
@@ -813,7 +813,7 @@ namespace Monocle {
             // Preload the width / height, and if needed, the entire texture.
 
             if (!string.IsNullOrEmpty(Path)) {
-                string extension = System.IO.Path.GetExtension(Path);
+                string extension = System.IO.Path.GetExtension(Path).ToLowerInvariant();
                 if (extension == ".data") {
                     // Easy.
                     using (FileStream stream = File.OpenRead(System.IO.Path.Combine(Engine.ContentDirectory, Path)))


### PR DESCRIPTION
**do not merge until asset reloading is properly tested**

currently, files such as `image.PNG` are not recognised as PNG images, whereas `image.png` are.
this PR makes the type guesser and texture reloader case insensitive for extensions, so those files would both be recognised as PNGs.