### PR TITLE
Fix missing asset path on preload fail

### DIFF
--- a/Celeste.Mod.mm/Patches/Monocle/VirtualTexture.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/VirtualTexture.cs
@@ -818,7 +818,7 @@ namespace Monocle {
                 } else if (extension == ".png") {
                     // Hard.
                     using (FileStream stream = File.OpenRead(System.IO.Path.Combine(Engine.ContentDirectory, Path)))
-                        return PreloadSizeFromPNG(stream);
+                        return PreloadSizeFromPNG(stream, Path);
 
                 } else {
                     // .xnb and other file formats - impossible.
@@ -830,7 +830,7 @@ namespace Monocle {
                 if (Metadata.Format == "png") {
                     // Hard.
                     using (Stream stream = Metadata.Stream)
-                        return PreloadSizeFromPNG(stream);
+                        return PreloadSizeFromPNG(stream, $"{Metadata.PathVirtual} (mod {Metadata.Source.Mod?.Name ?? "*unknown*"})");
 
                 } else {
                     // .xnb and other file formats - impossible.
@@ -841,21 +841,21 @@ namespace Monocle {
             return false;
         }
 
-        private bool PreloadSizeFromPNG(Stream stream) {
+        private bool PreloadSizeFromPNG(Stream stream, string path) {
             using (BinaryReader reader = new BinaryReader(stream)) {
                 ulong magic = reader.ReadUInt64();
                 if (magic != 0x0A1A0A0D474E5089U) {
-                    Logger.Log(LogLevel.Error, "vtex", $"Failed preloading PNG: Expected magic to be 0x0A1A0A0D474E5089, got 0x{magic.ToString("X16")} - {Path}");
+                    Logger.Log(LogLevel.Error, "vtex", $"Failed preloading PNG: Expected magic to be 0x0A1A0A0D474E5089, got 0x{magic.ToString("X16")} - {path}");
                     return false;
                 }
                 uint length = reader.ReadUInt32();
                 if (length != 0x0D000000U) {
-                    Logger.Log(LogLevel.Error, "vtex", $"Failed preloading PNG: Expected first chunk length to be 0x0D000000, got 0x{length.ToString("X8")} - {Path}");
+                    Logger.Log(LogLevel.Error, "vtex", $"Failed preloading PNG: Expected first chunk length to be 0x0D000000, got 0x{length.ToString("X8")} - {path}");
                     return false;
                 }
                 uint chunk = reader.ReadUInt32();
                 if (chunk != 0x52444849U) {
-                    Logger.Log(LogLevel.Error, "vtex", $"Failed preloading PNG: Expected IHDR marker 0x52444849, got 0x{chunk.ToString("X8")} - {Path}");
+                    Logger.Log(LogLevel.Error, "vtex", $"Failed preloading PNG: Expected IHDR marker 0x52444849, got 0x{chunk.ToString("X8")} - {path}");
                     return false;
                 }
                 Width = SwapEndian(reader.ReadInt32());


### PR DESCRIPTION
When failing to preload `PNG` assets, the log message tries to reference the asset's `Path`; but in many cases the `Path` was `null`, because the asset was tied to a `ModAsset`. This PR fixes this by taking a `path` parameter, which is then filled by `Path` or `Metadata.PathVirtual` + `Metadata.Source.Mod.Name` where applicable; or "unknown" if no mod is tied to the asset.