### PR TITLE
Support additional Mini Textbox dialog nodes

### DIFF
--- a/Celeste.Mod.mm/Patches/MiniTextbox.cs
+++ b/Celeste.Mod.mm/Patches/MiniTextbox.cs
@@ -19,10 +19,10 @@ namespace Celeste {
         private Sprite portrait;
         private FancyText.Portrait portraitData;
         private SoundSource talkerSfx;
-        
+
         private int start;
         private FancyText.Anchors anchor;
-        
+
         public patch_MiniTextbox(string dialogId)
             : base(dialogId) {
             // no-op. MonoMod ignores this - we only need this to make the compiler shut up.
@@ -32,7 +32,7 @@ namespace Celeste {
         [MonoModConstructor]
         public void ctor(string dialogId) {
             orig_ctor(dialogId);
-            
+
             // Find the anchor
             foreach (FancyText.Node node in text.Nodes) {
                 if (node is FancyText.Anchor anchorPos) {
@@ -44,7 +44,7 @@ namespace Celeste {
         [MonoModIgnore]
         [PatchMiniTextboxRoutine]
         private extern IEnumerator Routine();
-        
+
         [MonoModIgnore]
         [PatchMiniTextboxRender]
         public override extern void Render();
@@ -57,25 +57,23 @@ namespace Celeste {
                 portrait.Play(portraitData.TalkAnimation);
             }
         }
-        
+
         private void _handleDialogNode(ref float delay) {
             if (text[index] is FancyText.Wait wait) {
                 delay += wait.Duration;
             } else if (text[index] is FancyText.NewPage) {
                 start = index + 1;
             }
-            
-            if (delay > 0.5f)
-            {
+
+            if (delay > 0.5f) {
                 talkerSfx?.Param("dialogue_portrait", 0f);
                 talkerSfx?.Param("dialogue_end", 1f);
-                if (portrait != null && portraitData != null && portrait.Has(portraitData.IdleAnimation) && portrait.CurrentAnimationID != portraitData.IdleAnimation)
-                {
+                if (portrait != null && portraitData != null && portrait.Has(portraitData.IdleAnimation) && portrait.CurrentAnimationID != portraitData.IdleAnimation) {
                     portrait.Play(portraitData.IdleAnimation);
                 }
             }
         }
-        
+
         private void _applyAnchor(ref Vector2 center) {
             if (anchor == FancyText.Anchors.Bottom) {
                 center = new Vector2(Engine.Width / 2, Engine.Height - BoxHeight / 2.0f - (Engine.Width - BoxWidth) / 4f);
@@ -93,7 +91,7 @@ namespace MonoMod {
     /// </summary>
     [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchMiniTextboxRoutine))]
     class PatchMiniTextboxRoutine : Attribute { }
-    
+
     [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchMiniTextboxRender))]
     class PatchMiniTextboxRender : Attribute { }
 
@@ -102,7 +100,7 @@ namespace MonoMod {
         public static void PatchMiniTextboxRoutine(MethodDefinition method, CustomAttribute attrib) {
             MethodDefinition m_MiniTextbox_startTalking = method.DeclaringType.FindMethod("_startTalking")!;
             MethodDefinition m_MiniTextbox_handleNode = method.DeclaringType.FindMethod("_handleDialogNode")!;
-            
+
             FieldDefinition f_MiniTextbox_closing = method.DeclaringType.FindField("closing")!;
 
             // The routine is stored in a compiler-generated method.
@@ -148,44 +146,44 @@ namespace MonoMod {
                 cursor.EmitRet();
                 cursor.MarkLabel(yieldReturnNullTarget);
             });
-            
+
             new ILContext(method).Invoke(il => {
                 ILCursor cursor = new(il);
-                
+
                 // Before: 'if (text.Nodes[index] is FancyText.Char) { ... }' 
                 cursor.GotoNext(MoveType.AfterLabel, instr => instr.MatchIsinst("Celeste.FancyText/Char"));
                 cursor.GotoPrev(MoveType.AfterLabel, instr => instr.MatchLdloc1());
                 cursor.GotoPrev(MoveType.AfterLabel, instr => instr.MatchLdloc1());
-                
+
                 cursor.EmitLdloc1(); // this
                 cursor.EmitCall(m_MiniTextbox_startTalking);
-                
+
                 // Before: 'index++;'
                 cursor.GotoNext(MoveType.AfterLabel,
                     instr => instr.MatchLdloc1(),
                     instr => instr.MatchLdloc1(),
                     instr => instr.MatchLdfld("Celeste.MiniTextbox", "index"));
-                
+
                 cursor.EmitLdloc1(); // this
                 cursor.EmitLdloca(3); // ref float delay
                 cursor.EmitCall(m_MiniTextbox_handleNode);
             });
         }
-        
+
         public static void PatchMiniTextboxRender(ILContext il, CustomAttribute attrib) {
             MethodDefinition m_MiniTextbox_applyAnchor = il.Method.DeclaringType.FindMethod("_applyAnchor")!;
-            
+
             FieldDefinition f_MiniTextbox_start = il.Method.DeclaringType.FindField("start")!;
-            
+
             ILCursor cursor = new(il);
-            
+
             // After: 'Vector2 center = new Vector2(Engine.Width / 2, BoxHeight / 2.0f + (Engine.Width - BoxWidth) / 4f);'
             cursor.GotoNext(MoveType.After, instr => instr.MatchCall("Microsoft.Xna.Framework.Vector2", ".ctor"));
-            
+
             cursor.EmitLdarg0();
             cursor.EmitLdloca(1); // ref Vector2 center
             cursor.EmitCall(m_MiniTextbox_applyAnchor);
-            
+
             // Replace: 'text.Draw(new Vector2(topleft.X + portraitSize + 32f, center.Y), new Vector2(0f, 0.5f), new Vector2(1f, ease) * 0.75f, 1f, 0, index);'
             // With:    'text.Draw(new Vector2(topleft.X + portraitSize + 32f, center.Y), new Vector2(0f, 0.5f), new Vector2(1f, ease) * 0.75f, 1f, start, index);'
             cursor.Index = il.Instrs.Count - 1;

--- a/Celeste.Mod.mm/Patches/MiniTextbox.cs
+++ b/Celeste.Mod.mm/Patches/MiniTextbox.cs
@@ -1,14 +1,25 @@
+#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
+
 using System;
 using System.Collections;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
+using Monocle;
 using MonoMod;
 using MonoMod.Cil;
+using MonoMod.InlineRT;
 using MonoMod.Utils;
 
 namespace Celeste {
     class patch_MiniTextbox : MiniTextbox {
 
+        // We're effectively in MiniTextbox, but still need to "expose" private fields to our mod.
+        private int index;
+        private FancyText.Text text;
+        private Sprite portrait;
+        private FancyText.Portrait portraitData;
+        private SoundSource talkerSfx;
+        
         public patch_MiniTextbox(string dialogId)
             : base(dialogId) {
             // no-op. MonoMod ignores this - we only need this to make the compiler shut up.
@@ -18,12 +29,36 @@ namespace Celeste {
         [PatchMiniTextboxRoutine]
         private extern IEnumerator Routine();
 
+        private void _startTalking() {
+            talkerSfx?.Param("dialogue_portrait", portraitData?.SfxExpression ?? 1.0f);
+            talkerSfx?.Param("dialogue_end", 0f);
+            if (portrait != null && portraitData != null && portrait.Has(portraitData.TalkAnimation) && portrait.CurrentAnimationID != portraitData.TalkAnimation) {
+                portrait.Play(portraitData.TalkAnimation);
+            }
+        }
+        
+        private void _handleDialogNode(ref float delay) {
+            if (text[index] is FancyText.Wait wait) {
+                delay += wait.Duration;
+            }
+            
+            if (delay > 0.5f)
+            {
+                talkerSfx?.Param("dialogue_portrait", 0f);
+                talkerSfx?.Param("dialogue_end", 1f);
+                if (portrait != null && portraitData != null && portrait.Has(portraitData.IdleAnimation) && portrait.CurrentAnimationID != portraitData.IdleAnimation)
+                {
+                    portrait.Play(portraitData.IdleAnimation);
+                }
+            }
+        }
     }
 }
 
 namespace MonoMod {
     /// <summary>
     /// Patches the method to fix mini textbox not closing when it's expanding and another textbox is triggered.
+    /// Also adds additional dialog feature support, like regular text boxes, including anchors, waits and multiple pages
     /// </summary>
     [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchMiniTextboxRoutine))]
     class PatchMiniTextboxRoutine : Attribute { }
@@ -31,13 +66,19 @@ namespace MonoMod {
     static partial class MonoModRules {
 
         public static void PatchMiniTextboxRoutine(MethodDefinition method, CustomAttribute attrib) {
-            FieldDefinition f_MiniTextbox_closing = method.DeclaringType.FindField("closing");
+            MethodDefinition m_MiniTextbox_startTalking = method.DeclaringType.FindMethod("_startTalking")!;
+            MethodDefinition m_MiniTextbox_handleNode = method.DeclaringType.FindMethod("_handleDialogNode")!;
+            
+            FieldDefinition f_MiniTextbox_closing = method.DeclaringType.FindField("closing")!;
+            
+            TypeDefinition closureRoutineType = MonoModRule.Modder.Module.GetType("Celeste.BirdPath/<Routine>d__18");
+            FieldReference closureThisField = closureRoutineType.FindField("<>4__this")!;
 
             // The routine is stored in a compiler-generated method.
             method = method.GetEnumeratorMoveNext();
 
             new ILContext(method).Invoke(il => {
-                ILCursor cursor = new ILCursor(il);
+                ILCursor cursor = new(il);
 
                 /*
                     Change:
@@ -76,7 +117,28 @@ namespace MonoMod {
                 cursor.Emit(OpCodes.Ret);
                 cursor.MarkLabel(yieldReturnNullTarget);
             });
+            
+            new ILContext(method).Invoke(il => {
+                ILCursor cursor = new(il);
+                
+                // Before: 'if (text.Nodes[index] is FancyText.Char) { ... }' 
+                cursor.GotoNext(instr => instr.MatchIsinst("Celeste.FancyText.Char"));
+                cursor.GotoPrev(instr => instr.MatchLdloc1());
+                cursor.GotoPrev(instr => instr.MatchLdloc1());
+                
+                cursor.EmitLdarg0();
+                cursor.EmitCall(m_MiniTextbox_startTalking);
+                
+                // Before: 'index++;'
+                cursor.GotoNext(
+                    instr => instr.MatchLdloc1(),
+                    instr => instr.MatchLdloc1(),
+                    instr => instr.MatchLdfld("Celeste.MiniTextbox", "index"));
+                
+                cursor.EmitLdarg0();
+                cursor.EmitLdloca(3); // ref float delay
+                cursor.EmitCall(m_MiniTextbox_handleNode);
+            });
         }
-
     }
 }


### PR DESCRIPTION
Regular textboxes already support these features, but with this patch, mini-textboxes now also support the `Anchor`, `Wait` and `NewPage` dialog nodes.
