### PR TITLE
Add DecalRegistryHandler and refactor all everest handlers to use it

### DIFF
--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/AnimationDecalRegistryHandler.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/AnimationDecalRegistryHandler.cs
@@ -1,0 +1,17 @@
+﻿using System.Xml;
+
+namespace Celeste.Mod.Registry.DecalRegistryHandlers; 
+
+internal sealed class AnimationDecalRegistryHandler : DecalRegistryHandler {
+    private int[] _frames;
+    
+    public override string Name => "animation";
+    
+    public override void Parse(XmlAttributeCollection xml) {
+        _frames = GetCSVIntWithTricks(xml, "frames", "0");
+    }
+
+    public override void ApplyTo(Decal decal) {
+        ((patch_Decal)decal).MakeAnimation(_frames);
+    }
+}

--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/AnimationSpeedDecalRegistryHandler.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/AnimationSpeedDecalRegistryHandler.cs
@@ -1,0 +1,18 @@
+﻿using System.Xml;
+
+namespace Celeste.Mod.Registry.DecalRegistryHandlers; 
+
+internal sealed class AnimationSpeedDecalRegistryHandler : DecalRegistryHandler {
+    private int? _value;
+    
+    public override string Name => "animationSpeed";
+    
+    public override void Parse(XmlAttributeCollection xml) {
+        _value = GetNullable<int>(xml, "value");
+    }
+
+    public override void ApplyTo(Decal decal) {
+        if (_value is { } value)
+            decal.AnimationSpeed = value;
+    }
+}

--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/BannerDecalRegistryHandler.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/BannerDecalRegistryHandler.cs
@@ -1,0 +1,28 @@
+﻿using System.Xml;
+
+namespace Celeste.Mod.Registry.DecalRegistryHandlers; 
+
+internal sealed class BannerDecalRegistryHandler : DecalRegistryHandler {
+    private float _speed, _amplitude, _sliceSinIncrement, _offset;
+    private int _sliceSize;
+    private bool _easeDown, _onlyIfWindy;
+    
+    public override string Name => "banner";
+    
+    public override void Parse(XmlAttributeCollection xml) {
+        _speed = Get(xml, "speed", 1f);
+        _amplitude = Get(xml, "amplitude", 1f);
+        _sliceSize = Get(xml, "sliceSize", 1);
+        _sliceSinIncrement = Get(xml, "sliceSinIncrement", 1f);
+        _easeDown = GetBool(xml, "easeDown", false);
+        _offset = Get(xml, "offset", 0f);
+        _onlyIfWindy = GetBool(xml, "onlyIfWindy", false);
+    }
+
+    public override void ApplyTo(Decal decal) {
+        _amplitude *= ((patch_Decal)decal).Scale.X;
+        _offset *= float.Sign(((patch_Decal)decal).Scale.X) * float.Abs(((patch_Decal)decal).Scale.Y);
+
+        ((patch_Decal)decal).MakeBanner(_speed, _amplitude, _sliceSize, _sliceSinIncrement, _easeDown, _offset, _onlyIfWindy);
+    }
+}

--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/BloomDecalRegistryHandler.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/BloomDecalRegistryHandler.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.Xna.Framework;
+using System.Xml;
+
+namespace Celeste.Mod.Registry.DecalRegistryHandlers;
+
+internal sealed class BloomDecalRegistryHandler : DecalRegistryHandler {
+    private float _offX, _offY, _alpha, _radius;
+    
+    public override string Name => "bloom";
+    
+    public override void Parse(XmlAttributeCollection xml) {
+        _offX = Get(xml, "offsetX", 0f);
+        _offY = Get(xml, "offsetY", 0f);
+        _alpha = Get(xml, "alpha", 1f);
+        _radius = Get(xml, "radius", 1f);
+    }
+
+    public override void ApplyTo(Decal decal) {
+        Vector2 offset = decal.GetScaledOffset(_offX, _offY);
+        float radius = decal.GetScaledRadius(_radius);
+
+        decal.Add(new BloomPoint(offset, _alpha, radius));
+    }
+}

