### PR TITLE
Small mod search fix and support for Shift + Enter

### DIFF
--- a/Celeste.Mod.mm/Mod/UI/OuiModToggler.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiModToggler.cs
@@ -379,7 +379,7 @@ namespace Celeste.Mod.UI {
             }
 
             nextModIndex = startIndex;
-            return false;
+            return predicate(items[nextModIndex]);
         }
 
         private void AddSearchBox(TextMenu menu) {

--- a/Celeste.Mod.mm/Mod/UI/OuiModToggler.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiModToggler.cs
@@ -1,5 +1,6 @@
 ﻿using Ionic.Zip;
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Input;
 using Monocle;
 using System;
 using System.Collections;
@@ -437,7 +438,14 @@ namespace Celeste.Mod.UI {
 
             textBox.OnTextInputCharActions['\t'] = searchNextMod(false);
             textBox.OnTextInputCharActions['\n'] = (_) => { };
-            textBox.OnTextInputCharActions['\r'] = searchNextMod(false);
+            textBox.OnTextInputCharActions['\r'] = (textBox) => {
+                if (MInput.Keyboard.CurrentState.IsKeyDown(Keys.LeftShift)
+                    || MInput.Keyboard.CurrentState.IsKeyDown(Keys.RightShift)) {
+                    searchNextMod(true)(textBox);
+                } else {
+                    searchNextMod(false)(textBox);
+                }
+            };
             textBox.OnTextInputCharActions['\b'] = (textBox) => {
                 if (textBox.DeleteCharacter()) {
                     Audio.Play(SFX.ui_main_rename_entry_backspace);


### PR DESCRIPTION
1. Fix an off by one error with the mod search that caused the mod search to lose highlighting if only one mod was found
2. Allows the player to search in reverse with Shift + Enter