### PR TITLE
implement type fullname comparer for tracker dictionaries

### DIFF
--- a/Celeste.Mod.mm/Mod/Helpers/TypeNameEqualityComparer.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/TypeNameEqualityComparer.cs
@@ -1,0 +1,19 @@
+using Monocle;
+using System;
+using System.Collections.Generic;
+
+namespace Celeste.Mod
+{
+    /// <summary>
+    /// Used by the PatchTypeDictionaryComparer rule to allow debuggers to inspect dictionaries with types as keys.
+    /// </summary>
+    public class TypeNameEqualityComparer : IEqualityComparer<Type>
+    {
+        public bool Equals(Type x, Type y)
+        {
+            return (x == y) || x.FullName.Equals(y.FullName, StringComparison.Ordinal);
+        }
+
+        public int GetHashCode(Type type) => type.FullName.GetHashCode();
+    }
+}

--- a/Celeste.Mod.mm/Patches/Monocle/Pooler.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Pooler.cs
@@ -9,5 +9,10 @@ namespace Monocle {
             [MonoModIgnore]
             get;
         }
+
+        [MonoModIgnore]
+        [MonoModConstructor]
+        [PatchTypeDictionaryComparer]
+        public extern void ctor();
     }
 }

--- a/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
@@ -34,6 +34,12 @@ namespace Monocle {
     }
 
     class patch_Tracker : Tracker {
+
+        [MonoModIgnore]
+        [MonoModConstructor]
+        [PatchTypeDictionaryComparer]
+        public extern void ctor();
+
         // A temporary cache to store the results of FakeAssembly.GetFakeEntryAssemblies
         // Set to null outside of Initialize.
         private static Type[] _temporaryAllTypes;


### PR DESCRIPTION
currently, the tracker uses `Dictionary<Type, List<T>>` to track entities and components, which breaks debuggers (and the pooler works similarly, so probably has the same problem).
i'm not completely sure _why_ it breaks debuggers, but i believe it is to do with the debugger version of the type is a different instance to the one in the celeste process.
this means that when running eg. `level.Tracker.GetEntity<Player>()` in the debugger console, it fails to find the key in the dictionary.

this PR fixes that, by adding a new `TypeNameEqualityComparer` class that also takes into account the full name of the type.
this is then used to create the tracker/pooler dictionaries via a common IL patch.

~~it may be worth conditionally applying this change, based on whether `--debugger` is passed, but i don't think this is a performance concern.~~