### PR TITLE
Further clean up separation between mod and EverestModule

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -435,29 +435,30 @@ namespace Celeste.Mod {
             Assembly asm = typeof(CoreModule).Assembly;
             Type[] types = asm.GetTypesSafe();
             Loader.ProcessAssembly(core.Metadata, asm, types);
+            core.Metadata.RegisterMod();
 
             // Note: Everest fulfills some mod dependencies by itself.
-            new NullModule(new EverestModuleMetadata() {
+            new NullModule(new EverestModuleMetadata {
                 Name = "Celeste",
                 VersionString = $"{Celeste.Instance.Version.ToString()}-{(Flags.IsFNA ? "fna" : "xna")}"
             }).Register();
-            new NullModule(new EverestModuleMetadata() {
+            new NullModule(new EverestModuleMetadata {
                 Name = "DialogCutscene",
                 VersionString = "1.0.0"
             }).Register();
-            new NullModule(new EverestModuleMetadata() {
+            new NullModule(new EverestModuleMetadata {
                 Name = "UpdateChecker",
                 VersionString = "1.0.2"
             }).Register();
-            new NullModule(new EverestModuleMetadata() {
+            new NullModule(new EverestModuleMetadata {
                 Name = "InfiniteSaves",
                 VersionString = "1.0.0"
             }).Register();
-            new NullModule(new EverestModuleMetadata() {
+            new NullModule(new EverestModuleMetadata {
                 Name = "DebugRebind",
                 VersionString = "1.0.0"
             }).Register();
-            new NullModule(new EverestModuleMetadata() {
+            new NullModule(new EverestModuleMetadata {
                 Name = "RebindPeriod",
                 VersionString = "1.0.0"
             }).Register();
@@ -560,35 +561,8 @@ namespace Celeste.Mod {
                     LateInitializeModules(Enumerable.Repeat(module, 1));
             }
 
-            if (Engine.Instance != null && Engine.Scene is Overworld overworld) {
-                // we already are in the overworld. Register new Ouis real quick!
-                Type[] types = FakeAssembly.GetFakeEntryAssembly().GetTypesSafe();
-                foreach (Type type in types) {
-                    if (typeof(Oui).IsAssignableFrom(type) && !type.IsAbstract && !overworld.UIs.Any(ui => ui.GetType() == type)) {
-                        Logger.Log(LogLevel.Verbose, "core", $"Instantiating UI from {module.Metadata}: {type.FullName}");
-
-                        Oui oui = (Oui) Activator.CreateInstance(type);
-                        oui.Visible = false;
-                        overworld.Add(oui);
-                        overworld.UIs.Add(oui);
-                    }
-                }
-            }
-
-            InvalidateInstallationHash();
-
-            EverestModuleMetadata meta = module.Metadata;
-            meta.Hash = GetChecksum(meta);
-
-            // Audio banks are cached, and as such use the module's hash. We can only ingest those now.
-            if (patch_Audio.AudioInitialized) {
-                patch_Audio.IngestNewBanks();
-            }
-
             module.LogRegistration();
             Events.Everest.RegisterModule(module);
-
-            CheckDependenciesOfDelayedMods();
         }
 
         internal static void LateInitializeModules(IEnumerable<EverestModule> modules) {

--- a/Celeste.Mod.mm/Mod/Module/EverestModuleMetadata.cs
+++ b/Celeste.Mod.mm/Mod/Module/EverestModuleMetadata.cs
@@ -122,5 +122,21 @@ namespace Celeste.Mod {
             }
         }
 
+        /// <summary>
+        /// Performs the mod registration tasks that should be performed for every mod once, not for every instance of EverestModule or every DLL.
+        /// Called after the EverestModules have been registered.
+        /// </summary>
+        internal void RegisterMod() {
+            Everest.InvalidateInstallationHash();
+            Hash = Everest.GetChecksum(this);
+
+            // Audio banks are cached, and as such use the module's hash. We can only ingest those now.
+            if (patch_Audio.AudioInitialized) {
+                patch_Audio.IngestNewBanks();
+            }
+            
+            Everest.CheckDependenciesOfDelayedMods();
+        }
+
     }
 }


### PR DESCRIPTION
EverestModule.Register still did a few things that only need to be done once per mod instead of once per EverestModule instance. (Technically some of those should maybe be done once per multimeta, but that's a can of worms for later.) This PR moves those so they only run at the appropriate points. Needs to be tested thoroughly (I've tested that we can still load mods and that the Oui hotloading works.)