### PR TITLE
Revert "Fixes EntityIDs to be consistent for globally generated entities"

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
@@ -618,7 +618,7 @@ namespace Celeste.Mod {
 
                             ctor = type.GetConstructor(new Type[] { typeof(EntityData), typeof(Vector2), typeof(EntityID) });
                             if (ctor != null) {
-                                loader = (level, levelData, offset, entityData) => (Entity) ctor.Invoke(new object[] { entityData, offset, (entityData as patch_EntityData).EntityID });
+                                loader = (level, levelData, offset, entityData) => (Entity) ctor.Invoke(new object[] { entityData, offset, new EntityID(levelData.Name, entityData.ID + (patch_Level._isLoadingTriggers ? 10000000 : 0)) });
                                 goto RegisterEntityLoader;
                             }
 

--- a/Celeste.Mod.mm/Patches/EntityData.cs
+++ b/Celeste.Mod.mm/Patches/EntityData.cs
@@ -12,11 +12,5 @@ namespace Celeste {
             return orig_Has(key);
         }
 
-        public EntityID EntityID;
-
-        internal void InitializeEntityID() {
-            EntityID = new EntityID(Level.Name ?? string.Empty, ID + (patch_LevelData._isRegisteringTriggers ? 10000000 : 0));
-        }
-
     }
 }

--- a/Celeste.Mod.mm/Patches/Level.cs
+++ b/Celeste.Mod.mm/Patches/Level.cs
@@ -1,7 +1,6 @@
 #pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
 #pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
 
-using Celeste;
 using Celeste.Mod;
 using Celeste.Mod.Core;
 using Celeste.Mod.Entities;
@@ -12,7 +11,6 @@ using FMOD.Studio;
 using Microsoft.Xna.Framework;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
-using Mono.Cecil.Rocks;
 using Monocle;
 using MonoMod;
 using MonoMod.Cil;
@@ -614,6 +612,9 @@ namespace Celeste {
         }
 
         private bool _IsInDoNotLoadIncreased(LevelData level, EntityData entity) => Session.DoNotLoad.Contains(new EntityID(level.Name, entity.ID + 20000000));
