### PR TITLE
Update to .NET 8

### DIFF
--- a/.azure-pipelines/build.yml
+++ b/.azure-pipelines/build.yml
@@ -10,6 +10,7 @@ variables:
   solution: '**/*.sln'
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
+  runtimeVersion: 'net8.0' # Must match global.json
   VANILLA_CACHE: $(Pipeline.Workspace)/vanilla
 
 name: '$(Build.BuildId)+$(Build.BuildIdOffset)'
@@ -22,8 +23,6 @@ steps:
   inputs: # packageType defaults to sdk
     useGlobalJson: true # Config via global.json
   
-- task: NuGetToolInstaller@1
-
 - task: DotNetCoreCLI@2
   displayName: 'Restore NuGet packages'
   inputs:
@@ -43,14 +42,14 @@ steps:
     publishWebProjects: false
     zipAfterPublish: false
     projects: '*/*.csproj'
-    arguments: '--configuration $(buildConfiguration) "/p:Configuration=$(buildConfiguration)"'
+    arguments: '--configuration $(buildConfiguration) "/p:Configuration=$(buildConfiguration)" --no-restore'
 
 # Create and "publish" main artifact.
 - task: CopyFiles@2
   displayName: 'Pack main artifact: NETCoreifier'
   continueOnError: true
   inputs:
-    sourceFolder: '$(Build.SourcesDirectory)/NETCoreifier/bin/Release/net7.0/publish'
+    sourceFolder: '$(Build.SourcesDirectory)/NETCoreifier/bin/Release/$(runtimeVersion)/publish'
     contents: '**'
     targetFolder: '$(Build.ArtifactStagingDirectory)/main/'
     cleanTargetFolder: true
@@ -60,7 +59,7 @@ steps:
   displayName: 'Pack main artifact: Celeste.Mod.mm'
   continueOnError: true
   inputs:
-    sourceFolder: '$(Build.SourcesDirectory)/Celeste.Mod.mm/bin/Release/net7.0/publish'
+    sourceFolder: '$(Build.SourcesDirectory)/Celeste.Mod.mm/bin/Release/$(runtimeVersion)/publish'
     contents: '**'
     targetFolder: '$(Build.ArtifactStagingDirectory)/main/'
     cleanTargetFolder: false
@@ -70,7 +69,7 @@ steps:
   displayName: 'Pack main artifact: MiniInstaller'
   continueOnError: true
   inputs:
-    sourceFolder: '$(Build.SourcesDirectory)/MiniInstaller/bin/Release/net7.0/publish'
+    sourceFolder: '$(Build.SourcesDirectory)/MiniInstaller/bin/Release/$(runtimeVersion)/publish'
     contents: '**'
     targetFolder: '$(Build.ArtifactStagingDirectory)/main/'
     cleanTargetFolder: false

--- a/.azure-pipelines/build.yml
+++ b/.azure-pipelines/build.yml
@@ -24,10 +24,11 @@ steps:
   
 - task: NuGetToolInstaller@1
 
-- task: NuGetCommand@2
+- task: DotNetCoreCLI@2
   displayName: 'Restore NuGet packages'
   inputs:
-    restoreSolution: '$(solution)'
+    command: 'restore'
+    projects: '$(solution)'
 
 - task: PowerShell@2
   displayName: 'Run .azure-pipelines/prebuild.ps1'

--- a/.azure-pipelines/build.yml
+++ b/.azure-pipelines/build.yml
@@ -16,6 +16,12 @@ name: '$(Build.BuildId)+$(Build.BuildIdOffset)'
 
 steps:
 # Pre-build steps.
+  
+- task: UseDotNet@2
+  displayName: 'Set up .NET'
+  inputs: # packageType defaults to sdk
+    useGlobalJson: true # Config via global.json
+  
 - task: NuGetToolInstaller@1
 
 - task: NuGetCommand@2

