### PR TITLE
Catch exceptions when reading a module from the cache, and retry

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Relinker.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Relinker.cs
@@ -222,8 +222,16 @@ namespace Celeste.Mod {
                     Logger.Log(LogLevel.Verbose, "relinker", $"Loading cached assembly for {meta} - {asmname}");
 
                     // Load the assembly and the module definition
+                    ModuleDefinition mod = null;
+                    bool successfullyLoadedModule = false;
                     try {
-                        ModuleDefinition mod = ModuleDefinition.ReadModule(cachedPath);
+                        mod = ModuleDefinition.ReadModule(cachedPath);
+                        successfullyLoadedModule = true;
+                    } catch (Exception) {
+                        // Exceptions from inside ReadModule are often cache corruption, we should try loading from the non-cached assembly
+                        Logger.Log(LogLevel.Warn, "relinker", $"Failed loading module from cache {meta} - {asmname}, trying non-cached file");
+                    }
+                    if (successfullyLoadedModule) {
                         try {
                             Assembly asm = Assembly.LoadFrom(cachedPath);
                             _RelinkedAssemblies.Add(asm);
@@ -242,9 +250,6 @@ namespace Celeste.Mod {
                         } finally {
                             mod?.Dispose();
                         }
-                    } catch (Exception) {
-                        // Exceptions from inside ReadModule are often cache corruption, we should try loading from the non-cached assembly
-                        Logger.Log(LogLevel.Warn, "relinker", $"Failed loading module from cache {meta} - {asmname}, trying non-cached file");
                     }
                 }
 

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Relinker.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Relinker.cs
@@ -222,24 +222,29 @@ namespace Celeste.Mod {
                     Logger.Log(LogLevel.Verbose, "relinker", $"Loading cached assembly for {meta} - {asmname}");
 
                     // Load the assembly and the module definition
-                    ModuleDefinition mod = ModuleDefinition.ReadModule(cachedPath);
                     try {
-                        Assembly asm = Assembly.LoadFrom(cachedPath);
-                        _RelinkedAssemblies.Add(asm);
+                        ModuleDefinition mod = ModuleDefinition.ReadModule(cachedPath);
+                        try {
+                            Assembly asm = Assembly.LoadFrom(cachedPath);
+                            _RelinkedAssemblies.Add(asm);
 
-                        if (!_RelinkedModules.ContainsKey(mod.Assembly.Name.Name)) {
-                            _RelinkedModules.Add(mod.Assembly.Name.Name, mod);
-                            mod = null;
-                        } else
-                            Logger.Log(LogLevel.Warn, "relinker", $"Encountered module name conflict loading cached assembly {meta} - {asmname} - {mod.Assembly.Name}");
+                            if (!_RelinkedModules.ContainsKey(mod.Assembly.Name.Name)) {
+                                _RelinkedModules.Add(mod.Assembly.Name.Name, mod);
+                                mod = null;
+                            } else
+                                Logger.Log(LogLevel.Warn, "relinker", $"Encountered module name conflict loading cached assembly {meta} - {asmname} - {mod.Assembly.Name}");
 
-                        return asm;
-                    } catch (Exception e) {
-                        Logger.Log(LogLevel.Warn, "relinker", $"Failed loading cached assembly {meta} - {asmname}");
-                        e.LogDetailed();
-                        return null;
-                    } finally {
-                        mod?.Dispose();
+                            return asm;
+                        } catch (Exception e) {
+                            Logger.Log(LogLevel.Warn, "relinker", $"Failed loading cached assembly {meta} - {asmname}");
+                            e.LogDetailed();
+                            return null;
+                        } finally {
+                            mod?.Dispose();
+                        }
+                    } catch (Exception) {
+                        // Exceptions from inside ReadModule are often cache corruption, we should try loading from the non-cached assembly
+                        Logger.Log(LogLevel.Warn, "relinker", $"Failed loading module from cache {meta} - {asmname}, trying non-cached file");
                     }
                 }
 

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Relinker.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Relinker.cs
@@ -223,15 +223,13 @@ namespace Celeste.Mod {
 
                     // Load the assembly and the module definition
                     ModuleDefinition mod = null;
-                    bool successfullyLoadedModule = false;
                     try {
                         mod = ModuleDefinition.ReadModule(cachedPath);
-                        successfullyLoadedModule = true;
                     } catch (Exception) {
                         // Exceptions from inside ReadModule are often cache corruption, we should try loading from the non-cached assembly
                         Logger.Log(LogLevel.Warn, "relinker", $"Failed loading module from cache {meta} - {asmname}, trying non-cached file");
                     }
-                    if (successfullyLoadedModule) {
+                    if (mod != null) {
                         try {
                             Assembly asm = Assembly.LoadFrom(cachedPath);
                             _RelinkedAssemblies.Add(asm);


### PR DESCRIPTION
We get occasional issues that are due to cache corruption. Looking at the stack traces, most of them seem to originate from inside this particular call to ModuleDefintion.ReadModule. If we catch these exceptions, we can hopefully continue loading using the non-cached dll, rather than crashing as usual.