### PR TITLE
Fix openlog not working on windows due to .net core

### DIFF
--- a/Celeste.Mod.mm/Patches/Commands.cs
+++ b/Celeste.Mod.mm/Patches/Commands.cs
@@ -289,8 +289,14 @@ namespace Celeste {
         [Command("openlog", "open log.txt file")]
         private static void CmdOpenLog() {
             string pathLog = Everest.PathLog;
-            if (File.Exists(pathLog))
-                Process.Start(pathLog);
+            if (File.Exists(pathLog)) {
+                ProcessStartInfo startInfo = new() {
+                    FileName = pathLog,
+                    UseShellExecute = true,
+                };
+
+                Process.Start(startInfo);
+            }
             else
                 Engine.Commands.Log($"{pathLog} does not exist");
         }


### PR DESCRIPTION
The `openlog` command is broken on windows since core because of [this](https://learn.microsoft.com/en-us/dotnet/core/compatibility/fx-core#change-in-default-value-of-useshellexecute). 

This PR fixes the issue by setting `UseShellExecute` back to true. you can read more about it on [Discord](https://discord.com/channels/403698615446536203/1185177492638670878).