--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/CoreSwapDecalRegistryHandler.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/CoreSwapDecalRegistryHandler.cs
@@ -1,0 +1,18 @@
+﻿using System.Xml;
+
+namespace Celeste.Mod.Registry.DecalRegistryHandlers; 
+
+internal sealed class CoreSwapDecalRegistryHandler : DecalRegistryHandler {
+    private string _hotPath, _coldPath;
+    
+    public override string Name => "coreSwap";
+    
+    public override void Parse(XmlAttributeCollection xml) {
+        _hotPath = GetString(xml, "hotPath", null);
+        _coldPath = GetString(xml, "coldPath", null);
+    }
+
+    public override void ApplyTo(Decal decal) {
+        ((patch_Decal)decal).MakeFlagSwap("cold", _hotPath, _coldPath);
+    }
+}

--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/DecalRegistryHandler.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/DecalRegistryHandler.cs
@@ -1,0 +1,129 @@
+﻿using Microsoft.Xna.Framework;
+using Monocle;
+using System;
+using System.Globalization;
+using System.Xml;
+
+namespace Celeste.Mod.Registry.DecalRegistryHandlers {
+    /// <summary>
+    /// Represents a handler for a specific decal registry tag.
+    /// A new instance of this class will be created for each xml entry.
+    /// To register your handler, call <see cref="DecalRegistry.AddPropertyHandler{T}()"/>
+    /// </summary>
+    public abstract class DecalRegistryHandler {
+        /// <summary>
+        /// The name of this handler, which should match the xml tag name which creates this handler.
+        /// This field will be accessed in <see cref="DecalRegistry.AddPropertyHandler{T}()"/>, as well as in error handling.
+        /// </summary>
+        public abstract string Name { get; }
+        
+        /// <summary>
+        /// Parses the xml entry for an instance of this decal registry property.
+        /// This function gets called once per class instance, while parsing the xml file.
+        /// Use it to cache attributes from xml into fields on this handler instance.
+        /// </summary>
+        public abstract void Parse(XmlAttributeCollection xml);
+
+        /// <summary>
+        /// Applies this handler to the given decal.
+        /// This function gets called for each decal, so make sure to do as much work as possible in <see cref="Parse"/> instead.
+        /// </summary>
+        public abstract void ApplyTo(Decal decal);
+        
+        /// <summary>
+        /// Gets a parsable value from the xml attribute named <paramref name="attr"/>.
+        /// If the attribute does not exist or is invalid, returns <paramref name="def"/>.
+        /// </summary>
+        public T Get<T>(XmlAttributeCollection xml, string attr, T def)
+            where T : IParsable<T> {
+            if (xml[attr] is not { } attribute) 
+                return def;
+            
+            if (T.TryParse(attribute.Value, CultureInfo.InvariantCulture, out T parsed)) {
+                return parsed;
+            }
+                
+            Logger.Log(LogLevel.Warn, "Decal Registry", 
+                $"Invalid '{typeof(T).Name}' value '{attribute.Value}' for attribute '{attr}' in property '{Name}'. Defaulting to {def}.");
+
+            return def;
+        }
+        
+        /// <summary>
+        /// Gets a bool value from the xml attribute named <paramref name="attr"/>.
+        /// If the attribute does not exist or is invalid, returns <paramref name="def"/>.
+        /// </summary>
+        // bool doesn't implement IParseable???
+        public bool GetBool(XmlAttributeCollection xml, string attr, bool def) {
+            if (xml[attr] is not { } attribute) 
+                return def;
+            
+            if (bool.TryParse(attribute.Value, out bool parsed)) {
+                return parsed;
+            }
+                
+            Logger.Log(LogLevel.Warn, "Decal Registry", $"Invalid Bool value {attribute.Value} for attribute {attr} in property {Name}. Defaulting to {def}.");
+
+            return def;
+        }
+        
+        /// <summary>
+        /// Gets a string value from the xml attribute named <paramref name="attr"/>.
+        /// If the attribute does not exist or is invalid, returns <paramref name="def"/>.
+        /// </summary>
+        public string GetString(XmlAttributeCollection xml, string attr, string def) {
+            if (xml[attr] is not { } attribute) 
+                return def;
+
+            return attribute.Value;
+        }
+        
+        /// <summary>
+        /// Gets a hex color value from the xml attribute named <paramref name="attr"/>, by calling <see cref="Calc.HexToColor(string)"/>.
+        /// If the attribute does not exist or is invalid, returns <paramref name="def"/>.
+        /// </summary>
+        public Color GetHexColor(XmlAttributeCollection xml, string attr, Color def) {
+            if (xml[attr] is not { } attribute) 
+                return def;
+
+            return Calc.HexToColor(attribute.Value);
+        }
+
+        /// <summary>
+        /// Gets a CSV int array value from the xml attribute named <paramref name="attr"/>, by calling <see cref="Calc.ReadCSVIntWithTricks(string)"/>.
+        /// If the attribute does not exist or is invalid, returns <paramref name="def"/>.
+        /// </summary>
+        public int[] GetCSVIntWithTricks(XmlAttributeCollection xml, string attr, string def) {
+            if (xml[attr] is not { } attribute) 
+                return Calc.ReadCSVIntWithTricks(def);
+
+            try {
+                return Calc.ReadCSVIntWithTricks(attribute.Value);
+            } catch (Exception) {
+                Logger.Log(LogLevel.Warn, "Decal Registry", $"Invalid CSVInt value {attribute.Value} for attribute {attr} in property {Name}. Defaulting to {def}.");
+                return Calc.ReadCSVIntWithTricks(def);
+            }
+        }
+        
+        /// <summary>
+        /// Equivalent to <see cref="Get{TParsable}"/>, but returns null for value types if the attribute does not exist.
+        /// </summary>
+        public TParsable? GetNullable<TParsable>(XmlAttributeCollection xml, string attr) where TParsable : struct, IParsable<TParsable> {
+            if (xml[attr] is not { } attribute) 
+                return null;
+            
+            if (TParsable.TryParse(attribute.Value, CultureInfo.InvariantCulture, out TParsable parsed)) {
+                return parsed;
+            }
+                
+            Logger.Log(LogLevel.Warn, "Decal Registry", $"Invalid {typeof(TParsable).Name} value {attribute.Value} for attribute {attr} in property {Name}. Defaulting to null.");
+
+            return null;
+        }
+        
+        public Vector2 GetVector2(XmlAttributeCollection xml, string attrX, string attrY, Vector2 def) {
+            return new(Get(xml, attrX, def.X), Get(xml, attrY, def.Y));
+        }
+    }
+}
+    

