### PR TITLE
Allow manually creating postcards from sound IDs

### DIFF
--- a/Celeste.Mod.mm/Patches/LevelEnter.cs
+++ b/Celeste.Mod.mm/Patches/LevelEnter.cs
@@ -135,26 +135,7 @@ namespace Celeste {
         private IEnumerator EnterWithPostcardRoutine(string message, string soundId) {
             yield return 1f;
 
-            if (string.IsNullOrEmpty(soundId))
-                soundId = "csides";
-
-            string prefix;
-            if (soundId.StartsWith("event:/")) {
-                // sound ID is a FMOD event, take it as is.
-                prefix = soundId;
-            } else if (soundId == "variants") {
-                // sound ID is "variants", this is a special case since it is in the new_content bank.
-                prefix = "event:/new_content/ui/postcard_variants";
-            } else {
-                // if a number, use event:/ui/main/postcard_ch{number}
-                // if not, use event:/ui/main/postcard_{text}
-                prefix = "event:/ui/main/postcard_";
-                if (int.TryParse(soundId, out _))
-                    prefix += "ch";
-                prefix += soundId;
-            }
-
-            Add(postcard = new Postcard(message, prefix + "_in", prefix + "_out"));
+            Add(postcard = new patch_Postcard(message, soundId));
             yield return postcard.DisplayRoutine();
 
             IEnumerator inner = orig_Routine();

--- a/Celeste.Mod.mm/Patches/Postcard.cs
+++ b/Celeste.Mod.mm/Patches/Postcard.cs
@@ -19,5 +19,37 @@ namespace Celeste {
             ctor(msg, "event:/ui/main/postcard_csides_in", "event:/ui/main/postcard_csides_out");
         }
 
+        // 2-arg ctor parsing custom postcard sound IDs
+        [MonoModConstructor]
+        [MonoModRemove]
+        public patch_Postcard(string msg, string soundId) 
+            : base(msg, soundId, soundId) {
+            // no-op. This ctor is only used to make the compiler work in Celeste.LevelEnter
+        }
+
+        [MonoModConstructor]
+        public void ctor(string msg, string soundId) {
+            if (string.IsNullOrEmpty(soundId))
+                soundId = "csides";
+
+            string prefix;
+            if (soundId.StartsWith("event:/")) {
+                // sound ID is a FMOD event, take it as is.
+                prefix = soundId;
+            } else if (soundId == "variants") {
+                // sound ID is "variants", this is a special case since it is in the new_content bank.
+                prefix = "event:/new_content/ui/postcard_variants";
+            } else {
+                // if a number, use event:/ui/main/postcard_ch{number}
+                // if not, use event:/ui/main/postcard_{text}
+                prefix = "event:/ui/main/postcard_";
+                if (int.TryParse(soundId, out _))
+                    prefix += "ch";
+                prefix += soundId;
+            }
+
+            ctor(msg, prefix + "_in", prefix + "_out");
+        }
+
     }
 }


### PR DESCRIPTION
Moves the code that parses `PostcardSoundID` from map metadata into its own constructor, allowing mods to create their own postcards using that metadata field, or to use custom sound IDs entirely as the format itself is fairly useful.