### PR TITLE
Fix Open Log File Folder not handling paths with spaces

### DIFF
--- a/Celeste.Mod.mm/Mod/UI/CriticalErrorHandler.cs
+++ b/Celeste.Mod.mm/Mod/UI/CriticalErrorHandler.cs
@@ -337,7 +337,7 @@ namespace Celeste.Mod.UI {
 
                 Process.Start(new ProcessStartInfo() {
                    FileName = openProg,
-                   Arguments = Path.GetDirectoryName(LogFile),
+                   ArgumentList = { Path.GetDirectoryName(LogFile) },
                    UseShellExecute = true 
                 });
             }));


### PR DESCRIPTION
Attempting to open a log file path with spaces (for example, `~/Library/Application Support/itch/apps/celeste/Celeste.app/...`) would do nothing due to the space in "Application Support".

Using `ArgumentList` means that .NET will automatically escape arguments if required.

Tested on macOS, should work fine on Windows and Linux but untested.