### PR TITLE
Add `--debugger-attach` CLI option

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -293,6 +293,12 @@ namespace Celeste.Mod {
 
                 else if (arg == "--debugger")
                     Debugger.Launch();
+                    
+                else if (arg == "--debugger-attach") {
+                    Logger.Log(LogLevel.Info, "Everest", "Waiting for debugger to attach...");
+                    while (!Debugger.IsAttached) { }
+                    Logger.Log(LogLevel.Info, "Everest", "Debugger attached");
+                }
 
                 else if (arg == "--dump")
                     Content.DumpOnLoad = true;


### PR DESCRIPTION
The `--debugger` option only works on Windows, so this provides a way to debug the startup process on other platforms as well.
~~Note that this is basically useless on `dev`, since debugging .NET Frameworks applications on non-Windows isn't really done anyway.
But on `core`, this should be more usefull.~~