### PR TITLE
Option to update the cassette block manager during transitions

### DIFF
--- a/Celeste.Mod.mm/Mod/Meta/MapMeta.cs
+++ b/Celeste.Mod.mm/Mod/Meta/MapMeta.cs
@@ -532,6 +532,7 @@ namespace Celeste.Mod.Meta {
         public int Blocks { get; set; } = 2;
         public int BeatsMax { get; set; } = 256;
         public int BeatIndexOffset { get; set; } = 0;
+        public bool ActiveDuringTransitions { get; set; } = false;
         public bool OldBehavior { get; set; } = false;
 
         public void Parse(BinaryPacker.Element meta) {
@@ -542,6 +543,7 @@ namespace Celeste.Mod.Meta {
             meta.AttrIfInt("Blocks", v => Blocks = v);
             meta.AttrIfInt("BeatsMax", v => BeatsMax = v);
             meta.AttrIfInt("BeatIndexOffset", v => BeatIndexOffset = v);
+            meta.AttrIfBool("ActiveDuringTransitions", v => ActiveDuringTransitions = v);
             meta.AttrIfBool("OldBehavior", v => OldBehavior = v);
         }
     }

--- a/Celeste.Mod.mm/Patches/CassetteBlockManager.cs
+++ b/Celeste.Mod.mm/Patches/CassetteBlockManager.cs
@@ -54,6 +54,18 @@ namespace Celeste {
                 ticksPerSwap = meta.TicksPerSwap;
                 beatIndexMax = meta.BeatsMax;
                 beatIndexOffset = meta.BeatIndexOffset;
+
+                if (meta.ActiveDuringTransitions) {
+                    TransitionListener listener = Get<TransitionListener>();
+
+                    if (listener != null) {
+                        listener.OnOut = _ => {
+                            if (Scene != null) {
+                                Update();
+                            }
+                        };
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Implements the code from https://github.com/StrawberryJam2021/StrawberryJam2021/blob/e1404e5c0c470808f5ea1c42c09de0c09a5aa46c/Entities/CassetteMusicTransitionController.cs but using cassette map metadata. If you enable the option, the cassette block manager will keep updating during room transitions, reducing the silence between rooms of cassette levels down to only a stutter. This has been used in the three cassette levels in Strawberry Jam, and I promised I would add it to Everest. Better late than never, I guess.

The option is disabled by default to maintain backwards compatibility.

Sets a method on the existing `TransitionListener` rather than creating a new `TransitionListener` as I am not sure how safe adding components in `Awake` is for global entities. I _assume_ It is only called once ever, but I didn't check.