### PR TITLE
Add missing Polish translations

### DIFF
--- a/Celeste.Mod.mm/Content/Dialog/Polish.txt
+++ b/Celeste.Mod.mm/Content/Dialog/Polish.txt
@@ -193,7 +193,7 @@
 	EVERESTUPDATER_NOTSUPPORTED=			Aktualizowanie nie jest wspierane na tej platformie - anulowanie.
 	EVERESTUPDATER_NOUPDATE=				Brak aktualizacji - anulowanie.
 	EVERESTUPDATER_CREATINGLEGACYREF=			Konfigurowanie podstawowej instalacji legacyRef
-	EVERESTUPDATER_NOTAVAILABLE=				Wymagana budowa Everest jest niedostępna!
+	EVERESTUPDATER_NOTAVAILABLE=				Wymagana wersja Everest jest niedostępna!
 	EVERESTUPDATER_UPDATING=				Aktualizowanie do {0} (gałąź: {1}) @ {2}
 	EVERESTUPDATER_DOWNLOADING=				Pobieranie
 	EVERESTUPDATER_DOWNLOADING_PROGRESS=	Pobieranie:

--- a/Celeste.Mod.mm/Content/Dialog/Polish.txt
+++ b/Celeste.Mod.mm/Content/Dialog/Polish.txt
@@ -27,13 +27,16 @@
 	POSTCARD_MISSINGTUTORIAL=	{big}Ups!{/big}{n}Samouczek playbackowy {#ff1144}((tutorial)){#} nie mógł być znaleziony.{n}Sprawdź swój {#44adf7}log.txt{#} by uzyskać więcej informacji.
 	POSTCARD_TILEXMLERROR=		{big}Ups!{/big}{n}Wystąpił błąd podczas analizowania zestawu kafelków w {#ff1144}((path)){#}{n}Sprawdź swój {#44adf7}log.txt{#} by uzyskać więcej informacji.
 	POSTCARD_XMLERROR=			{big}Ups!{/big}{n}{#ff1144}((path)){#} zawiera błąd składniowy.{n}Sprawdź swój {#44adf7}log.txt{#} by uzyskać więcej informacji.
+	POSTCARD_BOSSLASTNODEHIT=	{big}Ups!{/big}{n}Obiekt typu {#ff1144}Badeline Boss{#} został dotknięty na ostatnim punkcie. Proszę dodać nowy punkt poza obszarem pokoju, aby upewnić, że gracz nie może się do niego dostać
+	POSTCARD_LEVELNOROOMS=		{big}Ups!{/big}{n}Ta mapa {#f94a4a}nie ma pokoi{#}!{n}Proszę dodać co najmniej {#44adf7}jeden pokój{#},{n}i upewnić się, że plik mapy został zapisany. 
 
 # Main Menu // Menu Główne
 	MENU_TITLETOUCH=		TOUCH
 	MENU_MAPLIST=			Lista Map
 	MENU_MODOPTIONS=		Opcje Modów
 	MENU_PAUSE_MODOPTIONS=	Opcje Modów
-	
+
+	MENU_MODOPTIONS_UPDATE_FAILED=			Aktualizacja Everest nie powiodła się
 	MENU_MODOPTIONS_ONE_MOD_FAILEDTOLOAD=		Błąd ładowania 1 moda
 	MENU_MODOPTIONS_MULTIPLE_MODS_FAILEDTOLOAD=	Błąd ładowania {0} modów
 	MENU_MODOPTIONS_EVEREST_YAML_ERRORS=		Wystąpiły błędy ładowania everest.yaml
@@ -43,6 +46,7 @@
 
 # Title Screen // Ekran Tytułowy
 	MENU_TITLESCREEN_RESTART_VANILLA=	Uruchamianie orig/Celeste.exe
+	MENU_TITLESCREEN_RESTART_VANILLA_SAVES_WARN= UWAGA: W wyniku limitacji systemu operacyjnego, pliki zapisu nie będą synchronizowane!
 	
 # Extra Key Mapping // Dodatkowe Przypisanie Klawiszy
 	KEY_CONFIG_ADDING=			NACIŚNIJ NASTĘPNY PRZYCISK DLA
@@ -56,6 +60,8 @@
 	MODOPTIONS_COREMODULE_UPDATE=							Uaktualnij Everest na wersję ((version))
 	MODOPTIONS_COREMODULE_DOWNLOADDEPS=						Zainstaluj brakujące Zależności
 	MODOPTIONS_COREMODULE_VERSIONLIST=						Zmiana wersji Everest
+	MODOPTIONS_COREMODULE_LEGACYREF=						Skonfiguruj instalację legacyRef
+	MODOPTIONS_COREMODULE_LEGACYREF_DESCR=						Wymagane aby budować modyfikacje kodu sprzed wersji .NET Core Everestu 
 	MODOPTIONS_COREMODULE_TITLE=							Rdzeń Everest
 	MODOPTIONS_COREMODULE_DEBUGMODE=						Tryb Debugowania
 	MODOPTIONS_COREMODULE_LAUNCHWITHFMODLIVEUPDATE=			Uruchamiaj z FMOD Live Update
@@ -71,6 +77,19 @@
 	MODOPTIONS_COREMODULE_INPUTGUI_PS4=						PS4
 	MODOPTIONS_COREMODULE_INPUTGUI_XB1=						XBONE
 	MODOPTIONS_COREMODULE_INPUTGUI_TOUCH=					TOUCH
+	MODOPTIONS_COREMODULE_COMPATMODE=				Tryb Kompatybilności
+	MODOPTIONS_COREMODULE_COMPATMODE_NONE=				WYŁ.
+	MODOPTIONS_COREMODULE_COMPATMODE_NONE_DESCR_A=
+	MODOPTIONS_COREMODULE_COMPATMODE_NONE_DESCR_B=
+	MODOPTIONS_COREMODULE_COMPATMODE_LEGACYXNA=				STARE XNA
+	MODOPTIONS_COREMODULE_COMPATMODE_LEGACYXNA_DESCR_A=		Przywraca zachowanie starych wersji XNA, pozwalając na częstotliwość 61 klatek na sekundę
+	MODOPTIONS_COREMODULE_COMPATMODE_LEGACYXNA_DESCR_B=		PRZEZNACZONE TYLKO DLA UŻYTKOWNIKÓW DOTKNIĘTYCH PRZEZ TĄ USTERKĘ!
+	MODOPTIONS_COREMODULE_COMPATMODE_LEGACYFNA=				STARE FNA
+	MODOPTIONS_COREMODULE_COMPATMODE_LEGACYFNA_DESCR_A=		Przywraca zachowanie starych wersji FNA, polegające na dodatkowym opóźnieniu sterowania
+	MODOPTIONS_COREMODULE_COMPATMODE_LEGACYFNA_DESCR_B=		PRZEZNACZONE TYLKO DLA UŻYTKOWNIKÓW PRZYZWYCZAJONYCH DO TEGO ZACHOWANIA!
+	MODOPTIONS_COREMODULE_COMPATMODE_INCOMPATIBLE=			Uwaga: Brak kompatybilności z oprogramowaniem twojej niemodyfikowanej instalacji!
+	MODOPTIONS_COREMODULE_D3D11EXCLUSIVEFULLSCREEN=			Tryb Ekskluzywnego Pełnego Ekranu
+	MODOPTIONS_COREMODULE_D3D11EXCLUSIVEFULLSCREEN_DESC=		Ma efekt na renderowaniu przy użyciu D3D11 na systemach Windows
 	MODOPTIONS_COREMODULE_MAINMENUMODE=						Tryb Menu Głównego
 	MODOPTIONS_COREMODULE_MAINMENUMODE_=					VANILLA
 	MODOPTIONS_COREMODULE_MAINMENUMODE_ROWS=				RZĘDY
@@ -84,6 +103,7 @@
 	MODOPTIONS_COREMODULE_MENUPAGEUP=						Strona w Górę
 	MODOPTIONS_COREMODULE_MENUPAGEDOWN=						Strona w Dół
 	MODOPTIONS_COREMODULE_DEBUGMODE_SUBHEADER=				TRYB DEBUGOWANIA
+	MODOPTIONS_COREMODULE_TOGGLEDEBUGCONSOLE=				Przełącz Konsolę Debugowania
 	MODOPTIONS_COREMODULE_DEBUGCONSOLE=						Konsola Debugowania
 	MODOPTIONS_COREMODULE_DEBUGMAP=							Mapa Debugowania
 	MODOPTIONS_COREMODULE_MOUNTAINCAM_SUBHEADER=			KAMERA GÓRY W MENU GŁÓWNYM
@@ -113,7 +133,10 @@
 	MODOPTIONS_COREMODULE_NOTLOADED_A=						Ładowanie niektórych modów nie powiodło się.
 	MODOPTIONS_COREMODULE_NOTLOADED_B=						Sprawdź swój log.txt by uzyskać więcej informacji.
 	MODOPTIONS_COREMODULE_NOTLOADED_NOTFOUND=				Nie znaleziono {0}
+	MODOPTIONS_COREMODULE_NOTLOADED_ASMLOADERROR=				błąd podczas ładowania pliku składowego modyfikacji
 	MODOPTIONS_COREMODULE_YAMLERRORS=						Ładowanie niektórych plików everest.yaml nie powiodło się.
+
+	MODOPTIONS_COREMODULE_SEARCHBOX_PLACEHOLDER=				Aby przejść do następnego wyniku, wćiśnij 'Tab' lub 'Enter'
 
 	MODOPTIONS_VANILLATRISTATE_NEVER=						NIGDY
 	MODOPTIONS_VANILLATRISTATE_EVEREST=						EVEREST
@@ -144,10 +167,12 @@
 
 # Updater // Aktualizator
 	UPDATER_TITLE=					AKTUALIZATOR
+	UPDATER_LEGACYREF_TITLE=		KONFIGURACJA LEGACYREF
 	UPDATER_VERSIONS_TITLE=			ZMIEŃ WERSJĘ EVEREST
 	UPDATER_VERSIONS_CURRENT=		Obecna wersja: ((version))
 	UPDATER_VERSIONS_REQUESTING=	Odświeżanie...
-	
+
+	UPDATER_VERSIONS_WAIT_REQUEST=	Pobieram listę wersji...
 	UPDATER_VERSIONS_ERR_DOWNLOAD=	Błąd podczas pobierania listy wersji.
 	UPDATER_VERSIONS_ERR_FORMAT=	Nieprawidłowy format.
 
@@ -156,6 +181,7 @@
 	UPDATER_SRC_STABLE=				STABLE
 	UPDATER_SRC_BETA=				BETA
 	UPDATER_SRC_DEV=				DEV
+	UPDATER_SRC_CORE=				CORE
 
 	UPDATER_SRC_RELEASE_GITHUB=		Oznaczone wydania (GitHub)
 	UPDATER_SRC_BUILDBOT_AZURE=		Automatyczne kompilacje (Azure)
@@ -166,6 +192,8 @@
 # Everest Updater // Aktualizator Everest
 	EVERESTUPDATER_NOTSUPPORTED=			Aktualizowanie nie jest wspierane na tej platformie - anulowanie.
 	EVERESTUPDATER_NOUPDATE=				Brak aktualizacji - anulowanie.
+	EVERESTUPDATER_CREATINGLEGACYREF=			Konfigurowanie podstawowej instalacji legacyRef
+	EVERESTUPDATER_NOTAVAILABLE=				Wymagana budowa Everest jest niedostępna!
 	EVERESTUPDATER_UPDATING=				Aktualizowanie do {0} (gałąź: {1}) @ {2}
 	EVERESTUPDATER_DOWNLOADING=				Pobieranie
 	EVERESTUPDATER_DOWNLOADING_PROGRESS=	Pobieranie:
@@ -177,6 +205,8 @@
 	EVERESTUPDATER_EXTRACTIONFINISHED=		Wypakowywanie zakończone.
 	EVERESTUPDATER_RESTARTING=				Ponowne uruchamianie
 	EVERESTUPDATER_RESTARTINGIN=			Ponowne uruchamianie za {0}
+	EVERESTUPDATER_WAITFORINSTALLER=		Czekam na dokończenie instalacji
+	EVERESTUPDATER_INSTALLERFAILED=			Instalacja nie powiodła się: kod wyjścia {0}
 	EVERESTUPDATER_STARTINGFAILED=			Uruchomienie instalatora nie powiodło się!
 	EVERESTUPDATER_ERRORHINT1=				Prosimy o zgłoszenie tego błędu na GitHub @ https://github.com/EverestAPI/Everest
 	EVERESTUPDATER_ERRORHINT2=				lub utwórz wątek w kanale #modding_help na Discordzie (zaproszenie w repozytorium).
@@ -198,6 +228,10 @@
 	MODUPDATECHECKER_UPDATE_ALL=			Zaktualizuj wszystkie mody
 	MODUPDATECHECKER_UPDATE_ALL_INPROGRESS=	Aktualizowanie wszystkich modów...
 	MODUPDATECHECKER_UPDATE_ALL_DONE=		Wszystkie mody zostały zaktualizowane.
+	MODUPDATECHECKER_RESTARTNEEDED= 		Aby kontynuować, Celeste musi być ponownie uruchomione
+	MODUPDATECHECKER_MENU_HEADER_RESTART= 		Wybierz czynność
+	MODUPDATECHECKER_SHUTDOWN= 			Wyjdź
+	MODUPDATECHECKER_RESTART= 			Uruchom ponownie
 	
 # Auto Mod Updater // Automatyczne Aktualizacje Modów
 	AUTOUPDATECHECKER_CHECKING=		Wyszukiwanie aktualizacji...
@@ -260,6 +294,8 @@
 	MODOPTIONS_MODTOGGLE_TOGGLEDEPS=			Przełączaj Zależności Automatycznie
 	MODOPTIONS_MODTOGGLE_TOGGLEDEPS_MESSAGE1=	Kiedy włączysz moda, wszystkie jego zależności zostaną włączone.
 	MODOPTIONS_MODTOGGLE_TOGGLEDEPS_MESSAGE2=	Kiedy wyłączysz moda, wszystkie mody które zależą od niego zostaną wyłączone.
+	MODOPTIONS_MODTOGGLE_PROTECTFAVORITES=			Ulubione Mody
+	MODOPTIONS_MODTOGGLE_PROTECTFAVORITES_MESSAGE=		Wćiśnij {0}, aby dodać lub usunąć mody z listy ulubionych.
 	MODOPTIONS_MODTOGGLE_MESSAGE_1=				Jeśli włączysz lub wyłączysz mody, twój blacklist.txt zostanie zaktualizowany,
 	MODOPTIONS_MODTOGGLE_MESSAGE_2=				a Celeste zostanie uruchomiony ponownie by zastosować zmiany.
 	MODOPTIONS_MODTOGGLE_MESSAGE_3=				Podświetlone mody są zależnościami innych modów.
@@ -270,6 +306,7 @@
 	MODOPTIONS_MODTOGGLE_ZIPS=					Pliki Zip
 	MODOPTIONS_MODTOGGLE_DIRECTORIES=			Foldery
 	MODOPTIONS_MODTOGGLE_BINS=					Pliki Binarne Map
+	MODOPTIONS_MODTOGGLE_SEARCHBOX_PLACEHOLDER=		Aby przejść do następnego wyniku, wćiśnij 'Tab' lub 'Enter'
 
 # Asset Reload Helper // Pomocnik Odświeżania Zasobów
 	ASSETRELOADHELPER_RELOADINGMAP=				Odświeżanie mapy

--- a/Celeste.Mod.mm/Content/Dialog/Polish.txt
+++ b/Celeste.Mod.mm/Content/Dialog/Polish.txt
@@ -27,7 +27,7 @@
 	POSTCARD_MISSINGTUTORIAL=	{big}Ups!{/big}{n}Samouczek playbackowy {#ff1144}((tutorial)){#} nie mógł być znaleziony.{n}Sprawdź swój {#44adf7}log.txt{#} by uzyskać więcej informacji.
 	POSTCARD_TILEXMLERROR=		{big}Ups!{/big}{n}Wystąpił błąd podczas analizowania zestawu kafelków w {#ff1144}((path)){#}{n}Sprawdź swój {#44adf7}log.txt{#} by uzyskać więcej informacji.
 	POSTCARD_XMLERROR=			{big}Ups!{/big}{n}{#ff1144}((path)){#} zawiera błąd składniowy.{n}Sprawdź swój {#44adf7}log.txt{#} by uzyskać więcej informacji.
-	POSTCARD_BOSSLASTNODEHIT=	{big}Ups!{/big}{n}Obiekt typu {#ff1144}Badeline Boss{#} został dotknięty na ostatnim punkcie. Proszę dodać nowy punkt poza obszarem pokoju, aby upewnić, że gracz nie może się do niego dostać
+	POSTCARD_BOSSLASTNODEHIT=	{big}Ups!{/big}{n}Obiekt typu {#ff1144}Badeline Boss{#} został dotknięty na ostatnim punkcie. Proszę dodać nowy punkt poza obszarem pokoju, aby upewnić, że gracz nie może się do niego dostać.
 	POSTCARD_LEVELNOROOMS=		{big}Ups!{/big}{n}Ta mapa {#f94a4a}nie ma pokoi{#}!{n}Proszę dodać co najmniej {#44adf7}jeden pokój{#},{n}i upewnić się, że plik mapy został zapisany. 
 
 # Main Menu // Menu Główne
@@ -46,7 +46,7 @@
 
 # Title Screen // Ekran Tytułowy
 	MENU_TITLESCREEN_RESTART_VANILLA=	Uruchamianie orig/Celeste.exe
-	MENU_TITLESCREEN_RESTART_VANILLA_SAVES_WARN= UWAGA: W wyniku limitacji systemu operacyjnego, pliki zapisu nie będą synchronizowane!
+	MENU_TITLESCREEN_RESTART_VANILLA_SAVES_WARN= UWAGA: Z powodu limitacji systemu plików, zapisane dane nie będą synchronizowane!
 	
 # Extra Key Mapping // Dodatkowe Przypisanie Klawiszy
 	KEY_CONFIG_ADDING=			NACIŚNIJ NASTĘPNY PRZYCISK DLA
@@ -61,7 +61,7 @@
 	MODOPTIONS_COREMODULE_DOWNLOADDEPS=						Zainstaluj brakujące Zależności
 	MODOPTIONS_COREMODULE_VERSIONLIST=						Zmiana wersji Everest
 	MODOPTIONS_COREMODULE_LEGACYREF=						Skonfiguruj instalację legacyRef
-	MODOPTIONS_COREMODULE_LEGACYREF_DESCR=						Wymagane aby budować modyfikacje kodu sprzed wersji .NET Core Everestu 
+	MODOPTIONS_COREMODULE_LEGACYREF_DESCR=						Wymagane aby budować modyfikacje kodu dla wersji Everest sprzed .NET Core
 	MODOPTIONS_COREMODULE_TITLE=							Rdzeń Everest
 	MODOPTIONS_COREMODULE_DEBUGMODE=						Tryb Debugowania
 	MODOPTIONS_COREMODULE_LAUNCHWITHFMODLIVEUPDATE=			Uruchamiaj z FMOD Live Update
@@ -82,14 +82,14 @@
 	MODOPTIONS_COREMODULE_COMPATMODE_NONE_DESCR_A=
 	MODOPTIONS_COREMODULE_COMPATMODE_NONE_DESCR_B=
 	MODOPTIONS_COREMODULE_COMPATMODE_LEGACYXNA=				STARE XNA
-	MODOPTIONS_COREMODULE_COMPATMODE_LEGACYXNA_DESCR_A=		Przywraca zachowanie starych wersji XNA, pozwalając na częstotliwość 61 klatek na sekundę
+	MODOPTIONS_COREMODULE_COMPATMODE_LEGACYXNA_DESCR_A=		Przywraca błędne odświeżanie 61 kl/s, spowodowane przez XNA
 	MODOPTIONS_COREMODULE_COMPATMODE_LEGACYXNA_DESCR_B=		PRZEZNACZONE TYLKO DLA UŻYTKOWNIKÓW DOTKNIĘTYCH PRZEZ TĄ USTERKĘ!
 	MODOPTIONS_COREMODULE_COMPATMODE_LEGACYFNA=				STARE FNA
-	MODOPTIONS_COREMODULE_COMPATMODE_LEGACYFNA_DESCR_A=		Przywraca zachowanie starych wersji FNA, polegające na dodatkowym opóźnieniu sterowania
+	MODOPTIONS_COREMODULE_COMPATMODE_LEGACYFNA_DESCR_A=		Przywraca dodatkowe opóźnienie klawiszy, spowodowane przez stare wersje FNA
 	MODOPTIONS_COREMODULE_COMPATMODE_LEGACYFNA_DESCR_B=		PRZEZNACZONE TYLKO DLA UŻYTKOWNIKÓW PRZYZWYCZAJONYCH DO TEGO ZACHOWANIA!
 	MODOPTIONS_COREMODULE_COMPATMODE_INCOMPATIBLE=			Uwaga: Brak kompatybilności z oprogramowaniem twojej niemodyfikowanej instalacji!
 	MODOPTIONS_COREMODULE_D3D11EXCLUSIVEFULLSCREEN=			Tryb Ekskluzywnego Pełnego Ekranu
-	MODOPTIONS_COREMODULE_D3D11EXCLUSIVEFULLSCREEN_DESC=		Ma efekt na renderowaniu przy użyciu D3D11 na systemach Windows
+	MODOPTIONS_COREMODULE_D3D11EXCLUSIVEFULLSCREEN_DESC=		Dotyczy renderera D3D11 na systemach Windows
 	MODOPTIONS_COREMODULE_MAINMENUMODE=						Tryb Menu Głównego
 	MODOPTIONS_COREMODULE_MAINMENUMODE_=					VANILLA
 	MODOPTIONS_COREMODULE_MAINMENUMODE_ROWS=				RZĘDY
@@ -133,7 +133,7 @@
 	MODOPTIONS_COREMODULE_NOTLOADED_A=						Ładowanie niektórych modów nie powiodło się.
 	MODOPTIONS_COREMODULE_NOTLOADED_B=						Sprawdź swój log.txt by uzyskać więcej informacji.
 	MODOPTIONS_COREMODULE_NOTLOADED_NOTFOUND=				Nie znaleziono {0}
-	MODOPTIONS_COREMODULE_NOTLOADED_ASMLOADERROR=				błąd podczas ładowania pliku składowego modyfikacji
+	MODOPTIONS_COREMODULE_NOTLOADED_ASMLOADERROR=				błąd podczas ładowania biblioteki modyfikacji
 	MODOPTIONS_COREMODULE_YAMLERRORS=						Ładowanie niektórych plików everest.yaml nie powiodło się.
 
 	MODOPTIONS_COREMODULE_SEARCHBOX_PLACEHOLDER=				Aby przejść do następnego wyniku, wciśnij 'Tab' lub 'Enter'
@@ -205,7 +205,7 @@
 	EVERESTUPDATER_EXTRACTIONFINISHED=		Wypakowywanie zakończone.
 	EVERESTUPDATER_RESTARTING=				Ponowne uruchamianie
 	EVERESTUPDATER_RESTARTINGIN=			Ponowne uruchamianie za {0}
-	EVERESTUPDATER_WAITFORINSTALLER=		Czekam na dokończenie instalacji
+	EVERESTUPDATER_WAITFORINSTALLER=		Oczekiwanie na zakończenie instalacji
 	EVERESTUPDATER_INSTALLERFAILED=			Instalacja nie powiodła się: kod wyjścia {0}
 	EVERESTUPDATER_STARTINGFAILED=			Uruchomienie instalatora nie powiodło się!
 	EVERESTUPDATER_ERRORHINT1=				Prosimy o zgłoszenie tego błędu na GitHub @ https://github.com/EverestAPI/Everest
@@ -228,7 +228,7 @@
 	MODUPDATECHECKER_UPDATE_ALL=			Zaktualizuj wszystkie mody
 	MODUPDATECHECKER_UPDATE_ALL_INPROGRESS=	Aktualizowanie wszystkich modów...
 	MODUPDATECHECKER_UPDATE_ALL_DONE=		Wszystkie mody zostały zaktualizowane.
-	MODUPDATECHECKER_RESTARTNEEDED= 		Aby kontynuować, Celeste musi być ponownie uruchomione
+	MODUPDATECHECKER_RESTARTNEEDED= 		Aby kontynuować, Celeste musi być uruchomione ponownie
 	MODUPDATECHECKER_MENU_HEADER_RESTART= 		Wybierz czynność
 	MODUPDATECHECKER_SHUTDOWN= 			Wyjdź
 	MODUPDATECHECKER_RESTART= 			Uruchom ponownie

--- a/Celeste.Mod.mm/Content/Dialog/Polish.txt
+++ b/Celeste.Mod.mm/Content/Dialog/Polish.txt
@@ -136,7 +136,7 @@
 	MODOPTIONS_COREMODULE_NOTLOADED_ASMLOADERROR=				błąd podczas ładowania pliku składowego modyfikacji
 	MODOPTIONS_COREMODULE_YAMLERRORS=						Ładowanie niektórych plików everest.yaml nie powiodło się.
 
-	MODOPTIONS_COREMODULE_SEARCHBOX_PLACEHOLDER=				Aby przejść do następnego wyniku, wćiśnij 'Tab' lub 'Enter'
+	MODOPTIONS_COREMODULE_SEARCHBOX_PLACEHOLDER=				Aby przejść do następnego wyniku, wciśnij 'Tab' lub 'Enter'
 
 	MODOPTIONS_VANILLATRISTATE_NEVER=						NIGDY
 	MODOPTIONS_VANILLATRISTATE_EVEREST=						EVEREST
@@ -295,7 +295,7 @@
 	MODOPTIONS_MODTOGGLE_TOGGLEDEPS_MESSAGE1=	Kiedy włączysz moda, wszystkie jego zależności zostaną włączone.
 	MODOPTIONS_MODTOGGLE_TOGGLEDEPS_MESSAGE2=	Kiedy wyłączysz moda, wszystkie mody które zależą od niego zostaną wyłączone.
 	MODOPTIONS_MODTOGGLE_PROTECTFAVORITES=			Ulubione Mody
-	MODOPTIONS_MODTOGGLE_PROTECTFAVORITES_MESSAGE=		Wćiśnij {0}, aby dodać lub usunąć mody z listy ulubionych.
+	MODOPTIONS_MODTOGGLE_PROTECTFAVORITES_MESSAGE=		Wciśnij {0}, aby dodać lub usunąć mody z listy ulubionych.
 	MODOPTIONS_MODTOGGLE_MESSAGE_1=				Jeśli włączysz lub wyłączysz mody, twój blacklist.txt zostanie zaktualizowany,
 	MODOPTIONS_MODTOGGLE_MESSAGE_2=				a Celeste zostanie uruchomiony ponownie by zastosować zmiany.
 	MODOPTIONS_MODTOGGLE_MESSAGE_3=				Podświetlone mody są zależnościami innych modów.
@@ -306,7 +306,7 @@
 	MODOPTIONS_MODTOGGLE_ZIPS=					Pliki Zip
 	MODOPTIONS_MODTOGGLE_DIRECTORIES=			Foldery
 	MODOPTIONS_MODTOGGLE_BINS=					Pliki Binarne Map
-	MODOPTIONS_MODTOGGLE_SEARCHBOX_PLACEHOLDER=		Aby przejść do następnego wyniku, wćiśnij 'Tab' lub 'Enter'
+	MODOPTIONS_MODTOGGLE_SEARCHBOX_PLACEHOLDER=		Aby przejść do następnego wyniku, wciśnij 'Tab' lub 'Enter'
 
 # Asset Reload Helper // Pomocnik Odświeżania Zasobów
 	ASSETRELOADHELPER_RELOADINGMAP=				Odświeżanie mapy


### PR DESCRIPTION
Added all missing localization keys. Proofreading would be appreciated (particularly with `MODOPTIONS_COREMODULE_COMPATMODE_INCOMPATIBLE` - there might be a cleaner way to translate "framework" and "vanilla" that I'm not aware of)