### PR TITLE
Various load time improvements

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/ContentExtensions.cs
+++ b/Celeste.Mod.mm/Mod/Everest/ContentExtensions.cs
@@ -273,7 +273,7 @@ namespace Celeste.Mod {
                         data = new byte[length];
                         dataPtr = IntPtr.Zero;
                     } else {
-                        data = new byte[0];
+                        data = Array.Empty<byte>();
                         dataPtr = Marshal.AllocHGlobal(length);
                     }
 
@@ -323,7 +323,7 @@ namespace Celeste.Mod {
                         data = new byte[length];
                         dataPtr = IntPtr.Zero;
                     } else {
-                        data = new byte[0];
+                        data = Array.Empty<byte>();
                         dataPtr = Marshal.AllocHGlobal(length);
                     }
 
@@ -400,7 +400,7 @@ namespace Celeste.Mod {
                 Texture2D.TextureDataFromStreamEXT(stream, out w, out h, out data);
                 dataPtr = IntPtr.Zero;
             } else {
-                data = new byte[0];
+                data = Array.Empty<byte>();
                 dataPtr = FNA3D_ReadImageStream(stream, out w, out h, out _);
             }
         }
@@ -416,7 +416,7 @@ namespace Celeste.Mod {
                 dataPtr = IntPtr.Zero;
                 length = data.Length;
             } else {
-                data = new byte[0];
+                data = Array.Empty<byte>();
                 dataPtr = FNA3D_ReadImageStream(stream, out w, out h, out length);
             }
 
@@ -425,12 +425,13 @@ namespace Celeste.Mod {
                 for (int i = length - 1 - 3; i > -1; i -= 4) {
                     byte a = raw[i + 3];
 
-                    if (a == 0 || a == 255)
+                    if (a is 0 or 255)
                         continue;
 
-                    raw[i + 0] = (byte) (raw[i + 0] * a / 255D);
-                    raw[i + 1] = (byte) (raw[i + 1] * a / 255D);
-                    raw[i + 2] = (byte) (raw[i + 2] * a / 255D);
+                    double by = a / 255D;
+                    raw[i + 0] = (byte) (raw[i + 0] * by);
+                    raw[i + 1] = (byte) (raw[i + 1] * by);
+                    raw[i + 2] = (byte) (raw[i + 2] * by);
                     // raw[i + 3] = a;
                 }
             }

--- a/Celeste.Mod.mm/Patches/Audio.cs
+++ b/Celeste.Mod.mm/Patches/Audio.cs
@@ -180,7 +180,7 @@ namespace Celeste {
             patch_Banks.ModCache[asset] = bank;
 
             bank.getID(out Guid id);
-            cachedBankPaths[id] = string.Format("bank:/mods/{0}", asset.PathVirtual.Substring("Audio/".Length));
+            cachedBankPaths[id] = $"bank:/mods/{asset.PathVirtual["Audio/".Length..]}";
             return bank;
         }
 