--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/DepthDecalRegistryHandler.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/DepthDecalRegistryHandler.cs
@@ -1,0 +1,18 @@
+﻿using System.Xml;
+
+namespace Celeste.Mod.Registry.DecalRegistryHandlers; 
+
+internal sealed class DepthDecalRegistryHandler : DecalRegistryHandler {
+    private int? _depth;
+    
+    public override string Name => "depth";
+    
+    public override void Parse(XmlAttributeCollection xml) {
+        _depth = GetNullable<int>(xml, "depth");
+    }
+
+    public override void ApplyTo(Decal decal) {
+        if (_depth is { } depth)
+            decal.Depth = depth;
+    }
+}

--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/FlagSwapDecalRegistryHandler.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/FlagSwapDecalRegistryHandler.cs
@@ -1,0 +1,21 @@
+﻿using System.Xml;
+
+namespace Celeste.Mod.Registry.DecalRegistryHandlers; 
+
+internal sealed class FlagSwapDecalRegistryHandler : DecalRegistryHandler {
+    private string _flag, _offPath, _onPath;
+    
+    public override string Name => "flagSwap";
+    
+    public override void Parse(XmlAttributeCollection xml) {
+        _flag = GetString(xml, "flag", null);
+        _offPath = GetString(xml, "offPath", null);
+        _onPath = GetString(xml, "onPath", null);
+    }
+
+    public override void ApplyTo(Decal decal) {
+        if (_flag is { } flag) {
+            ((patch_Decal)decal).MakeFlagSwap(flag, _offPath, _onPath);
+        }
+    }
+}

--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/FloatyDecalRegistryHandler.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/FloatyDecalRegistryHandler.cs
@@ -1,0 +1,14 @@
+﻿using System.Xml;
+
+namespace Celeste.Mod.Registry.DecalRegistryHandlers; 
+
+internal sealed class FloatyDecalRegistryHandler : DecalRegistryHandler {
+    public override string Name => "floaty";
+    
+    public override void Parse(XmlAttributeCollection xml) {
+    }
+
+    public override void ApplyTo(Decal decal) {
+        ((patch_Decal)decal).MakeFloaty();
+    }
+}

