### PR TITLE
Remove empty entries when splitting .obj lines

### DIFF
--- a/Celeste.Mod.mm/Patches/ObjModel.cs
+++ b/Celeste.Mod.mm/Patches/ObjModel.cs
@@ -69,7 +69,7 @@ namespace Celeste {
                 using (StreamReader streamReader = new StreamReader(stream)) {
                     string text;
                     while ((text = streamReader.ReadLine()) != null) {
-                        string[] array = text.Split(' ');
+                        string[] array = text.Split(' ', StringSplitOptions.RemoveEmptyEntries);
                         if (array.Length != 0) {
                             string a = array[0];
                             if (a == "o") {


### PR DESCRIPTION
This should marginally improve compatibility with `.obj` files generated from different programs.

Even though #396 already exists, which already suggested using a library to increase compatibility even more, this shouldn't hurt in the meantime.