### PR TITLE
Revert "Fixing EntityID duplication on Global objects"

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
@@ -618,7 +618,7 @@ namespace Celeste.Mod {
 
                             ctor = type.GetConstructor(new Type[] { typeof(EntityData), typeof(Vector2), typeof(EntityID) });
                             if (ctor != null) {
-                                loader = (level, levelData, offset, entityData) => (Entity) ctor.Invoke(new object[] { entityData, offset, (entityData as patch_EntityData).EntityID });
+                                loader = (level, levelData, offset, entityData) => (Entity) ctor.Invoke(new object[] { entityData, offset, new EntityID(levelData.Name, entityData.ID + (patch_Level._isLoadingTriggers ? 10000000 : 0)) });
                                 goto RegisterEntityLoader;
                             }
 

--- a/Celeste.Mod.mm/Patches/EntityData.cs
+++ b/Celeste.Mod.mm/Patches/EntityData.cs
@@ -12,9 +12,5 @@ namespace Celeste {
             return orig_Has(key);
         }
 
-        public EntityID EntityID;
-        internal void InitializeEntityID(string LevelName) {
-            EntityID = new EntityID(string.IsNullOrWhiteSpace(LevelName) ? EntityID.None.Level : LevelName, ID + (patch_LevelData._isRegisteringTriggers ? 10000000 : 0));
-        }
     }
 }

