### PR TITLE
Generate a publicized vanilla DLL while keeping Everest untouched

### DIFF
--- a/MiniInstaller/MiniInstaller.csproj
+++ b/MiniInstaller/MiniInstaller.csproj
@@ -21,6 +21,8 @@
   <!-- Set up Piton AppHosts -->
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.HostModel" Version="3.1.16" />
+    <!-- We just use this to reference the types. The assembly will be loaded dynamically. -->
+    <PackageReference Include="Mono.Cecil" Version="0.11.4" PrivateAssets="all" />
 
     <Content Include="..\lib-ext\piton-runtime.yaml" TargetPath="piton-runtime.yaml" CopyToOutputDirectory="always" CopyToPublishDirectory="always" />
   </ItemGroup>

--- a/MiniInstaller/Program.cs
+++ b/MiniInstaller/Program.cs
@@ -152,6 +152,8 @@ namespace MiniInstaller {
                     SetupAppHosts(PathEverestExe, PathEverestDLL, PathEverestDLL);
 
                     CombineXMLDoc(Path.ChangeExtension(PathCelesteExe, ".Mod.mm.xml"), Path.ChangeExtension(PathCelesteExe, ".xml"));
+                    
+                    File.Copy(Path.ChangeExtension(PathCelesteExe, ".xml"), Path.ChangeExtension(PathEverestExePublic, ".xml"));
 
                     // If we're updating, start the game. Otherwise, close the window.
                     if (PathUpdate != null) {


### PR DESCRIPTION
This creates a new `Celeste.public.dll`, which has all vanilla types/fields/methods publicizied, but keep Everest stuff untouched. This has the benefit of not requiring the publicizier in mods and it avoids accidently publicizing Everest internal stuff.

I'm not sure how to properly include this new DLL inside the lib-stripped release, but that would need to be done to access it inside a CI run.