### PR TITLE
Improve MiniInstaller backup symlink handling

### DIFF
--- a/MiniInstaller/Program.cs
+++ b/MiniInstaller/Program.cs
@@ -319,14 +319,26 @@ namespace MiniInstaller {
             try {
                 CreateBackupSymlinks();
             } catch (IOException e) {
-                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || unchecked((uint) e.HResult) != 0x80070522U) // ERROR_PRIVILEGE_NOT_HELD
+                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
                     throw;
-
-                LogLine("Failed to create backup symlinks - asking user if they want to retry with elevation");
-
-                // On Windows, offer to try again with elevation
-                if (!CreateBackupSymlinksWithElevation())
-                    throw;
+                }
+                switch (unchecked((uint) e.HResult)) {
+                    case 0x80070522U: // ERROR_PRIVILEGE_NOT_HELD
+                        LogLine("Failed to create backup symlinks due to missing privilege - asking user if they want to retry with elevation");
+                        // On Windows, offer to try again with elevation
+                        if (!CreateBackupSymlinksWithElevation()) {
+                            throw;
+                        }
+                        break;
+                    case 0x80070001U: // ERROR_INVALID_FUNCTION
+                        LogLine("Failed to create backup symlinks due to invalid function - warning user");
+                        if (!WarnAboutBackupSymlinkFilesystem()) {
+                            throw;
+                        }
+                        break;
+                    default:
+                        throw;
+                }
             }
         }
 
@@ -334,12 +346,12 @@ namespace MiniInstaller {
         private static bool CreateBackupSymlinksWithElevation() {
             switch (
                 MessageBox(0, """
-                The installer requires administrator privileges to link the vanilla installation to the modded one. 
+                The installer requires administrator privileges during the first installation to link the vanilla installation to the modded one. 
                 This is required to share save data with the "restart into vanilla" feature.
                 If denied, installation will continue, but saves will NOT be shared between vanilla and Everest.
 
                 Proceed with administrator privileges?
-                """.Trim(), "Everest Installation Elevation Request", 0x00000003U | 0x00000030U | 0x00010000U) // MB_YESNOCANCEL | MB_ICONWARNING | MB_SETFOREGROUND
+                """.Trim(), "Everest Installation Elevation Request", 0x00000003U | 0x00000040U | 0x00010000U) // MB_YESNOCANCEL | MB_ICONINFORMATION | MB_SETFOREGROUND
             ) {
                 case 2: // IDCANCEL
                     LogLine("User cancelled installation - rethrowing original error");
@@ -409,6 +421,28 @@ namespace MiniInstaller {
                 case 0: throw new Win32Exception();
             }
 
+            return true;
+        }
+        
+        [SupportedOSPlatform("windows")]
+        private static bool WarnAboutBackupSymlinkFilesystem() {
+            switch (
+                MessageBox(0, """
+                The installer failed to link the vanilla installation to the modded one due to missing support by your filesystem.
+                Installation can continue, but saves will NOT be shared between vanilla and Everest.
+                To fix this issue, install vanilla Celeste on an NTFS partition (this generally means a hard drive/SSD instead of an SD card or flash drive) and repeat the installation there.
+                """.Trim(), "Everest Installation Filesystem Warning", 0x00000001U | 0x00000030U | 0x00010000U) // MB_OKCANCEL | MB_ICONWARNING | MB_SETFOREGROUND)
+            ) {
+                case 2: // IDCANCEL
+                    LogLine("User cancelled installation - rethrowing original error");
+                    return false;
+                case 1: // IDOK
+                    LogLine("Continuing installation on non-NTFS filesystem - running fallback logic");
+                    CreateBackupSymlinksFallback();
+                    break;
+                case 0:
+                    throw new Win32Exception();
+            }
             return true;
         }
 


### PR DESCRIPTION
- Add handling for filesystems that don't support symlinks.
- Change icon for elevation prompt from warning to info.
- Add notice to elevation prompt that this is only required during the first installation.