@@ -191,23 +191,21 @@ namespace Celeste {
             Logger.Log(LogLevel.Verbose, "Audio.IngestGUIDs", asset.PathVirtual);
             using (Stream stream = asset.Stream)
             using (StreamReader reader = new StreamReader(asset.Stream)) {
-                string line;
                 while (reader.Peek() != -1) {
-                    line = reader.ReadLine().Trim('\r', '\n').Trim();
+                    var line = reader.ReadLine().AsSpan().Trim("\r\n").Trim();
 
                     int indexOfSpace = line.IndexOf(' ');
                     if (indexOfSpace == -1)
                         continue;
 
-                    if (!Guid.TryParse(line.Substring(0, indexOfSpace), out Guid id) ||
-                        cachedPaths.ContainsKey(id))
+                    if (!Guid.TryParse(line[..indexOfSpace], out Guid id) || cachedPaths.ContainsKey(id))
                         continue;
 
                     // only ingest the GUID if the corresponding event exists.
                     if (system.getEventByID(id, out EventDescription _event) > RESULT.OK)
                         continue;
 
-                    string path = line.Substring(indexOfSpace + 1);
+                    string path = line[(indexOfSpace + 1)..].ToString();
                     if (!usedGuids.TryGetValue(path, out HashSet<Guid> used))
                         usedGuids[path] = used = new HashSet<Guid>();
                     if (!used.Add(id))
@@ -282,7 +280,7 @@ namespace Celeste {
                 status = RESULT.OK;
 
             } else if (path.StartsWith("guid://")) {
-                status = system.getEventByID(new Guid(path.Substring(7)), out desc);
+                status = system.getEventByID(Guid.Parse(path.AsSpan(7)), out desc);
 
             } else {
                 status = system.getEvent(path, out desc);
@@ -321,7 +319,7 @@ namespace Celeste {
                     return bank;
 
                 ModAsset asset;
-                if (Everest.Content.TryGet<AssetTypeBank>(string.Format("Audio/{0}", name), out asset)) {
+                if (Everest.Content.TryGet<AssetTypeBank>($"Audio/{name}", out asset)) {
                     bank = IngestBank(asset);
 
                 } else {
@@ -332,7 +330,7 @@ namespace Celeste {
                 }
 
                 if (loadStrings) {
-                    if (Everest.Content.TryGet<AssetTypeBank>(string.Format("Audio/{0}.strings", name), out asset)) {
+                    if (Everest.Content.TryGet<AssetTypeBank>($"Audio/{name}.strings", out asset)) {
                         IngestBank(asset);
                     } else {
                         Bank strings;

--- a/Celeste.Mod.mm/Patches/BinaryPacker.cs
+++ b/Celeste.Mod.mm/Patches/BinaryPacker.cs
@@ -1,30 +1,119 @@
 ﻿#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
 
 using MonoMod;
+using System.Collections.Generic;
+using System.IO;
+using System;
+using System.Globalization;
 
 namespace Celeste {
     static class patch_BinaryPacker {
+        [MonoModIgnore]
+        private static string[] stringLookup;
 
         [MonoModIgnore] // We don't want to change anything about the method...
         [ProxyFileCalls] // ... except for proxying all System.IO.File.* calls to Celeste.Mod.FileProxy.*
         public static extern BinaryPacker.Element FromBinary(string filename);
+
+        // optimise the method
+        [MonoModReplace]
+        private static BinaryPacker.Element ReadElement(BinaryReader reader) {
+            BinaryPacker.Element element = new();
+            element.Name = stringLookup[reader.ReadInt16()];
+            
+            byte attributeCount = reader.ReadByte();
+            if (attributeCount > 0)
+                element.Attributes = new(attributeCount); // insert attribute count here to reduce memory allocations in the future
+
+            for (int i = 0; i < attributeCount; i++) {
+                string key = stringLookup[reader.ReadInt16()];
+                byte type = reader.ReadByte();
+
+                object obj = type switch {
+                    0 => reader.ReadBoolean(),
+                    1 => Convert.ToInt32(reader.ReadByte()),
+                    2 => Convert.ToInt32(reader.ReadInt16()),
+                    3 => reader.ReadInt32(),
+                    4 => reader.ReadSingle(),
+                    5 => stringLookup[reader.ReadInt16()],
+                    6 => reader.ReadString(),
+                    7 => ReadRunLengthEncoded(reader),
+                    _ => null
+                };
+                element.Attributes.Add(key, obj);
+            }
+
+            short childCount = reader.ReadInt16();
+            if (childCount > 0)
+                element.Children = new(childCount); // provide the starting capacity here
+            for (int i = 0; i < childCount; i++)
+                element.Children.Add(ReadElement(reader));
+
+            return element;
+        }
+
+        private static string ReadRunLengthEncoded(BinaryReader reader) {
+            short count = reader.ReadInt16();
+            
+            byte[] buffer = _runLengthEncodedBuffer ??= new byte[short.MaxValue];
+            int read = reader.Read(buffer, 0, count);
+
+            return patch_RunLengthEncoding.Decode(buffer.AsSpan()[..read]);
+        }
+
+        [ThreadStatic]
+        private static byte[] _runLengthEncodedBuffer;
 
         public class Element : BinaryPacker.Element {
             public extern bool orig_HasAttr(string name);
             public new bool HasAttr(string name)
                 => orig_HasAttr(name) || orig_HasAttr(name.ToLowerInvariant());
 
-            public extern string orig_Attr(string name, string defaultValue = "");
-            public new string Attr(string name, string defaultValue = "")
-                => orig_Attr(name, orig_Attr(name.ToLowerInvariant(), defaultValue));
+            [MonoModReplace] // implement case-insensitivity
+            public new string Attr(string name, string defaultValue = "") {
+                if (!AttrCore(name, out object stored))
+                    return defaultValue;
 
-            public extern bool orig_AttrBool(string name, bool defaultValue = false);
-            public new bool AttrBool(string name, bool defaultValue = false)
-                => orig_AttrBool(name, orig_AttrBool(name.ToLowerInvariant(), defaultValue));
+                return stored.ToString();
+            }
 
-            public extern float orig_AttrFloat(string name, float defaultValue = 0f);
-            public new float AttrFloat(string name, float defaultValue = 0f)
-                => orig_AttrFloat(name, orig_AttrFloat(name.ToLowerInvariant(), defaultValue));
+            [MonoModReplace] // implement case-insensitivity
+            public new bool AttrBool(string name, bool defaultValue = false) {
+                if (!AttrCore(name, out object stored))
+                    return defaultValue;
+                
+                return stored is bool flag ? flag : Convert.ToBoolean(stored, CultureInfo.InvariantCulture);
+            }
+
+            [MonoModReplace] // implement case-insensitivity
+            public new float AttrFloat(string name, float defaultValue = 0f){
+                if (!AttrCore(name, out object stored))
+                    return defaultValue;
+                
+                return stored is float f ? f : Convert.ToSingle(stored, CultureInfo.InvariantCulture);
+            }
+
+            /// <summary>
+            /// Core method for all Attr methods, which handles case-insensitive fallbacks.
+            /// </summary>
+            /// <returns>Whether a given attribute exists in the element</returns>
+            private bool AttrCore(string name, out object stored) {
+                if (Attributes is not { } attributes) {
+                    stored = null;
+                    return false;
+                }
+
+                if (attributes.TryGetValue(name, out stored)) {
+                    return true;
+                }
+                
+                if (attributes.TryGetValue(name.ToLowerInvariant(), out stored)) {
+                    return true;
+                }
+
+                stored = null;
+                return false;
+            }
         }
 
     }

--- a/Celeste.Mod.mm/Patches/RunLengthEncoding.cs
+++ b/Celeste.Mod.mm/Patches/RunLengthEncoding.cs
@@ -1,0 +1,40 @@
+﻿using MonoMod;
+using System;
+
+namespace Celeste {
+    static class patch_RunLengthEncoding {
+
+        [MonoModReplace]
+        public static string Decode(byte[] bytes) => Decode(bytes.AsSpan());
+        
+        // Optimise this method using spans and a shared buffer
+        public static string Decode(ReadOnlySpan<byte> bytes) {
+            _decodeBuffer ??= new char[4098];
+            
+            int written = 0;
+            var decodeBuffer = _decodeBuffer.AsSpan();
+            for (int index = 0; index < bytes.Length - 1; index += 2) {
+                byte count = bytes[index];
+                char c = (char) bytes[index + 1];
+                int endIndex = written + count;
+
+                // resize our buffer if needed
+                if (decodeBuffer.Length <= endIndex) {
+                    Array.Resize(ref _decodeBuffer, Math.Max(_decodeBuffer.Length * 2, endIndex));
+                    decodeBuffer = _decodeBuffer.AsSpan();
+                }
+                
+                decodeBuffer[written..endIndex].Fill(c);
+                written = endIndex;
+            }
+            
+            return decodeBuffer[..written].ToString();
+        }
+
+        /// <summary>
+        /// A buffer used by <see cref="Decode(ReadOnlySpan{byte})"/> to create the returned string.
+        /// </summary>
+        [ThreadStatic]
+        private static char[] _decodeBuffer;
+    }
+}


### PR DESCRIPTION
Shaves off a few seconds from loading times by optimizing various frequently called methods.

Most of the timesave is in `BinaryPacker`, achieved by providing starting capacities for lists and dictionaries so that they don't need to be resized all the time.

`RunLengthEncoding.Decode` got optimized to use a shared buffer instead of a `StringBuilder`, and now also accepts a `ReadOnlySpan<byte>` as an argument. From my testing, the shared buffer doesn't exceed 1MB, so it probably isn't worth it to clear it after map loading is finished. In the future, it might be worth it to make an internal class storing various shared buffers to be able to reuse them.

`Tracker.Initialize` ends up calling `FakeAssembly.GetTypesSafe` several times, so this PR introduces a temporary cache inside the `Tracker` to store the results of that call, saving ~200ms. Might be worth it to figure out caching `FakeAssembly.GetTypesSafe` directly, though that would require figuring out when the cache needs to be cleared...

`StrawberryRegistry`'s methods get called for each entity in each map in everest's `CoreMapProcessor`, taking a lot of time. A cache using `HashSet`s for them got introduced.

`BinaryPacker.Element.Attr*` methods were written *horribly* previously, always doing 2 dictionary lookups and a `string.ToLower`, even if that was unnecessary. They got rewritten now to return early.

A few other places got optimized slightly with spans, string interpolation instead of `string.Format`, and `Array.Empty<T>`, nothing major though.