### PR TITLE
Show a postcard when a map has no rooms

### DIFF
--- a/Celeste.Mod.mm/Content/Dialog/English.txt
+++ b/Celeste.Mod.mm/Content/Dialog/English.txt
@@ -28,6 +28,8 @@
 	POSTCARD_TILEXMLERROR=		{big}Oops!{/big}{n}There was an error parsing a tileset in {#ff1144}((path)){#}{n}Check your {#44adf7}log.txt{#} for more info.
 	POSTCARD_XMLERROR=			{big}Oops!{/big}{n}{#ff1144}((path)){#} has a syntax error.{n}Check your {#44adf7}log.txt{#} for more info.
 	POSTCARD_BOSSLASTNODEHIT=	{big}Oops!{/big}{n}{#ff1144}Badeline Boss{#} entity was hit on its last node, please add an additional node outside of the current room to ensure the player never hits it.
+	POSTCARD_LEVELNOROOMS=		{big}Oops!{/big}{n}This map has {#f94a4a}no rooms{#}!{n}Please make sure your map has{n}{#44adf7}at least one room{#}, and that{n}you've saved it since its creation.
+	POSTCARD_LEVELNOSTARTROOM=	{big}Oops!{/big}{n}The starting room {#f94a4a}((room)){#} does not exist!{n}Please make sure the room exists,{n}and that you've saved it since its creation.
 
 # Main Menu
 	MENU_TITLETOUCH= 		TOUCH

--- a/Celeste.Mod.mm/Patches/OuiChapterPanel.cs
+++ b/Celeste.Mod.mm/Patches/OuiChapterPanel.cs
@@ -1,6 +1,7 @@
 ﻿#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
 #pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
 
+using Celeste.Mod;
 using Celeste.Mod.UI;
 using Microsoft.Xna.Framework;
 using Mono.Cecil;
@@ -212,7 +213,20 @@ namespace Celeste {
                 Overworld.RendererList.MoveToFront(Overworld.Snow);
             }
             yield return 0.5f;
-            LevelEnter.Go(new Session(Area, checkpoint), false);
+            Session sess = null;
+            try {
+                sess = new Session(Area, checkpoint);
+            } catch (Exception e) {
+                Logger.Log(LogLevel.Error, "OuiChapterPanel", "Failed to construct session!");
+                Logger.LogDetailed(e, "OuiChapterPanel");
+
+                // rethrow the exception if there's no explicit error message
+                // LevelEnter.Go will show a postcard if there is one
+                // fortunately it doesn't care if session is null :catblob:
+                if (patch_LevelEnter.ErrorMessage == null)
+                    throw;
+            }
+            LevelEnter.Go(sess, false);
         }
 
         [MonoModIgnore] // We don't want to change anything about the method...

--- a/Celeste.Mod.mm/Patches/Session.cs
+++ b/Celeste.Mod.mm/Patches/Session.cs
@@ -1,6 +1,10 @@
 #pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
 
+using Mono.Cecil;
+using Mono.Cecil.Cil;
 using MonoMod;
+using MonoMod.Cil;
+using System;
 
 namespace Celeste {
     public class patch_Session {
@@ -8,6 +12,7 @@ namespace Celeste {
 
         public patch_Session(AreaKey area, string checkpoint = null, AreaStats oldStats = null) { }
 
+        [PatchSessionOrigCtor]
         public extern void orig_ctor(AreaKey area, string checkpoint = null, AreaStats oldStats = null);
 
         [MonoModConstructor]
@@ -19,6 +24,50 @@ namespace Celeste {
                 areaData.OverrideASideMeta(area.Mode);
             }
             orig_ctor(area, checkpoint, oldStats);
+        }
+    }
+}
+
+namespace MonoMod {
+
+    /// <summary>
+    /// Patch the session .ctor to default to "" if the map has no rooms,
+    /// or the default room does not exist
+    /// </summary>
+    [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchSessionOrigCtor))]
+    class PatchSessionOrigCtorAttribute : Attribute { }
+
+    static partial class MonoModRules {
+        public static void PatchSessionOrigCtor(ILContext context, CustomAttribute attrib) {
+            ILCursor cursor = new ILCursor(context);
+            cursor.GotoNext(MoveType.After, instr => instr.MatchCallvirt("Celeste.MapData", "StartLevel"));
+
+            ILLabel end = cursor.DefineLabel();
+
+            // go to ldfld string LevelData::Name if StartLevel() is not null
+            ILLabel yesLdfldName = cursor.DefineLabel();
+            cursor.Emit(OpCodes.Dup);
+            cursor.Emit(OpCodes.Brtrue_S, yesLdfldName);
+
+            // else replace it with null and skip the ldfld string LevelData::Name
+            ILLabel noLdfldName = cursor.DefineLabel();
+            cursor.Emit(OpCodes.Pop);
+            cursor.Emit(OpCodes.Ldnull);
+            cursor.Emit(OpCodes.Br_S, noLdfldName);
+
+            // next opcode is ldfld string LevelData::Name; mark the labels
+            cursor.MarkLabel(yesLdfldName);
+            cursor.Index++;
+            cursor.MarkLabel(noLdfldName);
+
+            // now use the value if it's not null, else default to ""
+            cursor.Emit(OpCodes.Dup);
+            cursor.Emit(OpCodes.Brtrue_S, end);
+            cursor.Emit(OpCodes.Pop);
+            cursor.Emit(OpCodes.Ldstr, "");
+
+            // don't forget to mark where the stfld string Session::Level is
+            cursor.MarkLabel(end);
         }
     }
 }


### PR DESCRIPTION
Instead of crashing, show a postcard when a map has no rooms, or when the starting room defined in map metadata does not exist.

Below are screenshots of this PR in action.
![Postcard saying "Oops! This map has no rooms! Please make sure the map has at least one room, and that you've saved it since its creation."](https://github.com/EverestAPI/Everest/assets/49392266/a1c197fc-9471-4e9a-a65a-580d14fc0ce6)
![Postcard saying "Oops! The starting room a-00 does not exist! Please make sure the room exists, and that you've saved it since its creation."](https://github.com/EverestAPI/Everest/assets/49392266/e6dba69d-0fdd-4538-8b51-fb2a711b68c4)
