### PR TITLE
Use `ReadingMode.Immediate` for patching

### DIFF
--- a/NETCoreifier/Coreifier.cs
+++ b/NETCoreifier/Coreifier.cs
@@ -18,7 +18,7 @@ namespace NETCoreifier {
             ModuleDefinition module = null;
             try {
                 // Read the module
-                ReaderParameters readerParams = new ReaderParameters()  { ReadSymbols = true };
+                ReaderParameters readerParams = new(ReadingMode.Immediate)  { ReadSymbols = true };
                 try {
                     module = ModuleDefinition.ReadModule(inputAsm, readerParams);
                 } catch (SymbolsNotFoundException) {


### PR DESCRIPTION
Turns out that using `ReadingMode.Deferred` is a horrible idea when you want to patch stuff.
Very simple one line fix to the monstrous so called "Cecil bug" which, to be honest, it probably isn't and patching in `ReadMode.Deferred` is outright not supported at all.

Don't think this need any comments since its evident enough.

This would allow us to upgrade to cecil 0.11.5 and latest MonoMod reorg.