### PR TITLE
CassetteListener component

### DIFF
--- a/Celeste.Mod.mm/Mod/Entities/CassetteListener.cs
+++ b/Celeste.Mod.mm/Mod/Entities/CassetteListener.cs
@@ -54,8 +54,17 @@ namespace Celeste.Mod.Entities {
         /// </summary>
         public Modes Mode;
 
-        public CassetteListener(int index) : base(false, false) {
+        /// <summary>
+        /// Matches the functionality of <see cref="CassetteBlock.ID"/>.
+        /// </summary>
+        public EntityID ID;
+
+        public CassetteListener(int index) : this(index, EntityID.None) {
+        }
+
+        public CassetteListener(int index, EntityID id) : base(false, false) {
             Index = index;
+            ID = id;
         }
 
         /// <summary>

--- a/Celeste.Mod.mm/Mod/Entities/CassetteListener.cs
+++ b/Celeste.Mod.mm/Mod/Entities/CassetteListener.cs
@@ -1,0 +1,119 @@
+using Monocle;
+using System;
+
+namespace Celeste.Mod.Entities {
+    [Tracked]
+    public class CassetteListener : Component {
+        /// <summary>
+        /// Called by <see cref="Level.LoadLevel"/> when loading a room.
+        /// The parameter indicates whether this component will be the active one.
+        /// </summary>
+        public Action<bool> OnStart;
+
+        /// <summary>
+        /// Called by <see cref="CassetteBlockManager.StopBlocks"/> after collecting a cassette.
+        /// </summary>
+        public Action OnFinish;
+
+        /// <summary>
+        /// Called by <see cref="CassetteBlockManager.SetWillActivate"/> if <see cref="Index"/> is about to become current.
+        /// For a <see cref="CassetteBlock"/>, this is represented by a non-collidable block moving one pixel up.
+        /// </summary>
+        public Action OnWillActivate;
+
+        /// <summary>
+        /// Called by <see cref="CassetteBlockManager.SetWillActivate"/> if <see cref="Index"/> is about to no longer be current.
+        /// For a <see cref="CassetteBlock"/>, this is represented by a collidable block moving one pixel down.
+        /// </summary>
+        public Action OnWillDeactivate;
+
+        /// <summary>
+        /// Called by <see cref="CassetteBlockManager.SetActiveIndex"/> if <see cref="Activated"/> was changed from false to true.
+        /// For a <see cref="CassetteBlock"/>, this is represented by the block becoming collidable.
+        /// </summary>
+        public Action OnActivated;
+
+        /// <summary>
+        /// Called by <see cref="CassetteBlockManager.SetActiveIndex"/> if <see cref="Activated"/> was changed from true to false.
+        /// For a <see cref="CassetteBlock"/>, this is represented by the block becoming non-collidable.
+        /// </summary>
+        public Action OnDeactivated;
+
+        /// <summary>
+        /// Matches the functionality of <see cref="CassetteBlock.Index"/>.
+        /// </summary>
+        public int Index;
+
+        /// <summary>
+        /// Matches the functionality of <see cref="CassetteBlock.Activated"/>.
+        /// </summary>
+        public bool Activated;
+
+        /// <summary>
+        /// Matches the functionality of <see cref="CassetteBlock.Mode"/>.
+        /// </summary>
+        public Modes Mode;
+
+        public CassetteListener(int index) : base(false, false) {
+            Index = index;
+        }
+
+        /// <summary>
+        /// Called by <see cref="CassetteBlockManager.SetActiveIndex"/>.
+        /// </summary>
+        public void SetActivated(bool activated) {
+            if (activated == Activated) {
+                return;
+            }
+
+            Activated = activated;
+
+            if (activated) {
+                Mode = Modes.Enabled;
+                OnActivated?.Invoke();
+            } else {
+                Mode = Modes.Disabled;
+                OnDeactivated?.Invoke();
+            }
+        }
+
+        /// <summary>
+        /// Called by <see cref="CassetteBlockManager.SilentUpdateBlocks"/>.
+        /// </summary>
+        public void Start(bool activated) {
+            Activated = activated;
+            Mode = activated ? Modes.Enabled : Modes.Disabled;
+            OnStart?.Invoke(activated);
+        }
+
+        /// <summary>
+        /// Called by <see cref="CassetteBlockManager.StopBlocks"/>.
+        /// </summary>
+        public void Finish() {
+            Activated = false;
+            Mode = Modes.Disabled;
+            OnFinish?.Invoke();
+        }
+
+        /// <summary>
+        /// Called by <see cref="CassetteBlockManager.SetWillActivate"/>.
+        /// </summary>
+        public void WillToggle() {
+            if (Activated) {
+                Mode = Modes.WillDisable;
+                OnWillDeactivate?.Invoke();
+            } else {
+                Mode = Modes.WillEnable;
+                OnWillActivate?.Invoke();
+            }
+        }
+
+        public enum Modes
+        {
+            Enabled,
+            WillDisable,
+            Disabled,
+            WillEnable,
+        }
+    }
+}

--- a/Celeste.Mod.mm/Patches/CassetteBlockManager.cs
+++ b/Celeste.Mod.mm/Patches/CassetteBlockManager.cs
@@ -159,7 +159,9 @@ namespace Celeste {
             }
 
             foreach (CassetteListener listener in Scene.Tracker.GetComponents<CassetteListener>()) {
-                listener.Start(listener.Index == currentIndex);
+                if (listener.ID.ID == EntityID.None.ID || listener.ID.Level == SceneAs<Level>().Session.Level) {
+                    listener.Start(listener.Index == currentIndex);
+                }
             }
         }
 

--- a/Celeste.Mod.mm/Patches/CassetteBlockManager.cs
+++ b/Celeste.Mod.mm/Patches/CassetteBlockManager.cs
@@ -191,5 +191,17 @@ namespace Celeste {
             }
         }
 