--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/LegacyDecalRegistryHandler.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/LegacyDecalRegistryHandler.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Xml;
+
+namespace Celeste.Mod.Registry.DecalRegistryHandlers; 
+
+/// <summary>
+/// A wrapper class which allows legacy callback-style decal registry handlers to work with the new system
+/// </summary>
+internal sealed class LegacyDecalRegistryHandler : DecalRegistryHandler {
+    private XmlAttributeCollection _xml;
+    private readonly Action<Decal, XmlAttributeCollection> _callback;
+
+    public LegacyDecalRegistryHandler(string propName, Action<Decal, XmlAttributeCollection> callback) {
+        _callback = callback;
+        Name = propName;
+    }
+
+    public override string Name { get; }
+
+    public override void Parse(XmlAttributeCollection xml) {
+        _xml = xml;
+    }
+
+    public override void ApplyTo(Decal decal) {
+        _callback(decal, _xml);
+    }
+}

--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/LightDecalRegistryHandler.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/LightDecalRegistryHandler.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.Xna.Framework;
+using Monocle;
+using System.Xml;
+
+namespace Celeste.Mod.Registry.DecalRegistryHandlers; 
+
+internal sealed class LightDecalRegistryHandler : DecalRegistryHandler {
+    private float _offX, _offY, _alpha;
+    private int _startFade, _endFade;
+    private Color _color;
+    
+    public override string Name => "light";
+    
+    public override void Parse(XmlAttributeCollection xml) {
+        _offX = Get(xml, "offsetX", 0f);
+        _offY = Get(xml, "offsetY", 0f);
+        _color = GetHexColor(xml, "color", Color.White);
+        _alpha = Get(xml, "alpha", 1f);
+        _startFade = Get(xml, "startFade", 16);
+        _endFade = Get(xml, "endFade", 24);
+    }
+
+    public override void ApplyTo(Decal decal) {
+        Vector2 offset = decal.GetScaledOffset(_offX, _offY);
+        int startFade = (int) decal.GetScaledRadius(_startFade);
+        int endFade = (int) decal.GetScaledRadius(_endFade);
+
+        decal.Add(new VertexLight(offset, _color, _alpha, startFade, endFade));
+    }
+}

--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/LightOccludeDecalRegistryHandler.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/LightOccludeDecalRegistryHandler.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.Xna.Framework;
+using System.Xml;
+
+namespace Celeste.Mod.Registry.DecalRegistryHandlers; 
+
+internal sealed class LightOccludeDecalRegistryHandler : DecalRegistryHandler {
+    private int _x, _y, _width, _height;
+    private float _alpha;
+    
+    public override string Name => "lightOcclude";
+    
+    public override void Parse(XmlAttributeCollection xml) {
+        _x = Get(xml, "x", 0);
+        _y = Get(xml, "y", 0);
+        _width = Get(xml, "width", 16);
+        _height = Get(xml, "height", 16);
+        _alpha = Get(xml, "alpha", 1f);
+    }
+
+    public override void ApplyTo(Decal decal) {
+        int x = _x, y = _y, width = _width, height = _height;
+        
+        decal.ScaleRectangle(ref x, ref y, ref width, ref height);
+
+        decal.Add(new LightOcclude(new Rectangle(x, y, width, height), _alpha));
+    }
+}

--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/MirrorDecalRegistryHandler.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/MirrorDecalRegistryHandler.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Xml;
+
+namespace Celeste.Mod.Registry.DecalRegistryHandlers; 
+
+internal sealed class MirrorDecalRegistryHandler : DecalRegistryHandler {
+    private bool _keepOffsetsClose;
+    
+    public override string Name => "mirror";
+    
+    public override void Parse(XmlAttributeCollection xml) {
+        _keepOffsetsClose = GetBool(xml, "keepOffsetsClose", false);
+    }
+
+    public override void ApplyTo(Decal decal) {
+        string text = decal.Name.ToLower();
+        if (text.StartsWith("decals/", StringComparison.Ordinal))
+            text = text.Substring(7);
+        
+        ((patch_Decal)decal).MakeMirror(text, _keepOffsetsClose);
+    }
+}

--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/OverlayDecalRegistryHandler.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/OverlayDecalRegistryHandler.cs
@@ -1,0 +1,13 @@
+﻿using System.Xml;
+
+namespace Celeste.Mod.Registry.DecalRegistryHandlers; 
+
+internal sealed class OverlayDecalRegistryHandler : DecalRegistryHandler {
+    public override string Name => "overlay";
+    public override void Parse(XmlAttributeCollection xml) {
+    }
+
+    public override void ApplyTo(Decal decal) {
+        ((patch_Decal)decal).MakeOverlay();
+    }
+}

