### PR TITLE
Fix P/Invokes crashing in `EverestModule.Load()`

### DIFF
--- a/Celeste.Mod.mm/Mod/Module/EverestModuleAssemblyContext.cs
+++ b/Celeste.Mod.mm/Mod/Module/EverestModuleAssemblyContext.cs
@@ -520,14 +520,7 @@ namespace Celeste.Mod {
                     // We have to unzip the native libs into the cache
                     string cachePath = Path.Combine(Everest.Loader.PathCache, "unmanaged-libs", UnmanagedLibraryFolder, ModuleMeta.Name);
 
-                    string modHash = (
-                        ModuleMeta.Hash
-                        ?? ModuleMeta.Multimeta.FirstOrDefault(meta => meta.Hash != null).Hash
-
-                        // if we're here, this means a P/Invoke occured in Load(); calculate the hash real quick
-                        // https://github.com/EverestAPI/Everest/issues/761
-                        ?? (ModuleMeta.Hash = Everest.GetChecksum(ModuleMeta))
-                    ).ToHexadecimalString();
+                    string modHash = (ModuleMeta.Hash ?? ModuleMeta.Multimeta.FirstOrDefault(meta => meta.Hash != null).Hash).ToHexadecimalString();
 
                     if (Directory.Exists(cachePath) && (!File.Exists(cachePath + ".sum") || File.ReadAllText(cachePath + ".sum") != modHash))
                         Directory.Delete(cachePath, true);

--- a/Celeste.Mod.mm/Mod/Module/EverestModuleAssemblyContext.cs
+++ b/Celeste.Mod.mm/Mod/Module/EverestModuleAssemblyContext.cs
@@ -520,7 +520,15 @@ namespace Celeste.Mod {
                     // We have to unzip the native libs into the cache
                     string cachePath = Path.Combine(Everest.Loader.PathCache, "unmanaged-libs", UnmanagedLibraryFolder, ModuleMeta.Name);
 
-                    string modHash = (ModuleMeta.Hash ?? ModuleMeta.Multimeta.First(meta => meta.Hash != null).Hash).ToHexadecimalString();
+                    string modHash = (
+                        ModuleMeta.Hash
+                        ?? ModuleMeta.Multimeta.FirstOrDefault(meta => meta.Hash != null).Hash
+
+                        // if we're here, this means a P/Invoke occured in Load(); calculate the hash real quick
+                        // https://github.com/EverestAPI/Everest/issues/761
+                        ?? (ModuleMeta.Hash = Everest.GetChecksum(ModuleMeta))
+                    ).ToHexadecimalString();
+
                     if (Directory.Exists(cachePath) && (!File.Exists(cachePath + ".sum") || File.ReadAllText(cachePath + ".sum") != modHash))
                         Directory.Delete(cachePath, true);
 

--- a/Celeste.Mod.mm/Mod/Module/EverestModuleAssemblyContext.cs
+++ b/Celeste.Mod.mm/Mod/Module/EverestModuleAssemblyContext.cs
@@ -520,7 +520,7 @@ namespace Celeste.Mod {
                     // We have to unzip the native libs into the cache
                     string cachePath = Path.Combine(Everest.Loader.PathCache, "unmanaged-libs", UnmanagedLibraryFolder, ModuleMeta.Name);
 
-                    string modHash = (ModuleMeta.Hash ?? ModuleMeta.Multimeta.FirstOrDefault(meta => meta.Hash != null).Hash).ToHexadecimalString();
+                    string modHash = ModuleMeta.Hash.ToHexadecimalString();
 
                     if (Directory.Exists(cachePath) && (!File.Exists(cachePath + ".sum") || File.ReadAllText(cachePath + ".sum") != modHash))
                         Directory.Delete(cachePath, true);

--- a/Celeste.Mod.mm/Mod/Module/EverestModuleMetadata.cs
+++ b/Celeste.Mod.mm/Mod/Module/EverestModuleMetadata.cs
@@ -74,10 +74,12 @@ namespace Celeste.Mod {
         /// </summary>
         public List<EverestModuleMetadata> OptionalDependencies { get; set; } = new List<EverestModuleMetadata>();
 
+        private byte[] _Hash;
+
         /// <summary>
         /// The runtime mod hash. Might not be determined by all mod content.
         /// </summary>
-        public byte[] Hash { get; set; }
+        public byte[] Hash => _Hash ??= Everest.GetChecksum(this);
 
         /// <summary>
         /// Whether this module supports experimental live code reloading or not.
@@ -126,7 +128,6 @@ namespace Celeste.Mod {
         /// </summary>
         internal void RegisterMod() {
             Everest.InvalidateInstallationHash();
-            Hash ??= Everest.GetChecksum(this);
 
             // Audio banks are cached, and as such use the module's hash. We can only ingest those now.
             if (patch_Audio.AudioInitialized) {

--- a/Celeste.Mod.mm/Mod/Module/EverestModuleMetadata.cs
+++ b/Celeste.Mod.mm/Mod/Module/EverestModuleMetadata.cs
@@ -126,7 +126,7 @@ namespace Celeste.Mod {
         /// </summary>
         internal void RegisterMod() {
             Everest.InvalidateInstallationHash();
-            Hash = Everest.GetChecksum(this);
+            Hash ??= Everest.GetChecksum(this);
 
             // Audio banks are cached, and as such use the module's hash. We can only ingest those now.
             if (patch_Audio.AudioInitialized) {


### PR DESCRIPTION
`EverestModuleAssemblyContext.LoadUnmanagedFromThisMod(string)` accesses  the module meta's `Hash`. If a P/Invoke occurs in `EverestModule.Load()`, the `Hash` has not yet been computed, which crashes the game.

This commit fixes that by calculating the `Hash` if it is `null`.

Fixes #761.