### PR TITLE
Add Player.GetStarFlyTimer()

### DIFF
--- a/Celeste.Mod.mm/Patches/Player.cs
+++ b/Celeste.Mod.mm/Patches/Player.cs
@@ -21,6 +21,7 @@ namespace Celeste {
 
         // We're effectively in Player, but still need to "expose" private fields to our mod.
         private bool wasDashB;
+        private float starFlyTimer;
         private HashSet<Trigger> triggersInside;
         private List<Entity> temp;
 
@@ -239,7 +240,14 @@ namespace Celeste {
                 return wasDashB ? NormalBadelineHairColor : UsedBadelineHairColor;
             return wasDashB ? NormalHairColor : UsedHairColor;
         }
-        
+
+        /// <summary>
+        /// Get starFlyTimer of the current player.
+        /// </summary>
+        /// <returns></returns>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public float GetStarFlyTimer() => starFlyTimer;
+
         /// <summary>
         /// Adds a new state to this player with the given behaviour, and returns the index of the new state.
         ///


### PR DESCRIPTION
Hi,

I'm trying to add a meter for starFlyTimer if Madeline is star flying in [Stamina Meter](https://gamebanana.com/mods/34280) mod, but I found `player.starFlyTimer` is private. This PR adds a public function `Player.GetStarFlyTimer()` to expose that value. I have no experience in C# and MonoMod, so please kindly tell me if there is another better way to expose a private field.

Thanks!