### PR TITLE
add ability to override tileset ignores

### DIFF
--- a/Celeste.Mod.mm/Patches/Autotiler.cs
+++ b/Celeste.Mod.mm/Patches/Autotiler.cs
@@ -70,7 +70,7 @@ namespace Celeste {
                 ReadIntoCustomTemplate(data, tileset, xml);
             }
 
-            if (xml.HasAttr("soundPath") && xml.HasAttr("sound")) { // Could accommodate for no sound attr, but requiring it should improve clarity on user's end 
+            if (xml.HasAttr("soundPath") && xml.HasAttr("sound")) { // Could accommodate for no sound attr, but requiring it should improve clarity on user's end
                 SurfaceIndex.TileToIndex[xml.AttrChar("id")] = xml.AttrInt("sound");
                 patch_SurfaceIndex.IndexToCustomPath[xml.AttrInt("sound")] = (xml.Attr("soundPath").StartsWith("event:/") ? "" : "event:/") + xml.Attr("soundPath");
             } else if (xml.HasAttr("sound")) {
@@ -81,6 +81,14 @@ namespace Celeste {
 
             if (xml.HasAttr("debris"))
                 data.Debris = xml.Attr("debris");
+
+            if (xml.HasAttr("ignoreOverrides")) {
+                string[] array = xml.Attr("ignoreOverrides").Split(',');
+
+                foreach (string text in array)
+					if (text.Length > 0)
+						data.IgnoreOverrides.Add(text[0]);
+            }
         }
 
         private void ReadIntoCustomTemplate(patch_TerrainType data, Tileset tileset, XmlElement xml) {
@@ -132,10 +140,10 @@ namespace Celeste {
                                             if (char.IsLetter(c))
                                                 masked.Mask[i++] = GetByteLookup(c);
                                             break;
-                                        /* 
-                                         * Error handling for characters that don't exist in a defined filter could be added,
-                                         * but is slightly more likely to break old custom tilesets if someone has defined a mask that containes nonstandard spacers (usually '-')
-                                        */
+                                            /*
+                                             * Error handling for characters that don't exist in a defined filter could be added,
+                                             * but is slightly more likely to break old custom tilesets if someone has defined a mask that containes nonstandard spacers (usually '-')
+                                            */
                                     }
                                 }
                             } catch (IndexOutOfRangeException e) {
@@ -389,6 +397,10 @@ namespace Celeste {
         // Required because TerrainType is private.
         private class patch_TerrainType {
             public char ID;
+
+            public HashSet<char> Ignores;
+            public HashSet<char> IgnoreOverrides;
+
             public List<patch_Masked> Masked;
             public patch_Tiles Center;
             public patch_Tiles Padded;
@@ -402,18 +414,24 @@ namespace Celeste {
             public Dictionary<byte, string> whitelists;
             public Dictionary<byte, string> blacklists;
 
-            [MonoModIgnore]
-            public extern bool Ignore(char c);
-
             public extern void orig_ctor(char id);
             [MonoModConstructor]
             public void ctor(char id) {
                 orig_ctor(id);
 
+                IgnoreOverrides = new HashSet<char>();
+
                 whitelists = new Dictionary<byte, string>();
                 blacklists = new Dictionary<byte, string>();
             }
 
+            [MonoModReplace]
+            public bool Ignore(char c) {
+                if (ID == c || IgnoreOverrides.Contains(c))
+                    return false;
+
+                return Ignores.Contains('*') || Ignores.Contains(c);
+            }
         }
 
         // Required because Tiles is private.

--- a/Celeste.Mod.mm/Patches/Autotiler.cs
+++ b/Celeste.Mod.mm/Patches/Autotiler.cs
@@ -82,12 +82,12 @@ namespace Celeste {
             if (xml.HasAttr("debris"))
                 data.Debris = xml.Attr("debris");
 
-            if (xml.HasAttr("ignoreOverrides")) {
-                string[] array = xml.Attr("ignoreOverrides").Split(',');
+            if (xml.HasAttr("ignoreExceptions")) {
+                string[] array = xml.Attr("ignoreExceptions").Split(',');
 
                 foreach (string text in array)
 					if (text.Length > 0)
-						data.IgnoreOverrides.Add(text[0]);
+						data.IgnoreExceptions.Add(text[0]);
             }
         }
 
@@ -399,7 +399,7 @@ namespace Celeste {
             public char ID;
 
             public HashSet<char> Ignores;
-            public HashSet<char> IgnoreOverrides;
+            public HashSet<char> IgnoreExceptions;
 
             public List<patch_Masked> Masked;
             public patch_Tiles Center;
@@ -419,7 +419,7 @@ namespace Celeste {
             public void ctor(char id) {
                 orig_ctor(id);
 
-                IgnoreOverrides = new HashSet<char>();
+                IgnoreExceptions = new HashSet<char>();
 
                 whitelists = new Dictionary<byte, string>();
                 blacklists = new Dictionary<byte, string>();
@@ -427,7 +427,7 @@ namespace Celeste {
 
             [MonoModReplace]
             public bool Ignore(char c) {
-                if (ID == c || IgnoreOverrides.Contains(c))
+                if (ID == c || IgnoreExceptions.Contains(c))
                     return false;
 
                 return Ignores.Contains('*') || Ignores.Contains(c);


### PR DESCRIPTION
adds an `ignoreOverrides` attr that overrides tileset `ignores`.
allows you to do eg.
```xml
<Tileset id="T" copy="z" path="example_tileset" ignores="*" ignoreOverrides="h,l"/>
```