### PR TITLE
Fix on screen keyboard handling

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/TextInput.cs
+++ b/Celeste.Mod.mm/Mod/Everest/TextInput.cs
@@ -62,6 +62,12 @@ namespace Celeste.Mod {
             } else if ((_OnInput == null || _OnInput.GetInvocationList().Length == 0) && TextInputEXT.IsTextInputActive()) {
                 TextInputEXT.StopTextInput();
             }
+
+            // Warn the modder if there's ever multiple subscriptions, because chances are that they misused the event
+            if (_OnInput?.GetInvocationList().Length > 1) {
+                Logger.Log(LogLevel.Warn, "TextInput", 
+                    "Simultaneous text input subscriptions detected, is this a bug? See TextInput.OnInput for proper usage");
+            }
         }
 
         public static string GetClipboardText() => SDL.SDL_GetClipboardText();

--- a/Celeste.Mod.mm/Mod/Everest/TextInput.cs
+++ b/Celeste.Mod.mm/Mod/Everest/TextInput.cs
@@ -40,9 +40,11 @@ namespace Celeste.Mod {
 
         /// <summary>
         /// Invoked whenever text input occurs, including some "input action" characters.
+        /// This event is in charge of managing `StartTextInput` and `StopTextInput` calls.
+        /// Consequently its use should be restricted to when text input from the keyboard is needed.
+        /// Note that the aforementioned FNA calls will bring up virtual keyboard (if available, Steam Deck is an
+        /// example), so it's the modder's job to make sure it does appear and disappear correctly.
         /// Take a look at the FNA TextInputExt documentation for more info: https://github.com/FNA-XNA/FNA/wiki/5:-FNA-Extensions#textinputext
-        /// !!!Make sure to unsubscribe to this as soon as you're done with input, otherwise it'll cause issues with
-        /// virtual keyboards (e.g SteamDeck) and mess up IME users!!!
         /// </summary>
         public static event Action<char> OnInput {
             add {

--- a/Celeste.Mod.mm/Mod/Everest/TextInput.cs
+++ b/Celeste.Mod.mm/Mod/Everest/TextInput.cs
@@ -2,7 +2,6 @@
 using Microsoft.Xna.Framework.Input;
 using SDL2;
 using System;
-using System.Reflection;
 
 namespace Celeste.Mod {
     /// <summary>
@@ -18,28 +17,52 @@ namespace Celeste.Mod {
                 return;
             Initialized = true;
 
+            // Subscribing is useless as long as we don't call `StartTextInput` so its ok for this to be here
             TextInputEXT.TextInput += ReceiveTextInput;
-            TextInputEXT.StartTextInput();
+            CheckTextStatus(); // Required check to handle pre-init subscriptions
         }
 
         internal static void Shutdown() {
             if (!Initialized)
                 return;
 
-            TextInputEXT.StopTextInput();
+            if (TextInputEXT.IsTextInputActive())
+                TextInputEXT.StopTextInput();
             TextInputEXT.TextInput -= ReceiveTextInput;
         }
 
         internal static void ReceiveTextInput(char c) {
             // Invoke our own event handler.
-            OnInput?.Invoke(c);
+            _OnInput?.Invoke(c);
         }
+
+        private static event Action<char> _OnInput;
 
         /// <summary>
         /// Invoked whenever text input occurs, including some "input action" characters.
         /// Take a look at the FNA TextInputExt documentation for more info: https://github.com/FNA-XNA/FNA/wiki/5:-FNA-Extensions#textinputext
+        /// !!!Make sure to unsubscribe to this as soon as you're done with input, otherwise it'll cause issues with
+        /// virtual keyboards (e.g SteamDeck) and mess up IME users!!!
         /// </summary>
-        public static event Action<char> OnInput;
+        public static event Action<char> OnInput {
+            add {
+                _OnInput += value;
+                CheckTextStatus();
+            }
+            remove {
+                _OnInput -= value;
+                CheckTextStatus();
+            }
+        }
+
+        private static void CheckTextStatus() {
+            if (!Initialized) return; // No text updates before this is initialized
+            if (_OnInput != null && _OnInput.GetInvocationList().Length != 0 && !TextInputEXT.IsTextInputActive()) {
+                TextInputEXT.StartTextInput();
+            } else if ((_OnInput == null || _OnInput.GetInvocationList().Length == 0) && TextInputEXT.IsTextInputActive()) {
+                TextInputEXT.StopTextInput();
+            }
+        }
 
         public static string GetClipboardText() => SDL.SDL_GetClipboardText();
         public static void SetClipboardText(string value) => SDL.SDL_SetClipboardText(value);

--- a/Celeste.Mod.mm/Mod/UI/OuiMapSearch.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiMapSearch.cs
@@ -30,7 +30,21 @@ namespace Celeste.Mod.UI {
 
         public bool FromChapterSelect = false;
 
-        public bool Searching;
+        private bool searching;
+
+        public bool Searching {
+            get => searching;
+            set {
+                if (value != searching) { // Prevent multiple subscriptions
+                    if (value) { 
+                        TextInput.OnInput += OnTextInput;
+                    } else {
+                        TextInput.OnInput -= OnTextInput;
+                    }
+                }
+                searching = value;
+            }
+        }
 
         private string search = "";
         private string searchPrev = "";
@@ -133,10 +147,6 @@ namespace Celeste.Mod.UI {
         }
 
         public void OnTextInput(char c) {
-
-            if (!Searching)
-                return;
-
             if (c == (char) 13) {
                 // Enter
                 Scene.OnEndOfFrame += () => {
@@ -420,8 +430,6 @@ namespace Celeste.Mod.UI {
         }
 
         public override IEnumerator Enter(Oui from) {
-            TextInput.OnInput += OnTextInput;
-
             searchBarColor = Color.DarkSlateGray;
             searchBarColor.A = 80;
 
@@ -452,8 +460,6 @@ namespace Celeste.Mod.UI {
         }
 
         public override IEnumerator Leave(Oui next) {
-            TextInput.OnInput -= OnTextInput;
-
             FromChapterSelect = false;
 
             MInput.Disabled = false;
@@ -576,7 +582,7 @@ namespace Celeste.Mod.UI {
         }
 
         public override void SceneEnd(Scene scene) {
-            TextInput.OnInput -= OnTextInput;
+            Searching = false; // Stop text input
             MInput.Disabled = false;
         }
 

--- a/Celeste.Mod.mm/Mod/UI/OuiModOptionString.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiModOptionString.cs
@@ -184,8 +184,8 @@ namespace Celeste.Mod.UI {
         }
 
         public override IEnumerator Leave(Oui next) {
-            if (UseKeyboardInput) 
-                TextInput.OnInput -= OnTextInput;
+            // Non existent unhooks aren't dangerous, and can get us out of weird situations
+            TextInput.OnInput -= OnTextInput;
 
             Overworld.ShowInputUI = true;
             Focused = false;

--- a/Celeste.Mod.mm/Mod/UI/OuiModOptionString.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiModOptionString.cs
@@ -113,7 +113,8 @@ namespace Celeste.Mod.UI {
         }
 
         public override IEnumerator Enter(Oui from) {
-            TextInput.OnInput += OnTextInput;
+            if (UseKeyboardInput) 
+                TextInput.OnInput += OnTextInput;
 
             Overworld.ShowInputUI = false;
 
@@ -183,7 +184,8 @@ namespace Celeste.Mod.UI {
         }
 
         public override IEnumerator Leave(Oui next) {
-            TextInput.OnInput -= OnTextInput;
+            if (UseKeyboardInput) 
+                TextInput.OnInput -= OnTextInput;
 
             Overworld.ShowInputUI = true;
             Focused = false;
@@ -209,10 +211,6 @@ namespace Celeste.Mod.UI {
         }
 
         public void OnTextInput(char c) {
-            if (!UseKeyboardInput) {
-                return;
-            }
-
             if (c == (char) 13) {
                 // Enter - confirm.
                 Finish();

--- a/Celeste.Mod.mm/Mod/UI/OuiNumberEntry.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiNumberEntry.cs
@@ -112,7 +112,8 @@ namespace Celeste.Mod.UI {
         }
 
         public override IEnumerator Enter(Oui from) {
-            TextInput.OnInput += OnKeyboardInput;
+            if (UseKeyboardInput) 
+                TextInput.OnInput += OnTextInput;
 
             Overworld.ShowInputUI = false;
 
@@ -184,7 +185,8 @@ namespace Celeste.Mod.UI {
         }
 
         public override IEnumerator Leave(Oui next) {
-            TextInput.OnInput -= OnKeyboardInput;
+            if (UseKeyboardInput)
+                TextInput.OnInput -= OnTextInput;
 
             Overworld.ShowInputUI = true;
             Focused = false;
@@ -206,14 +208,6 @@ namespace Celeste.Mod.UI {
                 var settings = Core.CoreModule.Instance._Settings as Core.CoreModuleSettings;
                 return settings?.UseKeyboardForTextInput ?? false;
             }
-        }
-
-        public void OnKeyboardInput(char c) {
-            if (!UseKeyboardInput) {
-                return;
-            }
-
-            OnTextInput(c);
         }
 
         public void OnTextInput(char c) {

--- a/Celeste.Mod.mm/Mod/UI/OuiNumberEntry.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiNumberEntry.cs
@@ -185,8 +185,8 @@ namespace Celeste.Mod.UI {
         }
 
         public override IEnumerator Leave(Oui next) {
-            if (UseKeyboardInput)
-                TextInput.OnInput -= OnTextInput;
+            // Non existent unhooks aren't dangerous, and can get us out of weird situations
+            TextInput.OnInput -= OnTextInput;
 
             Overworld.ShowInputUI = true;
             Focused = false;

--- a/Celeste.Mod.mm/Patches/Monocle/Commands.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Commands.cs
@@ -67,6 +67,12 @@ namespace Monocle {
 
         [MonoModReplace] // Don't create orig_ method.
         internal void UpdateClosed() {
+            if (installedListener) { 
+                // This is a really really really messy way to deal with this, but its simple enough to be viable
+                // And apparently `UpdateOpen` doesn't handle closing, so this goes here i guess
+                installedListener = false;
+                TextInput.OnInput -= HandleChar;
+            }
             if (!canOpen) {
                 canOpen = true;
             // Original code only checks OemTilde and Oem8, leaving QWERTZ users in the dark...
@@ -74,7 +80,7 @@ namespace Monocle {
                 Open = true;
                 currentState = Keyboard.GetState();
                 if (!installedListener) {
-                    // this should realistically be done in the constructor. if we ever patch the ctor move it there!
+                    // This has to be done here, since we'll be unsubscribing to stop the text input
                     installedListener = true;
                     TextInput.OnInput += HandleChar;
                 }
@@ -369,7 +375,7 @@ namespace Monocle {
         private void HandleChar(char key) {
             // this API seemingly handles repeating keys for us
             if (!Open) {
-                return;
+                return; // this should never execute, but it can if the update is delayed for some reason before this can get unsubscribed
             }
             if (char.IsControl(key)) {
                 return;
@@ -391,17 +397,17 @@ namespace Monocle {
         }
 
         private bool IsWordBoundary(int idx, bool forward) {
-                // for move forward that means t[i-1] is word and t[i] is nonword
-                // for move backward that means t[i] is word and t[i-1] is nonword
-                if (idx <= 0 || idx >= currentText.Length) {
-                    return true;
-                }
-                char chBack = currentText[idx - 1];
-                char chForward = currentText[idx];
-                bool backWord = IsWord(chBack);
-                bool foreWord = IsWord(chForward);
-                // oof
-                return (forward && backWord && !foreWord) || (!forward && !backWord && foreWord);
+            // for move forward that means t[i-1] is word and t[i] is nonword
+            // for move backward that means t[i] is word and t[i-1] is nonword
+            if (idx <= 0 || idx >= currentText.Length) {
+                return true;
+            }
+            char chBack = currentText[idx - 1];
+            char chForward = currentText[idx];
+            bool backWord = IsWord(chBack);
+            bool foreWord = IsWord(chForward);
+            // oof
+            return (forward && backWord && !foreWord) || (!forward && !backWord && foreWord);
         }
 
         // Fix for https://github.com/EverestAPI/Everest/issues/167

--- a/Celeste.Mod.mm/Patches/OuiFileNaming.cs
+++ b/Celeste.Mod.mm/Patches/OuiFileNaming.cs
@@ -25,10 +25,6 @@ namespace Celeste {
         }
 
         public void OnTextInput(char c) {
-            if (!UseKeyboardInput) {
-                return;
-            }
-
             if (c == (char) 13) {
                 // Enter - confirm.
                 Finish();
@@ -68,14 +64,17 @@ namespace Celeste {
         public extern IEnumerator orig_Enter(Oui from);
         public override IEnumerator Enter(Oui from) {
             Engine.Commands.Enabled = false;
-            TextInput.OnInput += OnTextInput;
+            // only subscribe if we're going to use the keyboard
+            if (UseKeyboardInput) 
+                TextInput.OnInput += OnTextInput;
             return orig_Enter(from);
         }
 
         public extern IEnumerator orig_Leave(Oui next);
         public override IEnumerator Leave(Oui next) {
             Engine.Commands.Enabled = (Celeste.PlayMode == Celeste.PlayModes.Debug);
-            TextInput.OnInput -= OnTextInput;
+            if (UseKeyboardInput) 
+                TextInput.OnInput -= OnTextInput;
             return orig_Leave(next);
         }
 

--- a/Celeste.Mod.mm/Patches/OuiFileNaming.cs
+++ b/Celeste.Mod.mm/Patches/OuiFileNaming.cs
@@ -73,8 +73,8 @@ namespace Celeste {
         public extern IEnumerator orig_Leave(Oui next);
         public override IEnumerator Leave(Oui next) {
             Engine.Commands.Enabled = (Celeste.PlayMode == Celeste.PlayModes.Debug);
-            if (UseKeyboardInput) 
-                TextInput.OnInput -= OnTextInput;
+            // Non existent unhooks aren't dangerous, and can get us out of weird situations
+            TextInput.OnInput -= OnTextInput;
             return orig_Leave(next);
         }
 


### PR DESCRIPTION
Currently Everest will call `TextInputEXT.StartTextInput()` as soon as the global initialization happens, this not only incorrect because it will show up the virtual keyboard (if available) on boot, but it has been shown that it can cause issues with IME users.
This pull request aims to fix that with a simple fix on Everest's `TextInput` API, where the text input will be started/stopped on demand rather than on boot and closed on shutdown (which follows the intended usage of this feature). This fixes the issues mentioned above and makes the on screen keyboard show up automatically when required.
With this change, some Everest usages of this API had to be adjusted, mainly the Celeste console patch to properly unsubscribe when closed. Other changes were to respect the "Use keyboard as input" setting where it will only subscribe the event if that setting is on.
Finally this is a behavioral change on a public API, which means that mods *may* be affected by this change. Luckily, a quick github search shows that this API is very uncommon to be used, and on the rare occasion that a mod is using it, its done properly.
But since that search only represents a (probably not too big) subset of all Celeste mods, a logged warning was implemented to warn the modder if multiple subscriptions are present at the same time (which, in most cases, will imply a forgotten subscription to the event).