--- a/Celeste.Mod.mm/Celeste.Mod.mm.csproj
+++ b/Celeste.Mod.mm/Celeste.Mod.mm.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Celeste.Mod.mm</AssemblyName>
     <RootNamespace>Celeste</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -33,17 +33,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Cecil" Version="0.11.4" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.5" />
     <ProjectReference Include="..\external\MonoMod\src\MonoMod.Patcher\MonoMod.Patcher.csproj" />
     <ProjectReference Include="..\external\MonoMod\src\MonoMod.Utils\MonoMod.Utils.csproj" />
     <ProjectReference Include="..\external\MonoMod\src\MonoMod.RuntimeDetour\MonoMod.RuntimeDetour.csproj" />
     <ProjectReference Include="..\external\MonoMod\src\MonoMod.RuntimeDetour.HookGen\MonoMod.RuntimeDetour.HookGen.csproj" />
     <PackageReference Include="DotNetZip" Version="1.16.0" />
-    <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.6" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Include="YamlDotNet" Version="8.1.2" />
-    <PackageReference Include="Jdenticon-net" Version="2.2.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="YamlDotNet" Version="15.3.0" />
+    <PackageReference Include="Jdenticon-net" Version="3.1.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <ProjectReference Include="..\external\NLua\build\net6.0\NLua.net6.0.csproj" />
     <PackageReference Include="MAB.DotIgnore" Version="3.0.2" />
   </ItemGroup>

--- a/DiscordGameSDK/DiscordGameSDK.csproj
+++ b/DiscordGameSDK/DiscordGameSDK.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>DiscordGameSDK</AssemblyName>
     <RootNamespace>Discord</RootNamespace>
     <LangVersion>9</LangVersion>

--- a/EverestSplash/EverestSplash.csproj
+++ b/EverestSplash/EverestSplash.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <UseAppHost>false</UseAppHost> <!-- EverestSplash will create its own AppHosts -->

--- a/MiniInstaller/MiniInstaller.csproj
+++ b/MiniInstaller/MiniInstaller.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>MiniInstaller</AssemblyName>
     <RootNamespace>MiniInstaller</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/NETCoreifier/NETCoreifier.csproj
+++ b/NETCoreifier/NETCoreifier.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>NETCoreifier</AssemblyName>
     <RootNamespace>NETCoreifier</RootNamespace>
     <LangVersion>11</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Cecil" Version="0.11.4" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.5" />
     <ProjectReference Include="..\external\MonoMod\src\MonoMod.Patcher\MonoMod.Patcher.csproj" />
     <ProjectReference Include="..\external\MonoMod\src\MonoMod.Utils\MonoMod.Utils.csproj" />
   </ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,9 @@
+{
+  "sdk": {
+    "rollForward": "latestPatch",
+    "version": "8.0.302"
+  },
+  "msbuild-sdks": {
+    "Microsoft.Net.Sdk.IL": "8.0.0"
+  }
+}

--- a/lib-ext/piton-runtime.yaml
+++ b/lib-ext/piton-runtime.yaml
@@ -1,23 +1,24 @@
+# Latest LTS as of July 8th 2024
 windows-x86:
-  version: 7.0.12
-  download: https://download.visualstudio.microsoft.com/download/pr/e6be672b-53a9-4050-9b55-53f74a55523c/b59ab5af9be85681cf415865a159624f/dotnet-runtime-7.0.12-win-x86.zip
-  download-sha512: 760f4483b9848c2165be30ad4623de4099529fdcbf61c4e6c1738dfe22e3d776ca7ced89e4d7485dc0337c988b1c3bf1c5757a01e97d156df4ad0cf848226244
+  version: 8.0.6
+  download: https://download.visualstudio.microsoft.com/download/pr/53f7cef2-50bf-419d-bf36-69f2989729b6/31261cddb6f9517e76cc4ee71d67be8b/dotnet-runtime-8.0.6-win-x86.zip
+  download-sha512: 4801ea1f67811ee368d78e03447cf972ba71e4d02818d5ed019ce99a241498eb4d242ceb520744141d6c3047bacb80c64be5b0f9a64f339087bce76e83a0b444
   download-format: zip
   
 windows-x86_64:
