### PR TITLE
Log untranslated Dialog IDs

### DIFF
--- a/Celeste.Mod.mm/Patches/Dialog.cs
+++ b/Celeste.Mod.mm/Patches/Dialog.cs
@@ -173,16 +173,10 @@ namespace Celeste {
                 return false;
 
             name = name.DialogKeyify();
-            if (language == null)
-                language = Dialog.Language;
+            language ??= Dialog.Language;
 
-            if (language.Dialog.ContainsKey(name))
-                return true;
-
-            if (language != FallbackLanguage)
-                return Has(name, FallbackLanguage);
-
-            return false;
+            return language.Dialog.ContainsKey(name)
+                || (language != FallbackLanguage && FallbackLanguage.Dialog.ContainsKey(name));
         }
 
         /// <inheritdoc cref="Dialog.Get(string, Language)"/>
@@ -192,8 +186,7 @@ namespace Celeste {
                 return "";
 
             name = name.DialogKeyify();
-            if (language == null)
-                language = Dialog.Language;
+            language ??= Dialog.Language;
 
             if (language.Dialog.TryGetValue(name, out string result))
                 return result;
@@ -212,8 +205,7 @@ namespace Celeste {
                 return "";
 
             name = name.DialogKeyify();
-            if (language == null)
-                language = Dialog.Language;
+            language ??= Dialog.Language;
 
             if (language.Cleaned.TryGetValue(name, out string result))
                 return result;

--- a/Celeste.Mod.mm/Patches/Dialog.cs
+++ b/Celeste.Mod.mm/Patches/Dialog.cs
@@ -88,7 +88,7 @@ namespace Celeste {
 
         public static void RefreshLanguages() {
             PostLanguageLoad();
-
+            DialogExt.MissingDialogIDs.Clear();
             Dialog.Language = Dialog.Languages[Dialog.Language.Id];
         }
 
@@ -200,6 +200,9 @@ namespace Celeste {
             if (language != FallbackLanguage)
                 return Get(name, FallbackLanguage);
 
+            if (DialogExt.MissingDialogIDs.Add(name))
+                Logger.Log(LogLevel.Warn, "Dialog", $"Could not get Dialog ID: {name}");
+
             return "[" + name + "]";
         }
 
@@ -219,6 +222,9 @@ namespace Celeste {
             if (language != FallbackLanguage)
                 return Clean(name, FallbackLanguage);
 
+            if (DialogExt.MissingDialogIDs.Add(name))
+                Logger.Log(LogLevel.Warn, "Dialog", $"Could not clean Dialog ID: {name}");
+
             return "{" + name + "}";
         }
 
@@ -227,10 +233,19 @@ namespace Celeste {
         /// Tries to find a value under both "LEVELSET_NAME" and "NAME", otherwise returns name.SpacedPascalCase()
         /// </summary>
         public static string CleanLevelSet(string name) {
-            if (string.IsNullOrEmpty(name)) {
+            if (string.IsNullOrEmpty(name))
                 return Dialog.Clean("levelset_");
-            }
-            return ("levelset_" + name).DialogCleanOrNull() ?? name.DialogCleanOrNull() ?? name.SpacedPascalCase();
+
+            name = name.DialogKeyify();
+
+            string cleaned = ("levelset_" + name).DialogCleanOrNull() ?? name.DialogCleanOrNull();
+            if (cleaned != null)
+                return cleaned;
+
+            if (DialogExt.MissingDialogIDs.Add(name))
+                Logger.Log(LogLevel.Warn, "Dialog", $"Could not clean level set Dialog ID: {name}");
+
+            return name.SpacedPascalCase();
         }
 
     }
@@ -240,6 +255,8 @@ namespace Celeste {
         [Obsolete("Use Dialog.CleanLevelSet instead.")]
         public static string CleanLevelSet(string name)
             => patch_Dialog.CleanLevelSet(name);
+
+        internal static readonly HashSet<string> MissingDialogIDs = new();
 
     }
 }

--- a/Celeste.Mod.mm/Patches/Dialog.cs
+++ b/Celeste.Mod.mm/Patches/Dialog.cs
@@ -89,7 +89,7 @@ namespace Celeste {
 
         public static void RefreshLanguages() {
             PostLanguageLoad();
-            DialogExt.MissingDialogIds.Clear();
+            MissingDialogIds.Clear();
             Dialog.Language = Dialog.Languages[Dialog.Language.Id];
         }
 
@@ -243,7 +243,7 @@ namespace Celeste {
         /// <param name="language">The language to check (defaults to <see cref="Dialog.Language"/>)</param>
         /// <param name="isLevelSet">Whether this is a level set Dialog ID</param>
         private static void WarnMissingDialogId(string dialogId, Language language = null, bool isLevelSet = false) {
-            if (!DialogExt.MissingDialogIds.Add(dialogId))
+            if (!MissingDialogIds.Add(dialogId))
                 return;
 
             language ??= Dialog.Language;
@@ -262,6 +262,15 @@ namespace Celeste {
             Logger.Log(LogLevel.Warn, "Dialog", logBuilder.ToString());
         }
 
+        // can't move the field higher up, else MonoMod causes a member name conflict in a compiler generated class
+        // see https://github.com/MonoMod/MonoMod/issues/73
+
+        /// <summary>
+        /// Contains all Dialog IDs which don't have a translation in the current language or <tt>English.txt</tt>.
+        /// It is reset whenever <see cref="AssetReloadHelper"/> reloads the current language.
+        /// </summary>
+        public static readonly HashSet<string> MissingDialogIds = new();
+
     }
     public static class DialogExt {
 
@@ -269,12 +278,6 @@ namespace Celeste {
         [Obsolete("Use Dialog.CleanLevelSet instead.")]
         public static string CleanLevelSet(string name)
             => patch_Dialog.CleanLevelSet(name);
-
-        /// <summary>
-        /// Contains all Dialog IDs which don't have a translation in the current language or <tt>English.txt</tt>.
-        /// It is reset whenever <see cref="AssetReloadHelper"/> reloads the current language.
-        /// </summary>
-        public static readonly HashSet<string> MissingDialogIds = new();
 
     }
 }

--- a/Celeste.Mod.mm/Patches/Dialog.cs
+++ b/Celeste.Mod.mm/Patches/Dialog.cs
@@ -260,10 +260,10 @@ namespace Celeste {
             if (isLevelSet)
                 logBuilder.Append("Level set ");
 
-            logBuilder.AppendFormat("Dialog ID \"{0}\" has no translation in {1}.txt", dialogId, language.Label ?? language.Id);
+            logBuilder.AppendFormat("Dialog ID \"{0}\" has no translation in {1}", dialogId, language.FilePath);
 
             if (language != FallbackLanguage)
-                logBuilder.AppendFormat(" or {0}.txt", FallbackLanguage.Label);
+                logBuilder.AppendFormat(" or {0}", FallbackLanguage.FilePath);
 
             logBuilder.Append('!');
 

--- a/Celeste.Mod.mm/Patches/Language.cs
+++ b/Celeste.Mod.mm/Patches/Language.cs
@@ -1,4 +1,6 @@
-﻿using Celeste.Mod;
+﻿#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
+
+using Celeste.Mod;
 using Monocle;
 using MonoMod;
 using System;
@@ -25,6 +27,13 @@ namespace Celeste {
         [MonoModIgnore]
         [PatchLoadLanguage]
         public static extern new Language FromTxt(string path);
+
+        public static extern Language orig_FromExport(string path);
+        public static new Language FromExport(string path) {
+            Language lang = orig_FromExport(path);
+            lang.FilePath = Path.GetFileNameWithoutExtension(path);
+            return lang;
+        }
 
         public static Language FromModExport(ModAsset asset) {
             Language lang = new Language();
@@ -56,6 +65,7 @@ namespace Celeste {
                 }
             }
 
+            lang.FilePath = Path.GetFileNameWithoutExtension(asset.PathVirtual);
             return lang;
         }
 


### PR DESCRIPTION
Whenever an untranslated Dialog ID shows up, log it. The mapper can then copy the Dialog ID from their `log.txt` or console for convenience.

The missing ID is only logged the first time it appears. If ARH reloads languages, the ID will be logged again.

Trying to add the field directly to `patch_Dialog` causes a mysterious `MissingFieldException`, so I had to put it in DialogExt.

```
System.MissingFieldException: Field not found: '<>c.<>9__5_0'.
   at Celeste.Dialog._GetFiles(String root, String searchPattern, SearchOption searchOption)
```