--- a/Celeste.Mod.mm/Patches/Level.cs
+++ b/Celeste.Mod.mm/Patches/Level.cs
@@ -613,6 +613,8 @@ namespace Celeste {
 
         private bool _IsInDoNotLoadIncreased(LevelData level, EntityData entity) => Session.DoNotLoad.Contains(new EntityID(level.Name, entity.ID + 20000000));
 
+        [ThreadStatic]
+        internal static bool _isLoadingTriggers;
     }
 
     public static class LevelExt {
@@ -684,8 +686,7 @@ namespace MonoMod {
             m_LoadStrings_Add.DeclaringType = t_LoadStrings;
             m_LoadStrings_ctor.DeclaringType = t_LoadStrings;
 
-
-            FieldDefinition f_EntityData_EntityID = MonoModRule.Modder.Module.GetType("Celeste.EntityData").Resolve().FindField("EntityID");
+            FieldReference f_isLoadingTriggers = context.Method.DeclaringType.FindField("_isLoadingTriggers")!;
             MethodReference m_IsInDoNotLoadIncreased = context.Method.DeclaringType.FindMethod("_IsInDoNotLoadIncreased")!;
 
             ILCursor cursor = new ILCursor(context);
@@ -710,23 +711,36 @@ namespace MonoMod {
                 cursor.Index++;
             }
 
-
-            // Reset to apply EntityID fix patches - replaces the isLoadingTriggers patch
+            // Reset to apply trigger loading patches
             cursor.Index = 0;
-            // First instance of call EntityID.ctor is referenced to ldloca.s 19 = entityID (in Entities loop), we want to add `entityID = entity.EntityID` after it
-            // We also don't want to break mod parity by replacing instruction content
-            cursor.GotoNext(MoveType.After, i => i.MatchLdloc(18)); // this is the only way i found that the gotoNext works. someone could easily clean this up in the future.
-            cursor.Index++; // checking against call System.Void Celeste.EntityID::.ctor(System.String, System.Int32) from the MonoModRule class didn't work.
-            cursor.EmitLdloc(17); // emits entity
-            cursor.EmitLdfld(f_EntityData_EntityID);
-            cursor.EmitStloc(19); // stores to entityID
-            // Second instance of call EntityID.ctor is referenced to ldloca.s 48 = entityID3 (in Triggers loop), we want to add entityID3 = trigger.EntityID` after it
-            // We also don't want to break mod parity by replacing instruction content
-            cursor.GotoNext(MoveType.After, i => i.MatchLdloc(47));
-            cursor.Index++;
-            cursor.EmitLdloc(46); // emits trigger
-            cursor.EmitLdfld(f_EntityData_EntityID);
-            cursor.EmitStloc(48); // stores to entityID3
+            int v_levelData = -1;
+            cursor.GotoNext(MoveType.Before, instr => instr.MatchLdloc(out v_levelData), instr => instr.MatchLdfld("Celeste.LevelData", "Triggers"));
+            // set global flag _isLoadingTriggers to true
+            cursor.EmitLdcI4(1);
+            cursor.EmitStsfld(f_isLoadingTriggers);
+            int v_entityData = -1;
+            cursor.GotoNext(instr => instr.MatchLdloc(out v_entityData), instr => instr.MatchLdfld("Celeste.EntityData", "ID"));
+            ILLabel continueLabel = null;
+            cursor.GotoNext(MoveType.After, instr => instr.MatchBrtrue(out continueLabel));
+            // add
+            // || _IsInDoNotLoadIncreased(levelData, trigger)
+            // to if condition for continue to handle triggers that already add 10000000 to their DoNotLoad entry
+            cursor.EmitLdarg0();
+            cursor.EmitLdloc(v_levelData);
+            cursor.EmitLdloc(v_entityData);
+            cursor.EmitCall(m_IsInDoNotLoadIncreased);
+            cursor.EmitBrtrue(continueLabel);
+            cursor.GotoNext(MoveType.AfterLabel, instr => instr.MatchLdloc(out _), instr => instr.MatchLdfld("Celeste.LevelData", "FgDecals"));
+            Instruction oldFinallyEnd = cursor.Next;
+            // set _isLoadingTriggers to false
+            cursor.EmitLdcI4(0);
+            Instruction newFinallyEnd = cursor.Prev;
+            cursor.EmitStsfld(f_isLoadingTriggers);
+            // fix end of finally block
+            foreach (ExceptionHandler handler in context.Body.ExceptionHandlers.Where(handler => handler.HandlerEnd == oldFinallyEnd)) {
+                handler.HandlerEnd = newFinallyEnd;
+                break;
+            }
 
             // Reset to apply entity patches
             cursor.Index = 0;

--- a/Celeste.Mod.mm/Patches/LevelData.cs
+++ b/Celeste.Mod.mm/Patches/LevelData.cs
@@ -10,14 +10,9 @@ using MonoMod.InlineRT;
 using MonoMod.Utils;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using Celeste;
 
 namespace Celeste {
     public class patch_LevelData : LevelData {
-
-        [ThreadStatic]
-        internal static bool _isRegisteringTriggers;
 
         public Vector2? DefaultSpawn;
 
@@ -29,7 +24,6 @@ namespace Celeste {
         [PatchLevelDataBerryTracker]
         [PatchLevelDataDecalLoader]
         [PatchLevelDataSpawnpointLoader]
-        [PatchLevelDataTriggerIDOffset]
         public extern void orig_ctor(BinaryPacker.Element data);
 
         [MonoModConstructor]
@@ -46,7 +40,7 @@ namespace Celeste {
         // Optimise the method
         [MonoModReplace]
         private EntityData CreateEntityData(BinaryPacker.Element entity) {
-            patch_EntityData entityData = new() {
+            EntityData entityData = new() {
                 Name = entity.Name,
                 Level = this
             };
@@ -57,7 +51,6 @@ namespace Celeste {
                     {
                         case "id":
                             entityData.ID = (int) value;
-                            entityData.InitializeEntityID(this.Name);
                             break;
                         case "x":
                             entityData.Position.X = Convert.ToSingle(value, CultureInfo.InvariantCulture);
@@ -130,9 +123,6 @@ namespace MonoMod {
     /// </summary>
     [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchLevelDataSpawnpointLoader))]
     class PatchLevelDataSpawnpointLoaderAttribute : Attribute { }
-
-    [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchLevelDataTriggerIDOffset))]
-    class PatchLevelDataTriggerIDOffsetAttribute : Attribute { }
 
     static partial class MonoModRules {
 
@@ -268,34 +258,6 @@ namespace MonoMod {
             cursor.Emit(OpCodes.Ldloc, v_spawnCoords);
             cursor.Emit(OpCodes.Callvirt, m_LevelDataCheckForDefaultSpawn);
             cursor.Emit(OpCodes.Ldloc, v_spawnCoords);
-        }
-
-        public static void PatchLevelDataTriggerIDOffset(ILContext context, CustomAttribute attrib) {
-            FieldDefinition f_LevelData__isRegisteringTriggers = context.Method.DeclaringType.FindField("_isRegisteringTriggers");
-
-            ILCursor cursor = new(context);
-            ILLabel oldLeave = null, endOfIfTriggers = null;
-
-            cursor.GotoNext(i => i.MatchStloc(10));
-            cursor.GotoPrev(MoveType.After, i => i.MatchBrfalse(out endOfIfTriggers));
-            cursor.EmitLdcI4(1);
-            cursor.EmitStsfld(f_LevelData__isRegisteringTriggers);
-            cursor.GotoNext(i => i.MatchLeave(out oldLeave));
-            ILCursor clone = cursor.Clone();
-            cursor.GotoNext(i => i.MatchLdloc(7), i => true, i => i.MatchLdstr("bgdecals"));
-            Instruction oldFinallyEnd = cursor.Next;
-            ILLabel newLeave = cursor.MarkLabel();
-            cursor.EmitLdcI4(0);
-            Instruction newFinallyEnd = cursor.Prev;
-            cursor.EmitStsfld(f_LevelData__isRegisteringTriggers);
-            cursor.EmitBr(oldLeave);
-
-            foreach (ExceptionHandler handler in context.Body.ExceptionHandlers.Where(handler => handler.HandlerEnd == oldFinallyEnd)) {
-                handler.HandlerEnd = newFinallyEnd;
-                break;
-            }
-
-            clone.Next.Operand = newLeave;
         }
     }
 }


### PR DESCRIPTION
Reverts EverestAPI/Everest#788

> the recently merged entity id pr is broken and causes crashes if EntityId.Level is null on stuff like 5c+ (extended c-sides), 9d or installing dependencies (adding yet another installing deps crash)

```
(07/25/2024 18:36:44) [Everest] [Warn] [LoadLevel] Failed loading room q-13 of nameguysdsidespack/0/10-Farewell
--------------------------------
Detailed exception log:
--------------------------------
System.NullReferenceException: Object reference not set to an instance of an object.
   at System.Collections.Generic.HashSet`1.FindItemIndex(T item)
   at System.Collections.Generic.HashSet`1.Contains(T item)
   at Celeste.Level.orig_LoadLevel(IntroTypes playerIntro, Boolean isFromLoader)
   at Celeste.Level.LoadLevel(IntroTypes playerIntro, Boolean isFromLoader) in /home/vsts/work/1/s/Celeste.Mod.mm/Patches/Level.cs:line 254
```