### PR TITLE
Fix WaterInteraction

### DIFF
--- a/Celeste.Mod.mm/Patches/WaterInteraction.cs
+++ b/Celeste.Mod.mm/Patches/WaterInteraction.cs
@@ -7,17 +7,38 @@ namespace Celeste {
     class patch_WaterInteraction : WaterInteraction {
 
         /// <summary>
-        /// The water collision used for this component's Entity.
+        /// Check whether the component is interacting with a given water-type entity.
+        /// </summary>
+        /// <param name="water">The entity to check the interaction with.</param>
+        /// <returns>Whether the component is interacting with the water.</returns>
+        public bool Check(Entity water) {
+            Collider normalCollider = Entity.Collider;
+            if (_collider != null) {
+                Entity.Collider = _collider;
+            }
+            bool result = water.CollideCheck(Entity);
+            Entity.Collider = normalCollider;
+            return result;
+        }
+
+        public Vector2 AbsoluteCenter => Entity.Position + (_collider ?? Entity.Collider).Center;
+
+        private Collider _collider;
+
+        /// <summary>
+        /// The absolute rectangular bounds around the water collision used for this component's Entity.
         /// </summary>
         public Rectangle Bounds {
             get {
-                if (_bounds is Rectangle bounds) {
-                    return new Rectangle((int) Entity.X + bounds.X, (int) Entity.Y + bounds.Y, bounds.Width, bounds.Height);
-                } else
-                    return new Rectangle((int) Entity.Center.X - 4, (int) Entity.Center.Y, 8, 16);
+                Collider normalCollider = Entity.Collider;
+                if (_collider != null) {
+                    Entity.Collider = _collider; // linking collider to entity makes the position absolute
+                }
+                Rectangle result = Entity.Collider.Bounds;
+                Entity.Collider = normalCollider;
+                return result;
             }
         }
-        private Rectangle? _bounds = null;
 
 
         /// <summary>
@@ -36,8 +57,13 @@ namespace Celeste {
 
         [MonoModConstructor]
         public void ctor(Rectangle bounds, Func<bool> isDashing) {
+            ctor(new Hitbox(bounds.Width, bounds.Height, bounds.X, bounds.Y), isDashing);
+        }
+
+        [MonoModConstructor]
+        public void ctor(Collider collider, Func<bool> isDashing) {
             ctor(isDashing);
-            _bounds = bounds;
+            _collider = collider;
         }
 
     }


### PR DESCRIPTION
The custom hitbox handling for WaterInteraction was very broken and also restricted to rectangular colliders when vanilla technically allows other shapes. This PR attempts to fix it in a way that's backwards compatible as much as possible, although in some cases it reflects the vanilla intention rather than the actual behavior.
Technically the sound sources should be an underwater point instead of the center of the collider, but this is how vanilla does it and you'd have to pay me to touch this MonoModRules patch any more.