+        [MonoModReplace]
+        public new void StopBlocks() {
+            foreach (CassetteBlock entity in base.Scene.Tracker.GetEntities<CassetteBlock>()) {
+                entity.Finish();
+            }
+            foreach (CassetteListener listener in base.Scene.Tracker.GetComponents<CassetteListener>()) {
+                listener.Finish();
+            }
+            if (!isLevelMusic) {
+                Audio.Stop(sfx);
+            }
+        }
     }
 }

--- a/Celeste.Mod.mm/Patches/CassetteBlockManager.cs
+++ b/Celeste.Mod.mm/Patches/CassetteBlockManager.cs
@@ -2,6 +2,7 @@
 #pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
 #pragma warning disable CS0169 // The field is never used
 
+using Celeste.Mod.Entities;
 using Celeste.Mod.Meta;
 using FMOD.Studio;
 using Monocle;
@@ -149,8 +150,44 @@ namespace Celeste {
             SilentUpdateBlocks();
         }
 
-        [MonoModIgnore]
-        private extern void SilentUpdateBlocks();
+        [MonoModReplace]
+        private void SilentUpdateBlocks() {
+            foreach (CassetteBlock entity in Scene.Tracker.GetEntities<CassetteBlock>()) {
+                if (entity.ID.Level == SceneAs<Level>().Session.Level) {
+                    entity.SetActivatedSilently(entity.Index == currentIndex);
+                }
+            }
+
+            foreach (CassetteListener listener in Scene.Tracker.GetComponents<CassetteListener>()) {
+                listener.Start(listener.Index == currentIndex);
+            }
+        }
+
+        [MonoModReplace]
+        public new void SetActiveIndex(int index) {
+            foreach (CassetteBlock entity in Scene.Tracker.GetEntities<CassetteBlock>()) {
+                entity.Activated = entity.Index == index;
+            }
+
+            foreach (CassetteListener listener in Scene.Tracker.GetComponents<CassetteListener>()) {
+                listener.SetActivated(listener.Index == index);
+            }
+        }
+
+        [MonoModReplace]
+        public new void SetWillActivate(int index) {
+            foreach (CassetteBlock entity in Scene.Tracker.GetEntities<CassetteBlock>()) {
+                if (entity.Index == index || entity.Activated) {
+                    entity.WillToggle();
+                }
+            }
+
+            foreach (CassetteListener listener in Scene.Tracker.GetComponents<CassetteListener>()) {
+                if (listener.Index == index || listener.Activated) {
+                    listener.WillToggle();
+                }
+            }
+        }
 
     }
 }


### PR DESCRIPTION
Resolves https://github.com/EverestAPI/Everest/issues/475

This is a fairly simple component for code modders to create cassette-based entities.  The component can be assigned delegates that are called in a similar fashion to `CassetteBlock` methods, as if the component were actually a cassette block.

Example entity:

```cs
public class SampleEntity : Entity {
    private Sprite sprite;

    public SampleEntity(EntityData data, Vector2 offset) : base(data.Position + offset) {
        Color activeColor = Color.White;
        Color toggleColor = activeColor * 0.75f;
        Color inactiveColor = activeColor * 0.3f;

        Add(sprite = GFX.SpriteBank.Create("sampleEntity"));

        Add(new CassetteListener(new EntityID(data.Level.Name, data.ID), data.Int("cassetteIndex"), data.Float("tempo", 1f)) {
            OnStart = activated => sprite.Color = activated ? activeColor : inactiveColor,
            OnActivated = () => sprite.Color = activeColor,
            OnDeactivated = () => sprite.Color = inactiveColor,
            OnWillActivate = () => sprite.Color = toggleColor,
            OnWillDeactivate = () => sprite.Color = toggleColor,
            OnFinish = () => sprite.Color = inactiveColor,
        });
    }
}
```
<br>

The `EntityID` is optional, and is used to prevent `OnStart` being called multiple times, in the same way that `CassetteBlock.SetActivatedSilently` is handled.

`EntityAdded` will attempt to create a `CassetteBlockManager` if required, using the same logic as `Level.LoadLevel`.


https://github.com/EverestAPI/Everest/assets/2331297/2a9bfdf4-c449-4f70-9e8e-1a1e3544bfb8