--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/ParallaxDecalRegistryHandler.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/ParallaxDecalRegistryHandler.cs
@@ -1,0 +1,19 @@
+﻿using System.Globalization;
+using System.Xml;
+
+namespace Celeste.Mod.Registry.DecalRegistryHandlers; 
+
+internal sealed class ParallaxDecalRegistryHandler : DecalRegistryHandler {
+    private float? _amount;
+    
+    public override string Name => "parallax";
+    
+    public override void Parse(XmlAttributeCollection xml) {
+        _amount = GetNullable<float>(xml, "amount");
+    }
+
+    public override void ApplyTo(Decal decal) {
+        if (_amount is { } amount)
+            ((patch_Decal)decal).MakeParallax(amount);
+    }
+}

--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/RandomizeFrameDecalRegistryHandler.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/RandomizeFrameDecalRegistryHandler.cs
@@ -1,0 +1,14 @@
+﻿using System.Xml;
+
+namespace Celeste.Mod.Registry.DecalRegistryHandlers; 
+
+internal sealed class RandomizeFrameDecalRegistryHandler : DecalRegistryHandler {
+    public override string Name => "randomizeFrame";
+    
+    public override void Parse(XmlAttributeCollection xml) {
+    }
+
+    public override void ApplyTo(Decal decal) {
+        ((patch_Decal)decal).RandomizeStartingFrame();
+    }
+}

--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/ScaleDecalRegistryHandler.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/ScaleDecalRegistryHandler.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.Xna.Framework;
+using System.Xml;
+
+namespace Celeste.Mod.Registry.DecalRegistryHandlers; 
+
+internal sealed class ScaleDecalRegistryHandler : DecalRegistryHandler {
+    private Vector2 _scale;
+    
+    public override string Name => "scale";
+    
+    public override void Parse(XmlAttributeCollection xml) {
+        _scale = GetVector2(xml, "multiplyX", "multiplyY", Vector2.One);
+    }
+
+    public override void ApplyTo(Decal decal) {
+        ((patch_Decal)decal).Scale *= _scale;
+    }
+}

--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/ScaredDecalRegistryHandler.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/ScaredDecalRegistryHandler.cs
@@ -1,0 +1,31 @@
+﻿using Monocle;
+using System.Xml;
+
+namespace Celeste.Mod.Registry.DecalRegistryHandlers; 
+
+internal sealed class ScaredDecalRegistryHandler : DecalRegistryHandler {
+    private int[] _idleFrames, _hiddenFrames, _hideFrames, _showFrames;
+    private int _hideRange, _showRange;
+    
+    public override string Name => "scared";
+    
+    public override void Parse(XmlAttributeCollection xml) {
+        _hideRange = Get(xml, "range", 32);
+        _showRange = Get(xml, "range", 48);
+        
+        _hideRange = Get(xml, "hideRange", _hideRange);
+        _showRange = Get(xml, "showRange", _showRange);
+        
+        _idleFrames = GetCSVIntWithTricks(xml, "idleFrames", "0");
+        _hiddenFrames = GetCSVIntWithTricks(xml, "hiddenFrames", "0");
+        _hideFrames = GetCSVIntWithTricks(xml, "hideFrames", "0");
+        _showFrames = GetCSVIntWithTricks(xml, "showFrames", "0");
+    }
+
+    public override void ApplyTo(Decal decal) {
+        int hideRange = (int) decal.GetScaledRadius(_hideRange);
+        int showRange = (int) decal.GetScaledRadius(_showRange);
+
+        ((patch_Decal)decal).MakeScaredAnimation(hideRange, showRange, _idleFrames, _hiddenFrames, _showFrames, _hideFrames);
+    }
+}

--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/SmokeDecalRegistryHandler.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/SmokeDecalRegistryHandler.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.Xna.Framework;
+using System.Xml;
+
+namespace Celeste.Mod.Registry.DecalRegistryHandlers; 
+
+internal sealed class SmokeDecalRegistryHandler : DecalRegistryHandler {
+    private float _offX, _offY;
+    private bool _inbg;
+    
+    public override string Name => "smoke";
+    
+    public override void Parse(XmlAttributeCollection xml) {
+        _offX = Get(xml, "offsetX", 0f);
+        _offY = Get(xml, "offsetY", 0f);
+        _inbg = GetBool(xml, "inbg", false);
+    }
+
+    public override void ApplyTo(Decal decal) {
+        Vector2 offset = decal.GetScaledOffset(_offX, _offY);
+
+        ((patch_Decal)decal).CreateSmoke(offset, _inbg);
+    }
+}