+
+        [ThreadStatic]
+        internal static bool _isLoadingTriggers;
     }
 
     public static class LevelExt {
@@ -685,8 +686,7 @@ namespace MonoMod {
             m_LoadStrings_Add.DeclaringType = t_LoadStrings;
             m_LoadStrings_ctor.DeclaringType = t_LoadStrings;
 
-            FieldDefinition f_EntityData_EntityID = MonoModRule.Modder.Module.GetType("Celeste.EntityData").Resolve().FindField("EntityID");
-
+            FieldReference f_isLoadingTriggers = context.Method.DeclaringType.FindField("_isLoadingTriggers")!;
             MethodReference m_IsInDoNotLoadIncreased = context.Method.DeclaringType.FindMethod("_IsInDoNotLoadIncreased")!;
 
             ILCursor cursor = new ILCursor(context);
@@ -713,20 +713,34 @@ namespace MonoMod {
 
             // Reset to apply trigger loading patches
             cursor.Index = 0;
-            // First instance of call EntityID.ctor is referenced to ldloca.s 19 = entityID (in Entities loop), we want to add `entityID = entity.EntityID` after it
-            // We also don't want to break mod parity by replacing instruction content
-            cursor.GotoNext(MoveType.After, i => i.MatchLdloc(18)); // this is the only way i found that the gotoNext works. someone could easily clean this up in the future.
-            cursor.Index++; // checking against call System.Void Celeste.EntityID::.ctor(System.String, System.Int32) from the MonoModRule class didn't work.
-            cursor.EmitLdloc(17); // emits entity
-            cursor.EmitLdfld(f_EntityData_EntityID);
-            cursor.EmitStloc(19); // stores to entityID
-            // Second instance of call EntityID.ctor is referenced to ldloca.s 48 = entityID3 (in Triggers loop), we want to add entityID3 = trigger.EntityID` after it
-            // We also don't want to break mod parity by replacing instruction content
-            cursor.GotoNext(MoveType.After, i => i.MatchLdloc(47));
-            cursor.Index++;
-            cursor.EmitLdloc(46); // emits trigger
-            cursor.EmitLdfld(f_EntityData_EntityID);
-            cursor.EmitStloc(48); // stores to entityID3
+            int v_levelData = -1;
+            cursor.GotoNext(MoveType.Before, instr => instr.MatchLdloc(out v_levelData), instr => instr.MatchLdfld("Celeste.LevelData", "Triggers"));
+            // set global flag _isLoadingTriggers to true
+            cursor.EmitLdcI4(1);
+            cursor.EmitStsfld(f_isLoadingTriggers);
+            int v_entityData = -1;
+            cursor.GotoNext(instr => instr.MatchLdloc(out v_entityData), instr => instr.MatchLdfld("Celeste.EntityData", "ID"));
+            ILLabel continueLabel = null;
+            cursor.GotoNext(MoveType.After, instr => instr.MatchBrtrue(out continueLabel));
+            // add
+            // || _IsInDoNotLoadIncreased(levelData, trigger)
+            // to if condition for continue to handle triggers that already add 10000000 to their DoNotLoad entry
+            cursor.EmitLdarg0();
+            cursor.EmitLdloc(v_levelData);
+            cursor.EmitLdloc(v_entityData);
+            cursor.EmitCall(m_IsInDoNotLoadIncreased);
+            cursor.EmitBrtrue(continueLabel);
+            cursor.GotoNext(MoveType.AfterLabel, instr => instr.MatchLdloc(out _), instr => instr.MatchLdfld("Celeste.LevelData", "FgDecals"));
+            Instruction oldFinallyEnd = cursor.Next;
+            // set _isLoadingTriggers to false
+            cursor.EmitLdcI4(0);
+            Instruction newFinallyEnd = cursor.Prev;
+            cursor.EmitStsfld(f_isLoadingTriggers);
+            // fix end of finally block
+            foreach (ExceptionHandler handler in context.Body.ExceptionHandlers.Where(handler => handler.HandlerEnd == oldFinallyEnd)) {
+                handler.HandlerEnd = newFinallyEnd;
+                break;
+            }
 
             // Reset to apply entity patches
             cursor.Index = 0;

--- a/Celeste.Mod.mm/Patches/LevelData.cs
+++ b/Celeste.Mod.mm/Patches/LevelData.cs
@@ -10,13 +10,9 @@ using MonoMod.InlineRT;
 using MonoMod.Utils;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 
 namespace Celeste {
     public class patch_LevelData : LevelData {
-
-        [ThreadStatic]
-        internal static bool _isRegisteringTriggers;
 
         public Vector2? DefaultSpawn;
 
@@ -28,7 +24,6 @@ namespace Celeste {
         [PatchLevelDataBerryTracker]
         [PatchLevelDataDecalLoader]
         [PatchLevelDataSpawnpointLoader]
-        [PatchLevelDataTriggerIDResolver]
         public extern void orig_ctor(BinaryPacker.Element data);
 
         [MonoModConstructor]
@@ -45,7 +40,7 @@ namespace Celeste {
         // Optimise the method
         [MonoModReplace]
         private EntityData CreateEntityData(BinaryPacker.Element entity) {
-            patch_EntityData entityData = new patch_EntityData() {
+            EntityData entityData = new() {
                 Name = entity.Name,
                 Level = this
             };
@@ -56,7 +51,6 @@ namespace Celeste {
                     {
                         case "id":
                             entityData.ID = (int) value;
-                            entityData.InitializeEntityID(); // creates EntityID based on Level Name rather than current Level in LoadLevel.
                             break;
                         case "x":
                             entityData.Position.X = Convert.ToSingle(value, CultureInfo.InvariantCulture);
@@ -129,12 +123,6 @@ namespace MonoMod {
     /// </summary>
     [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchLevelDataSpawnpointLoader))]
     class PatchLevelDataSpawnpointLoaderAttribute : Attribute { }
-
-    /// <summary>
-    /// Patch the constructor to handle EntityID values for Trigger Loading.
-    /// </summary>
-    [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchLevelDataTriggerIDResolver))]
-    class PatchLevelDataTriggerIDResolverAttribute : Attribute { }
 
     static partial class MonoModRules {
 
@@ -270,39 +258,6 @@ namespace MonoMod {
             cursor.Emit(OpCodes.Ldloc, v_spawnCoords);
             cursor.Emit(OpCodes.Callvirt, m_LevelDataCheckForDefaultSpawn);
             cursor.Emit(OpCodes.Ldloc, v_spawnCoords);
-        }
-
-        public static void PatchLevelDataTriggerIDResolver(ILContext context, CustomAttribute attrib) {
-            // Code Changes:
-            //  elseif(child.Name == "triggers") {
-            //      if (child.Children == null) continue;
-            // +    LevelData._isRegisteringTriggers = true;
-            //      foreach (BinaryPacker.Element child3 in child.Children)
-            //  		Triggers.Add(CreateEntityData(child3));
-            // +    LevelData._isRegisteringTriggers = false;
-            //  }
-            // 
-            // Equivalent to the _isLoadingTriggers patch but occuring on MapData load instead of in-game Level load.
-
-            FieldDefinition f_LevelData__isRegisteringTriggers = context.Method.DeclaringType.FindField(nameof(Celeste.patch_LevelData._isRegisteringTriggers));
-
-            ILCursor cursor = new ILCursor(context);
-            cursor.GotoNext(MoveType.After, instr => instr.MatchLdstr("triggers")); // Naive check to get to the general location of the hook
-            cursor.GotoNext(MoveType.Before, instr => instr.MatchStloc(8));
-            cursor.GotoPrev(MoveType.AfterLabel, instr => instr.MatchLdloc(7));
-            cursor.Emit(OpCodes.Ldc_I4_1);
-            cursor.Emit(OpCodes.Stsfld, f_LevelData__isRegisteringTriggers);
-            cursor.GotoNext(MoveType.AfterLabel, instr => instr.MatchLdloc(7), instr => true, instr => instr.MatchLdstr("bgdecals"));
-            Instruction oldFinallyEnd = cursor.Next;
-            // set _isRegisteringTriggers to false
-            cursor.Emit(OpCodes.Ldc_I4_0);
-            Instruction newFinallyEnd = cursor.Prev;
-            cursor.EmitStsfld(f_LevelData__isRegisteringTriggers);
-            // fix end of finally block
-            foreach (ExceptionHandler handler in context.Body.ExceptionHandlers.Where(handler => handler.HandlerEnd == oldFinallyEnd)) {
-                handler.HandlerEnd = newFinallyEnd;
-                break;
-            }
         }
     }
 }


### PR DESCRIPTION
Causes Senseless Zescent to crash 

[log.txt](https://github.com/user-attachments/files/16039395/log.txt)