-  version: 7.0.12
-  download: https://download.visualstudio.microsoft.com/download/pr/6d97a102-c4f3-4183-91d7-d810e96e73a1/272349ea2adf0145d9364e2c12bd23a4/dotnet-runtime-7.0.12-win-x64.zip
-  download-sha512: fada96dfe5c0ff99799032b21323b0c75764df8c7991e67c0f2757a0f4d9946c68dee07831a0bda7e884713749150121d618973d14bdcc915d389799b36848bb
+  version: 8.0.6
+  download: https://download.visualstudio.microsoft.com/download/pr/3c5bbae6-d848-46b0-bb65-c4f7a7ad4b2a/afba8a75f7e7f4f304362de0f1d4b3ea/dotnet-runtime-8.0.6-win-x64.zip
+  download-sha512: 2c0407df76878fe518105e132e5435f7f3ac42415fecf099e1a056ef4c068ed9d4e3bcfb5fe49b6c138cfe8b77db609bc6af28be5f11b5beca9eea7c1092ee51
   download-format: zip
 
 linux-x86_64:
-  version: 7.0.12
-  download: https://download.visualstudio.microsoft.com/download/pr/47a663ab-0c5f-4502-9ea1-93c27df8f9ed/5ee65ca13eb40220631dab82a27972d8/dotnet-runtime-7.0.12-linux-x64.tar.gz
-  download-sha512: 74bea25e88bd917a733a6899a3b3c9ac40c85a64f82dc0f36840714669621716afbb8fec6c3c398b1ffb522c0ed11958862cff5a4be0bf6268188cdb276bc109
+  version: 8.0.6
+  download: https://download.visualstudio.microsoft.com/download/pr/021c3de8-14d5-493f-92dc-2c8f8be76961/6ee3407acebf74631bfc01f14301afa6/dotnet-runtime-8.0.6-linux-x64.tar.gz
+  download-sha512: c0c5e93d4e68e2075c4c63336dc74246efb704ac9663411351efdefc4cc7da5a7750f44b8a23aebe959bb4308575bead443a41b2524ae03b29ac41929d27e0e0
   download-format: targz
 
 macos-x86_64:
-  version: 7.0.12
-  download: https://download.visualstudio.microsoft.com/download/pr/5a3eed2a-4c5f-4c05-9ef5-4b59de889a9e/4a577fd9e4b278dfebc16d901691b90f/dotnet-runtime-7.0.12-osx-x64.tar.gz
-  download-sha512: 3cfa807b64eb345ff104f33d7120d7d973443d40aedfe5fb49c0b67adb69f743c18a6e762a8463f59ee29b4a291970e8af48f97f841a94ed220809b56258b0e0
+  version: 8.0.6
+  download: https://download.visualstudio.microsoft.com/download/pr/20271d05-67e0-4356-87a9-0ce5102b5007/b7c91c6470e1c2ffbb493a35dd6883c0/dotnet-runtime-8.0.6-osx-x64.tar.gz
+  download-sha512: 44c0ad9fc613975fa0c12b12b91ff8cd8ba0be5e8ed59510e7a5ab22e55267a468b321ce34515daf070ffc8d557c09d7ea3ed3c3407887f706553b5d378e3232
   download-format: targz


### PR DESCRIPTION
Draft PR since we need to fix a few things still.
### Necessary:
- [ ] Update NLua submodule/get the pr merged and switch to a package
- [x] Verify that there is no floating point differences with the upgrade (basically run a long TAS)
- [ ] Fix code mod building targeting a .NET 8 everest
### Good to have but not strictly required:
- [ ] Wait for an updated package for MonoMod.Patcher and MonoMod.RuntimeDetour.Hookgen to ditch the submodule
- [x] Relinker rewrite
- [ ] Find a solution for old MacOS (or just not care about it) (update: game booted in a vm)
- [x] ~~Make piton delete the old runtime (.NET 7) on upgrade~~ Turns out it will be overwritten

I should note here that I upgraded the other nuget packages, since we might as well do it :P