--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/SolidDecalRegistryHandler.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/SolidDecalRegistryHandler.cs
@@ -1,0 +1,29 @@
+﻿using System.Xml;
+
+namespace Celeste.Mod.Registry.DecalRegistryHandlers; 
+
+internal sealed class SolidDecalRegistryHandler : DecalRegistryHandler {
+    private int _x, _y, _width, _height, _index;
+    private bool _blockWaterfalls, _safe;
+    
+    public override string Name => "solid";
+    
+    public override void Parse(XmlAttributeCollection xml) {
+        _x = Get(xml, "x", 0);
+        _y = Get(xml, "y", 0);
+        _width = Get(xml, "width", 16);
+        _height = Get(xml, "height", 16);
+
+        _index = Get(xml, "index", SurfaceIndex.ResortRoof);
+        _blockWaterfalls = GetBool(xml, "blockWaterfalls", true);
+        _safe = GetBool(xml, "safe", true);
+    }
+
+    public override void ApplyTo(Decal decal) {
+        int x = _x, y = _y, width = _width, height = _height;
+        
+        decal.ScaleRectangle(ref x, ref y, ref width, ref height);
+
+        ((patch_Decal)decal).MakeSolid(x, y, width, height, _index, _blockWaterfalls, _safe);
+    }
+}

--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/SoundDecalRegistryHandler.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/SoundDecalRegistryHandler.cs
@@ -1,0 +1,19 @@
+﻿using System.Xml;
+
+namespace Celeste.Mod.Registry.DecalRegistryHandlers; 
+
+internal sealed class SoundDecalRegistryHandler : DecalRegistryHandler {
+    private string _event;
+    
+    public override string Name => "sound";
+    
+    public override void Parse(XmlAttributeCollection xml) {
+        _event = GetString(xml, "event", null);
+    }
+
+    public override void ApplyTo(Decal decal) {
+        if (_event is { } @event) {
+            decal.Add(new SoundSource(@event));
+        }
+    }
+}

--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/StaticMoverDecalRegistryHandler.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/StaticMoverDecalRegistryHandler.cs
@@ -1,0 +1,24 @@
+﻿using System.Xml;
+
+namespace Celeste.Mod.Registry.DecalRegistryHandlers; 
+
+internal sealed class StaticMoverDecalRegistryHandler : DecalRegistryHandler {
+    private int _x, _y, _width, _height;
+    
+    public override string Name => "staticMover";
+    
+    public override void Parse(XmlAttributeCollection xml) {
+        _x = Get(xml, "x", 0);
+        _y = Get(xml, "y", 0);
+        _width = Get(xml, "width", 16);
+        _height = Get(xml, "height", 16);
+    }
+
+    public override void ApplyTo(Decal decal) {
+        int x = _x, y = _y, width = _width, height = _height;
+        
+        decal.ScaleRectangle(ref x, ref y, ref width, ref height);
+
+        ((patch_Decal)decal).MakeStaticMover(x, y, width, height);
+    }
+}


### PR DESCRIPTION
Currently, decal registry handlers perform XML object parsing for every decal instance, which is inefficient. This also makes it harder to cache things which need a bit more complex handling.

This PR adds a new way of creating decal registry handlers, by extending from this class and calling `DecalRegistry.AddPropertyHandler<T>()`:
```cs
    public abstract class DecalRegistryHandler {
        /// <summary>
        /// The name of this handler, which should match the xml tag name which creates this handler.
        /// This field will be accessed in <see cref="DecalRegistry.AddPropertyHandler{T}()"/>, as well as in error handling.
        /// </summary>
        public abstract string Name { get; }

        /// <summary>
        /// Parses the xml entry for an instance of this decal registry property.
        /// This function gets called once per class instance, while parsing the xml file.
        /// Use it to cache attributes from xml into fields on this handler instance.
        /// </summary>
        public abstract void Parse(XmlAttributeCollection xml);

        /// <summary>
        /// Applies this handler to the given decal.
        /// This function gets called for each decal, so make sure to do as much work as possible in <see cref="Parse"/> instead.
        /// </summary>
        public abstract void ApplyTo(Decal decal);
}
```

This class also exposes a variety of helper methods for easier parsing of the `XmlAttributeCollection`