### PR TITLE
Change cache checksums to be made of .zip files in case of archives

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Relinker.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Relinker.cs
@@ -258,6 +258,58 @@ namespace Celeste.Mod {
                 // Load the module
                 return /* _RuntimeRulesModule = */ ModuleDefinition.ReadModule(rulesPath, new ReaderParameters(ReadingMode.Immediate));
             }
+            
+            
+            /// <summary>
+            /// Get the cached path of a given mod's relinked .dll
+            /// </summary>
+            /// <param name="meta">The mod metadata.</param>
+            /// <returns>The full path to the cached relinked .dll</returns>
+            [Obsolete("Use the variant with an explicit assembly name instead.")]
+            public static string GetCachedPath(EverestModuleMetadata meta)
+                => GetCachedPath(meta, Path.GetFileNameWithoutExtension(meta.DLL));
+
+            /// <summary>
+            /// Get the cached path of a given mod's relinked .dll
+            /// </summary>
+            /// <param name="meta">The mod metadata.</param>
+            /// <param name="asmname"></param>
+            /// <returns>The full path to the cached relinked .dll</returns>
+            [Obsolete("Use EverestModuleAssemblyContext.GetCachedPath instead.")]
+            public static string GetCachedPath(EverestModuleMetadata meta, string asmname)
+                => EverestModuleAssemblyContext.GetCachedPath(meta, asmname);
+
+            /// <summary>
+            /// Get the checksum for a given mod's .dll or the containing .zip
+            /// </summary>
+            /// <param name="meta">The mod metadata.</param>
+            /// <returns>A checksum.</returns>
+            [Obsolete("Use meta.Hash instead.")]
+            public static string GetChecksum(EverestModuleMetadata meta) {
+                string path = meta.PathArchive;
+                if (string.IsNullOrEmpty(path))
+                    path = meta.DLL;
+                return GetChecksum(path);
+            }
+            /// <summary>
+            /// Get the checksum for a given file.
+            /// </summary>
+            /// <param name="path">The file path.</param>
+            /// <returns>A checksum.</returns>
+            [Obsolete("Use Everest.GetChecksum instead.")]
+            public static string GetChecksum(string path) {
+                using (FileStream fs = File.OpenRead(path))
+                    return ChecksumHasher.ComputeHash(fs).ToHexadecimalString();
+            }
+
+            /// <summary>
+            /// Determine if both checksum collections are equal.
+            /// </summary>
+            /// <param name="a">The first checksum array.</param>
+            /// <param name="b">The second checksum array.</param>
+            /// <returns>True if the contents of both arrays match, false otherwise.</returns>
+            [Obsolete("Use Everest.ChecksumsEqual instead")]
+            public static bool ChecksumsEqual(string[] a, string[] b) => Everest.ChecksumsEqual(a, b);
 
             [PatchInitMMFlags]
             private static void InitMMFlags(MonoModder modder) {

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Relinker.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Relinker.cs
@@ -258,8 +258,7 @@ namespace Celeste.Mod {
                 // Load the module
                 return /* _RuntimeRulesModule = */ ModuleDefinition.ReadModule(rulesPath, new ReaderParameters(ReadingMode.Immediate));
             }
-            
-            
+
             /// <summary>
             /// Get the cached path of a given mod's relinked .dll
             /// </summary>

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Relinker.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Relinker.cs
@@ -102,137 +102,36 @@ namespace Celeste.Mod {
             private static Dictionary<string, object> _SharedRelinkMap;
 
             /// <summary>
-            /// Relink a mod .dll, then load it.
-            /// </summary>
-            /// <param name="meta">The mod metadata, used for caching, among other things.</param>
-            /// <param name="stream">The stream to read the .dll from.</param>
-            /// <param name="depResolver">An optional dependency resolver.</param>
-            /// <param name="checksumsExtra">Any optional checksums</param>
-            /// <param name="prePatch">An optional step executed before patching, but after MonoMod has loaded the input assembly.</param>
-            /// <returns>The loaded, relinked assembly.</returns>
-            [Obsolete("Use the variant with an explicit assembly name instead.")]
-            public static Assembly GetRelinkedAssembly(EverestModuleMetadata meta, Stream stream,
-                MissingDependencyResolver depResolver = null, string[] checksumsExtra = null, Action<MonoModder> prePatch = null)
-                => GetRelinkedAssembly(meta, Path.GetFileNameWithoutExtension(meta.DLL), stream, depResolver, checksumsExtra, prePatch);
-
-            /// <summary>
             /// Relink a .dll to point towards Celeste.exe and FNA / XNA properly at runtime, then load it.
             /// </summary>
             /// <param name="meta">The mod metadata, used for caching, among other things.</param>
-            /// <param name="asmname"></param>
-            /// <param name="stream">The stream to read the .dll from.</param>
-            /// <param name="depResolver">An optional dependency resolver.</param>
-            /// <param name="checksumsExtra">Any optional checksums</param>
-            /// <param name="prePatch">An optional step executed before patching, but after MonoMod has loaded the input assembly.</param>
+            /// <param name="asmName">The name of the assembly, for logging.</param>
+            /// <param name="asmPath">The file path to the assembly.</param>
+            /// <param name="symPath">The file path to the assembly's debug symbols-</param>
+            /// <param name="outPath">The path where the relinked assembly should be written.</param>
+            /// <param name="tmpOutPath">The path to a temporary file, if the relinker had to fall back to one.</param>
             /// <returns>The loaded, relinked assembly.</returns>
-            public static Assembly GetRelinkedAssembly(EverestModuleMetadata meta, string asmname, Stream stream,
-                MissingDependencyResolver depResolver = null, string[] checksumsExtra = null, Action<MonoModder> prePatch = null)
-                => GetRelinkedAssembly(meta, asmname, stream, null, depResolver, checksumsExtra, prePatch);
-
-            /// <summary>
-            /// Relink a .dll to point towards Celeste.exe and FNA / XNA properly at runtime, then load it.
-            /// </summary>
-            /// <param name="meta">The mod metadata, used for caching, among other things.</param>
-            /// <param name="asmname"></param>
-            /// <param name="stream">The stream to read the .dll from.</param>
-            /// <param name="symStream">The stream to read the .dll debug symbols from (or null if there are no symbols).</param>
-            /// <param name="depResolver">An optional dependency resolver.</param>
-            /// <param name="checksumsExtra">Any optional checksums</param>
-            /// <param name="prePatch">An optional step executed before patching, but after MonoMod has loaded the input assembly.</param>
-            /// <returns>The loaded, relinked assembly.</returns>
-            public static Assembly GetRelinkedAssembly(EverestModuleMetadata meta, string asmname, Stream stream, Stream symStream,
-                MissingDependencyResolver depResolver = null, string[] checksumsExtra = null, Action<MonoModder> prePatch = null) {
+            public static Assembly GetRelinkedAssembly(EverestModuleMetadata meta, string asmName, string asmPath, string symPath, string outPath, out string tmpOutPath) {
+                tmpOutPath = null;
                 lock (RelinkerLock) {
-                    // Write the streams to a temporary file if it isn't a file stream
-                    string inPath;
-                    if (stream is FileStream fs)
-                        inPath = fs.Name;
-                    else {
-                        inPath = Path.GetTempFileName();
-                        using (FileStream tmpFs = File.OpenWrite(inPath))
-                            stream.CopyTo(tmpFs);
-                    }
-
-                    string inSymPath = null;
-                    if (symStream != null) {
-                        if (symStream is FileStream symFs)
-                            inSymPath = symFs.Name;
-                        else {
-                            inSymPath = Path.GetTempFileName();
-                            using (FileStream tmpFs = File.OpenWrite(inSymPath))
-                                symStream.CopyTo(tmpFs);
-                        }
-                    }
-
-                    // Determine cache paths
-                    string cachePath = GetCachedPath(meta, asmname);
-                    string cacheChecksumPath = Path.ChangeExtension(cachePath, ".sum");
-
-                    Assembly asm = null;
-
-                    // Try to load the assembly from the cache
-                    if (TryLoadCachedAssembly(meta, asmname, inPath, inSymPath, cachePath, cacheChecksumPath, checksumsExtra, out string[] checksums) is not Assembly cacheAsm) {
-                        // Delete cached files
-                        File.Delete(cachePath);
-                        File.Delete(cacheChecksumPath);
-
-                        try {
-                            // Relink the assembly                
-                            if (RelinkAssembly(meta, asmname, inPath, inSymPath, cachePath, depResolver, prePatch, out string tmpOutPath) is not Assembly relinkedAsm)
-                                return null;
-                            else
-                                asm = relinkedAsm;
-
-                            // Write the checksums for the cached assembly to be loaded in the future
-                            // Skip this step if the relinker had to fall back to using a temporary output file
-                            if (tmpOutPath == null)
-                                File.WriteAllLines(cacheChecksumPath, checksums);
-                        } catch (Exception e) {
-                            Logger.Log(LogLevel.Warn, "relinker", $"Failed relinking {meta} - {asmname}");
-                            e.LogDetailed();
+                    try {
+                        // Relink the assembly
+                        if (RelinkAssembly(meta, asmPath, symPath, outPath, out tmpOutPath) is not { } relinkedAsm) {
                             return null;
                         }
-                    } else
-                        asm = cacheAsm;
 
-                    Logger.Log(LogLevel.Verbose, "relinker", $"Loading assembly for {meta} - {asmname} - {asm.FullName}");
-                    return asm;
+                        Logger.Log(LogLevel.Verbose, "relinker", $"Loading assembly for {meta} - {asmName} - {relinkedAsm.FullName}");
+
+                        return relinkedAsm;
+                    } catch (Exception e) {
+                        Logger.Log(LogLevel.Warn, "relinker", $"Failed relinking {meta} - {asmName}");
+                        e.LogDetailed();
+                        return null;
+                    }
                 }
             }
 
-            private static Assembly TryLoadCachedAssembly(EverestModuleMetadata meta, string asmName, string inPath, string inSymPath, string cachePath, string cacheChecksumsPath, string[] extraChecksums, out string[] curChecksums) {
-                // Calculate checksums
-                List<string> checksums = new List<string>();
-                checksums.Add(GameChecksum);
-                checksums.Add(Everest.GetChecksum(inPath).ToHexadecimalString());
-                if (inSymPath != null)
-                    checksums.Add(Everest.GetChecksum(inSymPath).ToHexadecimalString());
-
-                if (extraChecksums != null)
-                    checksums.AddRange(extraChecksums);
-
-                curChecksums = checksums.ToArray();
-
-                // Check if the cached assembly + its checksums exist on disk, and if the checksums match
-                if (!File.Exists(cachePath) || !File.Exists(cacheChecksumsPath))
-                    return null;
-
-                if (!ChecksumsEqual(curChecksums, File.ReadAllLines(cacheChecksumsPath)))
-                    return null;
-                
-                Logger.Log(LogLevel.Verbose, "relinker", $"Loading cached assembly for {meta} - {asmName}");
-
-                // Try to load the assembly and the module definition
-                try {
-                    return meta.AssemblyContext.LoadRelinkedAssembly(cachePath);
-                } catch (Exception e) {
-                    Logger.Log(LogLevel.Warn, "relinker", $"Failed loading cached assembly for {meta} - {asmName}");
-                    e.LogDetailed();
-                    return null;
-                }
-            }
-
-            private static Assembly RelinkAssembly(EverestModuleMetadata meta, string asmname, string inPath, string inSymPath, string outPath, MissingDependencyResolver depResolver, Action<MonoModder> prePatch, out string tmpOutPath) {
+            private static Assembly RelinkAssembly(EverestModuleMetadata meta, string inPath, string inSymPath, string outPath, out string tmpOutPath) {
                 tmpOutPath = null;
 
                 // Check if the assembly name is on the blacklist
@@ -256,7 +155,7 @@ namespace Celeste.Mod {
                     RelinkMap = new Dictionary<string, object>(SharedRelinkMap),
 
                     AssemblyResolver = meta.AssemblyContext,
-                    MissingDependencyResolver = depResolver
+                    MissingDependencyThrow = false
                 };
                 try {
                     InitMMFlags(modder);
@@ -271,9 +170,6 @@ namespace Celeste.Mod {
                     // Map assembly dependencies
                     modder.MapDependencies();
                     modder.MapDependencies(runtimeRulesMod);
-
-                    // Patch the assembly
-                    prePatch?.Invoke(modder);
 
                     TypeDefinition runtimeRulesType = runtimeRulesMod.GetType("MonoMod.MonoModRules");
                     modder.ParseRules(runtimeRulesMod);
@@ -328,7 +224,7 @@ namespace Celeste.Mod {
                 try {
                     return meta.AssemblyContext.LoadRelinkedAssembly(outPath);
                 } catch (Exception e) {
-                    Logger.Log(LogLevel.Warn, "relinker", $"Failed loading relinked assembly {meta} - {asmname}");
+                    Logger.Log(LogLevel.Warn, "relinker", $"Failed loading relinked assembly {meta} - {Path.GetFileNameWithoutExtension(inPath)}");
                     e.LogDetailed();
                     return null;
                 }
@@ -361,62 +257,6 @@ namespace Celeste.Mod {
 
                 // Load the module
                 return /* _RuntimeRulesModule = */ ModuleDefinition.ReadModule(rulesPath, new ReaderParameters(ReadingMode.Immediate));
-            }
-
-            /// <summary>
-            /// Get the cached path of a given mod's relinked .dll
-            /// </summary>
-            /// <param name="meta">The mod metadata.</param>
-            /// <returns>The full path to the cached relinked .dll</returns>
-            [Obsolete("Use the variant with an explicit assembly name instead.")]
-            public static string GetCachedPath(EverestModuleMetadata meta)
-                => GetCachedPath(meta, Path.GetFileNameWithoutExtension(meta.DLL));
-
-            /// <summary>
-            /// Get the cached path of a given mod's relinked .dll
-            /// </summary>
-            /// <param name="meta">The mod metadata.</param>
-            /// <param name="asmname"></param>
-            /// <returns>The full path to the cached relinked .dll</returns>
-            public static string GetCachedPath(EverestModuleMetadata meta, string asmname)
-                => Path.Combine(Loader.PathCache, meta.Name + "." + asmname + ".dll");
-
-            /// <summary>
-            /// Get the checksum for a given mod's .dll or the containing .zip
-            /// </summary>
-            /// <param name="meta">The mod metadata.</param>
-            /// <returns>A checksum.</returns>
-            [Obsolete("Use meta.Hash instead.")]
-            public static string GetChecksum(EverestModuleMetadata meta) {
-                string path = meta.PathArchive;
-                if (string.IsNullOrEmpty(path))
-                    path = meta.DLL;
-                return GetChecksum(path);
-            }
-            /// <summary>
-            /// Get the checksum for a given file.
-            /// </summary>
-            /// <param name="path">The file path.</param>
-            /// <returns>A checksum.</returns>
-            [Obsolete("Use Everest.GetChecksum instead.")]
-            public static string GetChecksum(string path) {
-                using (FileStream fs = File.OpenRead(path))
-                    return ChecksumHasher.ComputeHash(fs).ToHexadecimalString();
-            }
-
-            /// <summary>
-            /// Determine if both checksum collections are equal.
-            /// </summary>
-            /// <param name="a">The first checksum array.</param>
-            /// <param name="b">The second checksum array.</param>
-            /// <returns>True if the contents of both arrays match, false otherwise.</returns>
-            public static bool ChecksumsEqual(string[] a, string[] b) {
-                if (a.Length != b.Length)
-                    return false;
-                for (int i = 0; i < a.Length; i++)
-                    if (a[i].Trim() != b[i].Trim())
-                        return false;
-                return true;
             }
 
             [PatchInitMMFlags]

--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -169,6 +169,21 @@ namespace Celeste.Mod {
             stream.Seek(pos, SeekOrigin.Begin);
             return hash;
         }
+        
+        /// <summary>
+        /// Determine if both checksum collections are equal.
+        /// </summary>
+        /// <param name="a">The first checksum array.</param>
+        /// <param name="b">The second checksum array.</param>
+        /// <returns>True if the contents of both arrays match, false otherwise.</returns>
+        public static bool ChecksumsEqual(string[] a, string[] b) {
+            if (a.Length != b.Length)
+                return false;
+            for (int i = 0; i < a.Length; i++)
+                if (a[i].Trim() != b[i].Trim())
+                    return false;
+            return true;
+        }
 
         private static byte[] _InstallationHash;
         public static byte[] InstallationHash {

--- a/Celeste.Mod.mm/Mod/Module/EverestModuleAssemblyContext.cs
+++ b/Celeste.Mod.mm/Mod/Module/EverestModuleAssemblyContext.cs
@@ -165,32 +165,38 @@ namespace Celeste.Mod {
                 // This can fix self referential assemblies blowing up
                 _LoadedAssemblies.Add(asmPath, null);
 
+                // Determine cache paths
+                string cachePath = GetCachedPath(ModuleMeta, asmName);
+                string cacheChecksumPath = Path.ChangeExtension(cachePath, ".sum");
+
+                // Calculate checksums
+                string[] checksums = { Everest.Relinker.GameChecksum, ModuleMeta.Hash.ToHexadecimalString() };
+
                 // Try to load + relink the assembly
                 // Do this on the main thread, as otherwise stuff can break
                 Stack<EverestModuleAssemblyContext> prevCtxs = _ActiveLocalLoadContexts;
                 _ActiveLocalLoadContexts = null;
                 try {
-                    if (!string.IsNullOrEmpty(ModuleMeta.PathArchive))
-                        using (ZipFile zip = new ZipFile(ModuleMeta.PathArchive)) {
-                            // Try to find + load the (symbol) entry
-                            string entryPath = osSepPath.Replace(Path.DirectorySeparatorChar, '/');
-                            ZipEntry entry = zip.Entries.FirstOrDefault(entry => entry.FileName == entryPath);
+                    if (TryLoadCachedAssembly(ModuleMeta, asmName, cachePath, cacheChecksumPath, checksums) is not { } relinkedAsm) {
+                        File.Delete(cachePath);
+                        File.Delete(cacheChecksumPath);
 
-                            string symEntryPath = Path.ChangeExtension(osSepPath, ".pdb").Replace(Path.DirectorySeparatorChar, '/');
-                            ZipEntry symEntry = zip.Entries.FirstOrDefault(entry => entry.FileName == symEntryPath);
+                        (string asmFilePath, string symPath) = GetAssemblyFilePathsForRelinking(asmPath);
 
-                            if (entry != null)
-                                using (Stream stream = entry.ExtractStream())
-                                using (Stream symStream = symEntry?.ExtractStream())
-                                    asm = Everest.Relinker.GetRelinkedAssembly(ModuleMeta, asmName, stream, symStream);
+                        if (asmFilePath == null) {
+                            return null;
                         }
-                    else if (!string.IsNullOrEmpty(ModuleMeta.PathDirectory)) {
-                        string symPath = Path.ChangeExtension(path, ".pdb");
-                        if (File.Exists(path))
-                            using (Stream stream = File.OpenRead(path))
-                            using (Stream symStream = File.Exists(symPath) ? File.OpenRead(symPath) : null)
-                                asm = Everest.Relinker.GetRelinkedAssembly(ModuleMeta, asmName, stream, symStream);
+
+                        relinkedAsm = Everest.Relinker.GetRelinkedAssembly(ModuleMeta, asmName, asmFilePath, symPath, cachePath, out string tmpOutPath);
+                        
+                        // Write the checksums for the cached assembly to be loaded in the future
+                        // Skip this step if the relinker had to fall back to using a temporary output file
+                        if (tmpOutPath == null) {
+                            File.WriteAllLines(cacheChecksumPath, checksums);
+                        }
                     }
+
+                    asm = relinkedAsm;
                 } finally {
                     _ActiveLocalLoadContexts = prevCtxs;
                 }
@@ -207,6 +213,82 @@ namespace Celeste.Mod {
                 }
 
                 return asm;
+            }
+        }
+
+        private (string, string) GetAssemblyFilePathsForRelinking(string assemblyPath) {
+            string symPath = Path.ChangeExtension(assemblyPath, "pdb");
+
+            if (ModuleMeta.PathDirectory != null) {
+                return (assemblyPath, symPath);
+            }
+
+            if (ModuleMeta.PathArchive != null) {
+                using ZipFile zip = new(ModuleMeta.PathArchive);
+
+                // Try to find + load the (symbol) entry
+                string entryPath = assemblyPath.Replace(Path.DirectorySeparatorChar, '/');
+                ZipEntry entry = zip.Entries.FirstOrDefault(entry => entry.FileName == entryPath);
+
+                string symEntryPath = symPath.Replace(Path.DirectorySeparatorChar, '/');
+                ZipEntry symEntry = zip.Entries.FirstOrDefault(entry => entry.FileName == symEntryPath);
+
+                if (entry == null) {
+                    return default;
+                }
+
+                var asmZipStream = entry.ExtractStream();
+                var symZipStream = symEntry?.ExtractStream();
+
+                string assemblyOutPath = Path.GetTempFileName();
+                using (FileStream tmpFs = File.OpenWrite(assemblyOutPath))
+                    asmZipStream.CopyTo(tmpFs);
+
+                string symOutPath = null;
+                if (symZipStream != null) {
+                    symOutPath = Path.GetTempFileName();
+                    using (FileStream tmpFs = File.OpenWrite(symOutPath))
+                        symZipStream.CopyTo(tmpFs);
+                }
+
+                return (assemblyOutPath, symOutPath);
+            }
+
+            return default;
+        }
+        
+        /// <summary>
+        /// Get the cached path of a given mod's relinked .dll
+        /// </summary>
+        /// <param name="meta">The mod metadata.</param>
+        /// <param name="asmname"></param>
+        /// <returns>The full path to the cached relinked .dll</returns>
+        public static string GetCachedPath(EverestModuleMetadata meta, string asmname)
+            => Path.Combine(Everest.Loader.PathCache, meta.Name + "." + asmname + ".dll");
+        
+        private static Assembly TryLoadCachedAssembly(EverestModuleMetadata meta, string asmName, string cachePath, string cacheChecksumPath, string[] checksums) {
+            // Check if the cached assembly + its checksums exist on disk, and if the checksums match
+            if (!File.Exists(cachePath) || !File.Exists(cacheChecksumPath)) {
+                Logger.Log(LogLevel.Verbose, "relinker", $"Cache miss - no cache file for {meta} - {asmName}");
+                return null;
+            }
+
+            if (!Everest.ChecksumsEqual(checksums, File.ReadAllLines(cacheChecksumPath))) {
+                Logger.Log(LogLevel.Verbose, "relinker", $"Cache miss - checksum mismatch for {meta} - {asmName}");
+                return null;
+            }
+
+            Logger.Log(LogLevel.Verbose, "relinker", $"Loading cached assembly for {meta} - {asmName}");
+
+            // Try to load the assembly and the module definition
+            try {
+                Assembly assembly = meta.AssemblyContext.LoadRelinkedAssembly(cachePath);
+                Logger.Log(LogLevel.Verbose, "relinker", $"Cache hit - loaded cached assembly for {meta} - {asmName}");
+                return assembly;
+            } catch (Exception e) {
+                Logger.Log(LogLevel.Warn, "relinker", $"Cache miss - failed loading cached assembly for {meta} - {asmName}");
+                e.LogDetailed();
+                return null;
             }
         }
 

--- a/Celeste.Mod.mm/Mod/Module/EverestModuleMetadata.cs
+++ b/Celeste.Mod.mm/Mod/Module/EverestModuleMetadata.cs
@@ -77,7 +77,9 @@ namespace Celeste.Mod {
         /// <summary>
         /// The runtime mod hash. Might not be determined by all mod content.
         /// </summary>
-        public byte[] Hash { get; set; }
+        public byte[] Hash => _hash ??= Everest.GetChecksum(this);
+        
+        private byte[] _hash;
 
         /// <summary>
         /// Whether this module supports experimental live code reloading or not.
@@ -126,7 +128,6 @@ namespace Celeste.Mod {
         /// </summary>
         internal void RegisterMod() {
             Everest.InvalidateInstallationHash();
-            Hash = Everest.GetChecksum(this);
 
             // Audio banks are cached, and as such use the module's hash. We can only ingest those now.
             if (patch_Audio.AudioInitialized) {


### PR DESCRIPTION
## About the PR

This PR changes the way the relinker loads cached assemblies by comparing the checksum of a mod archive instead of extracting the assembly and comparing its checksum. Cache logic has been moved to the AssemblyLoadContext level, and load contexts will no longer try to unzip files when the checksums match. 

The signature of `GetRelinkedAssembly()` has changed, so I tossed the other two obsolete methods. Flame me in the comments if I shouldn't have done that.

Also I changed the metadata to be computed on access of `meta.Hash` instead of in `RegisterMod()`. I needed the hash before `RegisterMod()` would have been called, so I changed this. I don't think it would break existing code, but worth mentioning anyways.

Conflicts with #749

## How this contributes to Everest

The current implementation will always extract an assembly to generate the checksum and compare it with the cache, which eats up some initialization time (especially for large mods). Checksums are fast however and we do them anyways, so we can make an assumption that we can toss cached assemblies if the archive has changed (we would only lose init time, and archives aren't supposed to be touched anyways). 

With these changes I managed to load an install of SJ in ~30 seconds compared to ~40 seconds on stable (~70mb/s reading speed)
