### PR TITLE
Crash handler improvements

### DIFF
--- a/Celeste.Mod.mm/Mod/UI/CriticalErrorHandler.cs
+++ b/Celeste.Mod.mm/Mod/UI/CriticalErrorHandler.cs
@@ -229,6 +229,20 @@ namespace Celeste.Mod.UI {
 
                 writer.WriteLine();
                 writer.WriteLine($"Crash Exception: {error}");
+                writer.WriteLine();
+                writer.WriteLine($"Crash HResult: {error.HResult}");
+                writer.WriteLine($"Inner exception (if any): {error.InnerException}");
+                writer.WriteLine();
+                
+                StackTrace trace = new(error, true);
+                StackFrame latestFrame = trace.GetFrame(0);
+                if (latestFrame != null) {
+                    writer.WriteLine($"Last stack trace: {latestFrame}");
+                    writer.WriteLine($"Trace IL offset: {latestFrame.GetILOffset()}");
+                    writer.WriteLine($"Trace native offset: {latestFrame.GetNativeOffset()}");
+                } else {
+                    writer.WriteLine("Couldn't fetch latest frame!");
+                }
             } catch (Exception ex) {
                 Logger.Log(LogLevel.Error, "crit-error-handler", "Error backing up log file:");
                 Logger.LogDetailed(ex, "crit-error-handler");

--- a/Celeste.Mod.mm/Mod/UI/CriticalErrorHandler.cs
+++ b/Celeste.Mod.mm/Mod/UI/CriticalErrorHandler.cs
@@ -722,8 +722,14 @@ namespace Celeste.Mod.UI {
 
             DrawLineWrap($"Error Details: {errorType}: {errorMessage}", 0.7f, Color.LightGray);
             textPos.X += 50;
-            string[] btLines = (errorStackTrace ?? string.Empty).Split('\n').Select(l => l.Trim()).Where(l => !l.StartsWith("at Hook<") && !l.StartsWith("at DMD<")).ToArray();
+            string[] btLines = (errorStackTrace ?? string.Empty)
+                .Split('\n')
+                .Select(l => l.Trim())
+                .ToArray();
             for (int i = 0; i < btLines.Length; i++) {
+                // Declutter the stack trace from MonoMod detours, additionally skip the check if it's the latest one,
+                // since that means the crash was in there
+                if (i != 0 && btLines[i].StartsWith("at Hook<")) continue;
                 DrawLineWrap(btLines[i], 0.4f, Color.Gray);
                 if (textPos.Y >= Celeste.TargetHeight * 0.9f && i+1 < btLines.Length) {
                     DrawLineWrap("...", 0.5f, Color.Gray);


### PR DESCRIPTION
Slight improvements to the crash handler screen and the crash logs:
- Add some extra info polled from the exception itself, such as the ILOffset (if available) and the NativeOffset, which could be vital to diagnose crashes where the PDB is not helpful (either because its missing or points to the wrong locations).
- Marks outdated in the mods list if the crash is late enough for everest to have polled the latest versions, helps quickly check whether an user is on the latest version of a mod which seems to crash.
- Oversight in the on-screen stacktrace where `DMD`s would be hidden, but are instead vital to the stacktrace, since they indicated IL-patched methods. The filter is completely disabled for the latest stack frame to not hide possible MonoMod crashes.
