### PR TITLE
EntityID fix: force resolve Level nullref on map reload

### DIFF
--- a/Celeste.Mod.mm/Patches/EntityData.cs
+++ b/Celeste.Mod.mm/Patches/EntityData.cs
@@ -16,17 +16,7 @@ namespace Celeste {
 
         public EntityID EntityID;
 
-        internal void InitializeEntityID() {
-            int id = ID + (patch_LevelData._isRegisteringTriggers ? 10000000 : 0);
-            if (Level == null) {
-                Logger.Log(LogLevel.Error, "Everest", "Level was found to be null after Level set in EntityData!");
-                EntityID = new EntityID(EntityID.None.Level, id);
-            }
-            else if (string.IsNullOrWhiteSpace(Level.Name))
-                EntityID = new EntityID(EntityID.None.Level, id);
-            else
-                EntityID = new EntityID(Level?.Name ?? EntityID.None.Level, id);            
-        }
+        internal void InitializeEntityID(string LevelName) => new EntityID(string.IsNullOrWhiteSpace(LevelName) ? EntityID.None.Level : LevelName, ID + (patch_LevelData._isRegisteringTriggers ? 10000000 : 0));
 
     }
 }

--- a/Celeste.Mod.mm/Patches/EntityData.cs
+++ b/Celeste.Mod.mm/Patches/EntityData.cs
@@ -16,7 +16,9 @@ namespace Celeste {
 
         public EntityID EntityID;
 
-        internal void InitializeEntityID(string LevelName) => new EntityID(string.IsNullOrWhiteSpace(LevelName) ? EntityID.None.Level : LevelName, ID + (patch_LevelData._isRegisteringTriggers ? 10000000 : 0));
+        internal void InitializeEntityID(string LevelName) {
+            EntityID = new EntityID(string.IsNullOrWhiteSpace(LevelName) ? EntityID.None.Level : LevelName, ID + (patch_LevelData._isRegisteringTriggers ? 10000000 : 0));
+        }
 
     }
 }

--- a/Celeste.Mod.mm/Patches/EntityData.cs
+++ b/Celeste.Mod.mm/Patches/EntityData.cs
@@ -1,6 +1,8 @@
 ﻿#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
 
 
+using Celeste.Mod;
+
 namespace Celeste {
     class patch_EntityData : EntityData {
         /// <origdoc/>
@@ -15,7 +17,15 @@ namespace Celeste {
         public EntityID EntityID;
 
         internal void InitializeEntityID() {
-            EntityID = new EntityID(Level.Name ?? string.Empty, ID + (patch_LevelData._isRegisteringTriggers ? 10000000 : 0));
+            int id = ID + (patch_LevelData._isRegisteringTriggers ? 10000000 : 0);
+            if (Level == null) {
+                Logger.Log(LogLevel.Error, "Everest", "Level was found to be null after Level set in EntityData!");
+                EntityID = new EntityID(EntityID.None.Level, id);
+            }
+            else if (string.IsNullOrWhiteSpace(Level.Name))
+                EntityID = new EntityID(EntityID.None.Level, id);
+            else
+                EntityID = new EntityID(Level?.Name ?? EntityID.None.Level, id);            
         }
 
     }

--- a/Celeste.Mod.mm/Patches/LevelData.cs
+++ b/Celeste.Mod.mm/Patches/LevelData.cs
@@ -56,7 +56,7 @@ namespace Celeste {
                     {
                         case "id":
                             entityData.ID = (int) value;
-                            entityData.InitializeEntityID(); // creates EntityID based on Level Name rather than current Level in LoadLevel.
+                            entityData.InitializeEntityID(Name); // creates EntityID based on Level Name rather than current Level in LoadLevel.
                             break;
                         case "x":
                             entityData.Position.X = Convert.ToSingle(value, CultureInfo.InvariantCulture);


### PR DESCRIPTION
This forces the EntityID initializer to handle Level nullreferences with the string `none` when map reload occurs. This should never reasonably happen, but an error has come up somewhere. 

Since I can't actually *test* this error, I've decided to ensure there are 0 chances of having a NullRef in the first place.