### PR TITLE
Fixing EntityID duplication on Global objects

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
@@ -618,7 +618,7 @@ namespace Celeste.Mod {
 
                             ctor = type.GetConstructor(new Type[] { typeof(EntityData), typeof(Vector2), typeof(EntityID) });
                             if (ctor != null) {
-                                loader = (level, levelData, offset, entityData) => (Entity) ctor.Invoke(new object[] { entityData, offset, new EntityID(levelData.Name, entityData.ID + (patch_Level._isLoadingTriggers ? 10000000 : 0)) });
+                                loader = (level, levelData, offset, entityData) => (Entity) ctor.Invoke(new object[] { entityData, offset, (entityData as patch_EntityData).EntityID });
                                 goto RegisterEntityLoader;
                             }
 

--- a/Celeste.Mod.mm/Patches/EntityData.cs
+++ b/Celeste.Mod.mm/Patches/EntityData.cs
@@ -12,5 +12,9 @@ namespace Celeste {
             return orig_Has(key);
         }
 
+        public EntityID EntityID;
+        internal void InitializeEntityID(string LevelName) {
+            EntityID = new EntityID(string.IsNullOrWhiteSpace(LevelName) ? EntityID.None.Level : LevelName, ID + (patch_LevelData._isRegisteringTriggers ? 10000000 : 0));
+        }
     }
 }

--- a/Celeste.Mod.mm/Patches/Level.cs
+++ b/Celeste.Mod.mm/Patches/Level.cs
@@ -686,7 +686,8 @@ namespace MonoMod {
             m_LoadStrings_Add.DeclaringType = t_LoadStrings;
             m_LoadStrings_ctor.DeclaringType = t_LoadStrings;
 
-            FieldReference f_isLoadingTriggers = context.Method.DeclaringType.FindField("_isLoadingTriggers")!;
+
+            FieldDefinition f_EntityData_EntityID = MonoModRule.Modder.Module.GetType("Celeste.EntityData").Resolve().FindField("EntityID");
             MethodReference m_IsInDoNotLoadIncreased = context.Method.DeclaringType.FindMethod("_IsInDoNotLoadIncreased")!;
 
             ILCursor cursor = new ILCursor(context);
@@ -711,36 +712,23 @@ namespace MonoMod {
                 cursor.Index++;
             }
 
-            // Reset to apply trigger loading patches
+
+            // Reset to apply EntityID fix patches - replaces the isLoadingTriggers patch
             cursor.Index = 0;
-            int v_levelData = -1;
-            cursor.GotoNext(MoveType.Before, instr => instr.MatchLdloc(out v_levelData), instr => instr.MatchLdfld("Celeste.LevelData", "Triggers"));
-            // set global flag _isLoadingTriggers to true
-            cursor.EmitLdcI4(1);
-            cursor.EmitStsfld(f_isLoadingTriggers);
-            int v_entityData = -1;
-            cursor.GotoNext(instr => instr.MatchLdloc(out v_entityData), instr => instr.MatchLdfld("Celeste.EntityData", "ID"));
-            ILLabel continueLabel = null;
-            cursor.GotoNext(MoveType.After, instr => instr.MatchBrtrue(out continueLabel));
-            // add
-            // || _IsInDoNotLoadIncreased(levelData, trigger)
-            // to if condition for continue to handle triggers that already add 10000000 to their DoNotLoad entry
-            cursor.EmitLdarg0();
-            cursor.EmitLdloc(v_levelData);
-            cursor.EmitLdloc(v_entityData);
-            cursor.EmitCall(m_IsInDoNotLoadIncreased);
-            cursor.EmitBrtrue(continueLabel);
-            cursor.GotoNext(MoveType.AfterLabel, instr => instr.MatchLdloc(out _), instr => instr.MatchLdfld("Celeste.LevelData", "FgDecals"));
-            Instruction oldFinallyEnd = cursor.Next;
-            // set _isLoadingTriggers to false
-            cursor.EmitLdcI4(0);
-            Instruction newFinallyEnd = cursor.Prev;
-            cursor.EmitStsfld(f_isLoadingTriggers);
-            // fix end of finally block
-            foreach (ExceptionHandler handler in context.Body.ExceptionHandlers.Where(handler => handler.HandlerEnd == oldFinallyEnd)) {
-                handler.HandlerEnd = newFinallyEnd;
-                break;
-            }
+            // First instance of call EntityID.ctor is referenced to ldloca.s 19 = entityID (in Entities loop), we want to add `entityID = entity.EntityID` after it
+            // We also don't want to break mod parity by replacing instruction content
+            cursor.GotoNext(MoveType.After, i => i.MatchLdloc(18)); // this is the only way i found that the gotoNext works. someone could easily clean this up in the future.
+            cursor.Index++; // checking against call System.Void Celeste.EntityID::.ctor(System.String, System.Int32) from the MonoModRule class didn't work.
+            cursor.EmitLdloc(17); // emits entity
+            cursor.EmitLdfld(f_EntityData_EntityID);
+            cursor.EmitStloc(19); // stores to entityID
+            // Second instance of call EntityID.ctor is referenced to ldloca.s 48 = entityID3 (in Triggers loop), we want to add entityID3 = trigger.EntityID` after it
+            // We also don't want to break mod parity by replacing instruction content
+            cursor.GotoNext(MoveType.After, i => i.MatchLdloc(47));
+            cursor.Index++;
+            cursor.EmitLdloc(46); // emits trigger
+            cursor.EmitLdfld(f_EntityData_EntityID);
+            cursor.EmitStloc(48); // stores to entityID3
 
             // Reset to apply entity patches
             cursor.Index = 0;

--- a/Celeste.Mod.mm/Patches/Level.cs
+++ b/Celeste.Mod.mm/Patches/Level.cs
@@ -613,8 +613,6 @@ namespace Celeste {
 
         private bool _IsInDoNotLoadIncreased(LevelData level, EntityData entity) => Session.DoNotLoad.Contains(new EntityID(level.Name, entity.ID + 20000000));
 
-        [ThreadStatic]
-        internal static bool _isLoadingTriggers;
     }
 
     public static class LevelExt {


### PR DESCRIPTION
This is the same as the fixEntityID patch but i put it in a single commit

EntityID before was set by (level the player is in):(entity internal ID) which is not consistent for entities that spawn from EntityData globally, since (level the player is in) changed based on Save & Quit/Return To Map/Enter From Checkpoint

This sets EntityID to be relative to the LevelData that was used to house the EntityData, and also changes the patches in Level to use that EntityID without breaking mods hooking Level (which is why i didn't remove instructions)