### PR TITLE
Everest splash fixes 2

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
@@ -253,7 +253,7 @@ namespace Celeste.Mod {
                 if (!File.Exists(archive)) // Relative path? Let's just make it absolute.
                     archive = Path.Combine(PathMods, archive);
                 if (!File.Exists(archive)) { // It just doesn't exist.
-                    EverestSplashHandler.IncreaseLoadedModCount(null);
+                    EverestSplashHandler.IncreaseLoadedModCount(null); // Increase the splash count anyway, since it was detected as an entry
                     return;
                 }
 
@@ -353,7 +353,7 @@ namespace Celeste.Mod {
                 if (!Directory.Exists(dir)) // Relative path?
                     dir = Path.Combine(PathMods, dir);
                 if (!Directory.Exists(dir)) { // It just doesn't exist.
-                    EverestSplashHandler.IncreaseLoadedModCount(null);
+                    EverestSplashHandler.IncreaseLoadedModCount(null); // Increase the splash count anyway, since it was detected as an entry
                     return;
                 }
 
@@ -465,8 +465,8 @@ namespace Celeste.Mod {
 
                 callback?.Invoke();
 
-                LoadMod(meta);
                 EverestSplashHandler.IncreaseLoadedModCount(meta.Name);
+                LoadMod(meta);
             }
 
             /// <summary>

--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -686,7 +686,8 @@ namespace Celeste.Mod {
                                 } else {
                                     // all dependencies are loaded, all optional dependencies are either loaded or won't load => we're good to go!
                                     Logger.Log(LogLevel.Info, "core", $"Dependencies of mod {entry.Item1} are now satisfied: loading");
-
+                                    EverestSplashHandler.IncreaseLoadedModCount(entry.Item1.Name); // Notify the splash
+                                    
                                     if (Everest.Modules.Any(mod => mod.Metadata.Name == entry.Item1.Name)) {
                                         // a duplicate of the mod was loaded while it was sitting in the delayed list.
                                         Logger.Log(LogLevel.Warn, "core", $"Mod {entry.Item1.Name} already loaded!");
@@ -696,7 +697,6 @@ namespace Celeste.Mod {
                                         Loader.LoadMod(entry.Item1);
                                     }
                                     Loader.Delayed.RemoveAt(i);
-                                    EverestSplashHandler.IncreaseLoadedModCount(entry.Item1.Name);
 
                                     // we now loaded an extra mod, consider all delayed mods again to deal with transitive dependencies.
                                     i = -1;

--- a/Celeste.Mod.mm/Mod/Everest/EverestSplashHandler.cs
+++ b/Celeste.Mod.mm/Mod/Everest/EverestSplashHandler.cs
@@ -105,17 +105,15 @@ namespace Celeste.Mod {
 
         public static void IncreaseLoadedModCount(string latestLoadedMod) {
             loadedMods++;
-            UpdateSplashLoadingProgress(latestLoadedMod);
+            SendMessageToSplash("#progress" + loadedMods + ";" + totalMods + ";" + latestLoadedMod);
         }
 
         public static void AllModsLoaded() {
             loadedMods = totalMods;
-            UpdateSplashLoadingProgress(null);
+            SendMessageToSplash("#finish" + totalMods + ";" + "Final touches...");
         }
 
-        private static void UpdateSplashLoadingProgress(string latestLoadedMod) {
-            if (totalMods == 0)
-                return;
+        private static void SendMessageToSplash(string message) {
             lock (splashPipeLock) {
                 if (splashPipeServerStream == null)
                     return; // If the splash never ran, no-op
@@ -123,10 +121,10 @@ namespace Celeste.Mod {
                     return; // If the splash never connected or its no longer alive, no-op
                 try {
                     StreamWriter sw = new(splashPipeServerStream);
-                    sw.WriteLine("#progress" + loadedMods + ";" + totalMods + ";" + latestLoadedMod);
+                    sw.WriteLine(message);
                     sw.Flush();
                 } catch (Exception e) {
-                    Logger.Log(LogLevel.Error, "EverestSplash", "Could not send progress to splash!");
+                    Logger.Log(LogLevel.Error, "EverestSplash", "Could not send data to splash!");
                     Logger.LogDetailed(e);
                 }
             }

--- a/Celeste.Mod.mm/Mod/Everest/EverestSplashHandler.cs
+++ b/Celeste.Mod.mm/Mod/Everest/EverestSplashHandler.cs
@@ -110,7 +110,7 @@ namespace Celeste.Mod {
 
         public static void AllModsLoaded() {
             loadedMods = totalMods;
-            SendMessageToSplash("#finish" + totalMods + ";" + "Final touches...");
+            SendMessageToSplash("#finish" + totalMods + ";" + "Almost done...");
         }
 
         private static void SendMessageToSplash(string message) {

--- a/EverestSplash/EverestSplash.cs
+++ b/EverestSplash/EverestSplash.cs
@@ -296,14 +296,6 @@ public class EverestSplashWindow {
         
         // Okay, good code continues here
 
-        if (randomness.WithChance(0.01)) {
-            // May be expanded on the future
-            string[] possibleTexts = {
-                "Adding {0} to the pie",
-            };
-            loadingText = possibleTexts[new Random().Next(possibleTexts.Length)];
-        }
-
         if (randomness.WithChance(0.05)) {
             rightSidedWheel = true;
         }

--- a/EverestSplash/FontLoader.cs
+++ b/EverestSplash/FontLoader.cs
@@ -1,9 +1,7 @@
 using EverestSplash.SDL2;
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.IO;
-using System.Runtime.InteropServices;
 
 namespace EverestSplash;
 

--- a/EverestSplash/SplashContent/fonts/renogare.xml
+++ b/EverestSplash/SplashContent/fonts/renogare.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0"?>
+<font>
+    <info face="Renogare" size="-64" bold="0" italic="0" charset="" unicode="1" stretchH="100" smooth="0" aa="1" padding="0,0,0,0" spacing="1,1" outline="0"/>
+    <common lineHeight="75" base="60" scaleW="512" scaleH="512" pages="1" packed="0" alphaChnl="0" redChnl="4" greenChnl="4" blueChnl="4"/>
+    <pages>
+        <page id="0" file="renogare_0.png"/>
+    </pages>
+    <chars count="95">
+        <char id="32" x="0" y="0" width="0" height="0" xoffset="0" yoffset="0" xadvance="19" page="0" chnl="15"/>
+        <char id="33" x="275" y="383" width="13" height="48" xoffset="3" yoffset="13" xadvance="20" page="0" chnl="15"/>
+        <char id="34" x="97" y="484" width="25" height="15" xoffset="2" yoffset="13" xadvance="30" page="0" chnl="15"/>
+        <char id="35" x="127" y="1" width="56" height="48" xoffset="0" yoffset="12" xadvance="57" page="0" chnl="15"/>
+        <char id="36" x="1" y="116" width="40" height="58" xoffset="2" yoffset="8" xadvance="45" page="0" chnl="15"/>
+        <char id="37" x="67" y="1" width="59" height="48" xoffset="2" yoffset="13" xadvance="64" page="0" chnl="15"/>
+        <char id="38" x="50" y="386" width="43" height="50" xoffset="1" yoffset="12" xadvance="46" page="0" chnl="15"/>
+        <char id="39" x="168" y="484" width="11" height="15" xoffset="2" yoffset="13" xadvance="15" page="0" chnl="15"/>
+        <char id="40" x="297" y="139" width="22" height="64" xoffset="3" yoffset="9" xadvance="27" page="0" chnl="15"/>
+        <char id="41" x="315" y="51" width="22" height="64" xoffset="0" yoffset="9" xadvance="24" page="0" chnl="15"/>
+        <char id="42" x="69" y="485" width="27" height="24" xoffset="1" yoffset="13" xadvance="29" page="0" chnl="15"/>
+        <char id="43" x="198" y="148" width="33" height="32" xoffset="2" yoffset="25" xadvance="37" page="0" chnl="15"/>
+        <char id="44" x="156" y="484" width="11" height="18" xoffset="1" yoffset="50" xadvance="14" page="0" chnl="15"/>
+        <char id="45" x="135" y="496" width="20" height="9" xoffset="3" yoffset="37" xadvance="27" page="0" chnl="15"/>
+        <char id="46" x="129" y="276" width="11" height="10" xoffset="2" yoffset="51" xadvance="15" page="0" chnl="15"/>
+        <char id="47" x="1" y="53" width="40" height="62" xoffset="-3" yoffset="7" xadvance="36" page="0" chnl="15"/>
+        <char id="48" x="94" y="386" width="43" height="49" xoffset="3" yoffset="12" xadvance="49" page="0" chnl="15"/>
+        <char id="49" x="287" y="214" width="24" height="47" xoffset="0" yoffset="13" xadvance="29" page="0" chnl="15"/>
+        <char id="50" x="215" y="386" width="36" height="48" xoffset="2" yoffset="12" xadvance="42" page="0" chnl="15"/>
+        <char id="51" x="274" y="1" width="35" height="49" xoffset="1" yoffset="12" xadvance="39" page="0" chnl="15"/>
+        <char id="52" x="99" y="338" width="39" height="47" xoffset="3" yoffset="13" xadvance="45" page="0" chnl="15"/>
+        <char id="53" x="242" y="91" width="36" height="48" xoffset="1" yoffset="13" xadvance="40" page="0" chnl="15"/>
+        <char id="54" x="177" y="386" width="37" height="48" xoffset="3" yoffset="13" xadvance="43" page="0" chnl="15"/>
+        <char id="55" x="216" y="320" width="35" height="47" xoffset="2" yoffset="13" xadvance="39" page="0" chnl="15"/>
+        <char id="56" x="179" y="222" width="36" height="49" xoffset="2" yoffset="12" xadvance="41" page="0" chnl="15"/>
+        <char id="57" x="217" y="435" width="37" height="49" xoffset="4" yoffset="11" xadvance="44" page="0" chnl="15"/>
+        <char id="58" x="180" y="483" width="11" height="28" xoffset="1" yoffset="33" xadvance="14" page="0" chnl="15"/>
+        <char id="59" x="276" y="177" width="11" height="36" xoffset="1" yoffset="32" xadvance="14" page="0" chnl="15"/>
+        <char id="60" x="245" y="180" width="30" height="36" xoffset="3" yoffset="23" xadvance="37" page="0" chnl="15"/>
+        <char id="61" x="37" y="486" width="31" height="24" xoffset="3" yoffset="30" xadvance="38" page="0" chnl="15"/>
+        <char id="62" x="266" y="140" width="30" height="36" xoffset="3" yoffset="23" xadvance="37" page="0" chnl="15"/>
+        <char id="63" x="179" y="272" width="35" height="49" xoffset="-1" yoffset="11" xadvance="37" page="0" chnl="15"/>
+        <char id="64" x="121" y="50" width="51" height="49" xoffset="3" yoffset="18" xadvance="57" page="0" chnl="15"/>
+        <char id="65" x="67" y="50" width="53" height="48" xoffset="-1" yoffset="12" xadvance="52" page="0" chnl="15"/>
+        <char id="66" x="179" y="435" width="37" height="47" xoffset="5" yoffset="13" xadvance="45" page="0" chnl="15"/>
+        <char id="67" x="1" y="338" width="48" height="49" xoffset="2" yoffset="12" xadvance="51" page="0" chnl="15"/>
+        <char id="68" x="52" y="437" width="44" height="47" xoffset="5" yoffset="13" xadvance="53" page="0" chnl="15"/>
+        <char id="69" x="215" y="272" width="36" height="47" xoffset="5" yoffset="13" xadvance="45" page="0" chnl="15"/>
+        <char id="70" x="216" y="219" width="36" height="47" xoffset="5" yoffset="13" xadvance="43" page="0" chnl="15"/>
+        <char id="71" x="67" y="99" width="50" height="49" xoffset="2" yoffset="12" xadvance="55" page="0" chnl="15"/>
+        <char id="72" x="97" y="436" width="42" height="47" xoffset="5" yoffset="13" xadvance="53" page="0" chnl="15"/>
+        <char id="73" x="289" y="383" width="10" height="47" xoffset="6" yoffset="13" xadvance="22" page="0" chnl="15"/>
+        <char id="74" x="279" y="90" width="35" height="48" xoffset="0" yoffset="13" xadvance="40" page="0" chnl="15"/>
+        <char id="75" x="118" y="100" width="42" height="47" xoffset="5" yoffset="13" xadvance="48" page="0" chnl="15"/>
+        <char id="76" x="252" y="267" width="35" height="47" xoffset="5" yoffset="13" xadvance="41" page="0" chnl="15"/>
+        <char id="77" x="1" y="288" width="49" height="49" xoffset="5" yoffset="11" xadvance="60" page="0" chnl="15"/>
+        <char id="78" x="52" y="231" width="42" height="51" xoffset="5" yoffset="11" xadvance="53" page="0" chnl="15"/>
+        <char id="79" x="1" y="238" width="50" height="49" xoffset="3" yoffset="12" xadvance="56" page="0" chnl="15"/>
+        <char id="80" x="139" y="338" width="38" height="47" xoffset="5" yoffset="13" xadvance="44" page="0" chnl="15"/>
+        <char id="81" x="184" y="1" width="50" height="52" xoffset="3" yoffset="12" xadvance="56" page="0" chnl="15"/>
+        <char id="82" x="161" y="100" width="41" height="47" xoffset="5" yoffset="13" xadvance="46" page="0" chnl="15"/>
+        <char id="83" x="99" y="288" width="40" height="49" xoffset="3" yoffset="12" xadvance="46" page="0" chnl="15"/>
+        <char id="84" x="178" y="338" width="37" height="47" xoffset="3" yoffset="13" xadvance="41" page="0" chnl="15"/>
+        <char id="85" x="95" y="227" width="42" height="48" xoffset="5" yoffset="13" xadvance="53" page="0" chnl="15"/>
+        <char id="86" x="1" y="388" width="48" height="49" xoffset="0" yoffset="13" xadvance="48" page="0" chnl="15"/>
+        <char id="87" x="1" y="1" width="65" height="51" xoffset="0" yoffset="11" xadvance="66" page="0" chnl="15"/>
+        <char id="88" x="1" y="438" width="50" height="47" xoffset="0" yoffset="13" xadvance="50" page="0" chnl="15"/>
+        <char id="89" x="50" y="338" width="48" height="47" xoffset="-1" yoffset="13" xadvance="47" page="0" chnl="15"/>
+        <char id="90" x="51" y="288" width="47" height="47" xoffset="-1" yoffset="13" xadvance="46" page="0" chnl="15"/>
+        <char id="91" x="272" y="315" width="19" height="67" xoffset="5" yoffset="7" xadvance="25" page="0" chnl="15"/>
+        <char id="92" x="1" y="175" width="35" height="62" xoffset="-4" yoffset="7" xadvance="33" page="0" chnl="15"/>
+        <char id="93" x="252" y="315" width="19" height="68" xoffset="0" yoffset="7" xadvance="22" page="0" chnl="15"/>
+        <char id="94" x="1" y="486" width="35" height="24" xoffset="2" yoffset="13" xadvance="40" page="0" chnl="15"/>
+        <char id="95" x="97" y="500" width="37" height="9" xoffset="3" yoffset="59" xadvance="44" page="0" chnl="15"/>
+        <char id="96" x="123" y="484" width="18" height="11" xoffset="0" yoffset="11" xadvance="19" page="0" chnl="15"/>
+        <char id="97" x="118" y="148" width="38" height="37" xoffset="3" yoffset="24" xadvance="46" page="0" chnl="15"/>
+        <char id="98" x="203" y="92" width="38" height="50" xoffset="4" yoffset="11" xadvance="45" page="0" chnl="15"/>
+        <char id="99" x="184" y="54" width="37" height="37" xoffset="3" yoffset="24" xadvance="42" page="0" chnl="15"/>
+        <char id="100" x="235" y="1" width="38" height="50" xoffset="3" yoffset="11" xadvance="46" page="0" chnl="15"/>
+        <char id="101" x="173" y="184" width="37" height="37" xoffset="3" yoffset="24" xadvance="44" page="0" chnl="15"/>
+        <char id="102" x="252" y="384" width="22" height="50" xoffset="2" yoffset="10" xadvance="25" page="0" chnl="15"/>
+        <char id="103" x="140" y="287" width="38" height="50" xoffset="3" yoffset="23" xadvance="46" page="0" chnl="15"/>
+        <char id="104" x="253" y="217" width="33" height="49" xoffset="4" yoffset="11" xadvance="41" page="0" chnl="15"/>
+        <char id="105" x="275" y="432" width="11" height="49" xoffset="4" yoffset="11" xadvance="20" page="0" chnl="15"/>
+        <char id="106" x="255" y="435" width="19" height="62" xoffset="-3" yoffset="11" xadvance="21" page="0" chnl="15"/>
+        <char id="107" x="310" y="1" width="34" height="49" xoffset="4" yoffset="11" xadvance="39" page="0" chnl="15"/>
+        <char id="108" x="173" y="50" width="10" height="49" xoffset="4" yoffset="11" xadvance="18" page="0" chnl="15"/>
+        <char id="109" x="37" y="193" width="56" height="37" xoffset="4" yoffset="23" xadvance="65" page="0" chnl="15"/>
+        <char id="110" x="211" y="181" width="33" height="37" xoffset="4" yoffset="23" xadvance="41" page="0" chnl="15"/>
+        <char id="111" x="134" y="186" width="38" height="37" xoffset="3" yoffset="24" xadvance="44" page="0" chnl="15"/>
+        <char id="112" x="138" y="386" width="38" height="48" xoffset="4" yoffset="23" xadvance="45" page="0" chnl="15"/>
+        <char id="113" x="140" y="435" width="38" height="48" xoffset="3" yoffset="23" xadvance="46" page="0" chnl="15"/>
+        <char id="114" x="292" y="51" width="22" height="36" xoffset="4" yoffset="24" xadvance="27" page="0" chnl="15"/>
+        <char id="115" x="260" y="52" width="31" height="37" xoffset="2" yoffset="24" xadvance="36" page="0" chnl="15"/>
+        <char id="116" x="288" y="262" width="21" height="47" xoffset="2" yoffset="14" xadvance="26" page="0" chnl="15"/>
+        <char id="117" x="232" y="143" width="33" height="36" xoffset="4" yoffset="25" xadvance="42" page="0" chnl="15"/>
+        <char id="118" x="94" y="189" width="39" height="37" xoffset="-1" yoffset="25" xadvance="38" page="0" chnl="15"/>
+        <char id="119" x="67" y="149" width="50" height="39" xoffset="0" yoffset="23" xadvance="51" page="0" chnl="15"/>
+        <char id="120" x="157" y="148" width="40" height="35" xoffset="0" yoffset="25" xadvance="40" page="0" chnl="15"/>
+        <char id="121" x="138" y="224" width="40" height="48" xoffset="0" yoffset="25" xadvance="41" page="0" chnl="15"/>
+        <char id="122" x="222" y="54" width="37" height="36" xoffset="-1" yoffset="24" xadvance="36" page="0" chnl="15"/>
+        <char id="123" x="42" y="53" width="24" height="69" xoffset="2" yoffset="6" xadvance="27" page="0" chnl="15"/>
+        <char id="124" x="287" y="432" width="8" height="60" xoffset="6" yoffset="7" xadvance="20" page="0" chnl="15"/>
+        <char id="125" x="42" y="123" width="24" height="69" xoffset="1" yoffset="6" xadvance="28" page="0" chnl="15"/>
+        <char id="126" x="95" y="276" width="33" height="11" xoffset="2" yoffset="28" xadvance="38" page="0" chnl="15"/>
+    </chars>
+    <kernings count="0"/>
+</font>

--- a/EverestSplash/SplashContent/fonts/renogare_reference_as_xml.xml
+++ b/EverestSplash/SplashContent/fonts/renogare_reference_as_xml.xml
@@ -1,3 +1,9 @@
+<!-- 
+    This file is not actually in use by any component in Everest nor its splash rather it is only in here for reference 
+    purposes, since the loaded fontbmp definition for the splash is `renogare.bin` (for performance purposes), debugging 
+    with that file format may be harder, as such this file just contains the exact same data in xml format, which is 
+    human readable. 
+-->
 <?xml version="1.0"?>
 <font>
     <info face="Renogare" size="-64" bold="0" italic="0" charset="" unicode="1" stretchH="100" smooth="0" aa="1" padding="0,0,0,0" spacing="1,1" outline="0"/>


### PR DESCRIPTION
Fixes mods getting displayed on the splash after they were loaded, not before. Also introduces a final phase for the splash otherwise the last mod will look like its loading for longer than it actually is.
Cleans up some code left over from the early stages of the splash, when it ran on the same process as Everest.
Adds some funny "features" to the splash that may be triggered by chance.