### PR TITLE
Allow `--vanilla` to not be the first argument

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/BOOT.cs
+++ b/Celeste.Mod.mm/Mod/Everest/BOOT.cs
@@ -107,7 +107,7 @@ namespace Celeste.Mod {
 
                 // Start vanilla if instructed to
                 string vanillaDummy = Path.Combine(Path.GetDirectoryName(everestPath), "nextLaunchIsVanilla.txt");
-                if (File.Exists(vanillaDummy) || args.FirstOrDefault() == "--vanilla") {
+                if (File.Exists(vanillaDummy) || args.Contains("--vanilla")) {
                     File.Delete(vanillaDummy);
                     StartVanilla();
                     goto Exit;


### PR DESCRIPTION
This makes the `--vanilla` argument work again, since, by convention, the first argument is the current binary path, consequently it wont ever be `--vanilla` even if provided. This changes it so that the game will launch the vanilla version if the argument is present on the list.