### PR TITLE
Fix code hot reload accidentally loading a cached version

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
@@ -484,7 +484,9 @@ namespace Celeste.Mod {
                     return true;
 
                 using var _ = new ScopeFinalizer(() => Events.Everest.LoadMod(meta));
-
+                
+                // (Re)compute the hash
+                meta.Hash = GetChecksum(meta);
                 // Create an assembly context
                 meta.AssemblyContext ??= new EverestModuleAssemblyContext(meta);
 

--- a/Celeste.Mod.mm/Mod/Module/EverestModuleMetadata.cs
+++ b/Celeste.Mod.mm/Mod/Module/EverestModuleMetadata.cs
@@ -74,12 +74,10 @@ namespace Celeste.Mod {
         /// </summary>
         public List<EverestModuleMetadata> OptionalDependencies { get; set; } = new List<EverestModuleMetadata>();
 
-        private byte[] _Hash;
-
         /// <summary>
         /// The runtime mod hash. Might not be determined by all mod content.
         /// </summary>
-        public byte[] Hash => _Hash ??= Everest.GetChecksum(this);
+        public byte[] Hash { get; internal set; }
 
         /// <summary>
         /// Whether this module supports experimental live code reloading or not.


### PR DESCRIPTION
cache invalidation strikes again

The hash is never recomputed when an assembly changes, which makes Everest load a cached version even though the assembly has changed.

This change is yet untested