### PR TITLE
Do not use shared checksum hasher, it is not thread-safe

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.DiscordSDK.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.DiscordSDK.cs
@@ -268,7 +268,7 @@ namespace Celeste.Mod {
                         return IconBaseURL + "/rich-presence-icons-static/null.png";
                     }
                 } else {
-                    byte[] hash = ChecksumHasher.ComputeHash(icon.Data);
+                    byte[] hash = ComputeHash(icon.Data);
                     string hashString = BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
                     if (RichPresenceIcons.Contains(hashString)) {
                         return IconBaseURL + "/rich-presence-icons/" + hashString + ".png";

--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -122,13 +122,13 @@ namespace Celeste.Mod {
         internal static bool _ContentLoaded;
 
         public static byte[] ComputeHash(byte[] buffer) {
-            try (HashAlgorithm checksumHasher = XXHash64.Create()) {
+            using (HashAlgorithm checksumHasher = XXHash64.Create()) {
                 return checksumHasher.ComputeHash(buffer);
             }
         }
 
         public static byte[] ComputeHash(Stream inputStream) {
-            try (HashAlgorithm checksumHasher = XXHash64.Create()) {
+            using (HashAlgorithm checksumHasher = XXHash64.Create()) {
                 return checksumHasher.ComputeHash(inputStream);
             }
         }

--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -121,10 +121,17 @@ namespace Celeste.Mod {
 
         internal static bool _ContentLoaded;
 
-        /// <summary>
-        /// The hasher used to determine the mod and installation hashes.
-        /// </summary>
-        public readonly static HashAlgorithm ChecksumHasher = XXHash64.Create();
+        public static byte[] ComputeHash(byte[] buffer) {
+            try (HashAlgorithm checksumHasher = XXHash64.Create()) {
+                return checksumHasher.ComputeHash(buffer);
+            }
+        }
+
+        public static byte[] ComputeHash(Stream inputStream) {
+            try (HashAlgorithm checksumHasher = XXHash64.Create()) {
+                return checksumHasher.ComputeHash(inputStream);
+            }
+        }
 
         /// <summary>
         /// Get the checksum for a given file.
@@ -133,7 +140,7 @@ namespace Celeste.Mod {
         /// <returns>A checksum.</returns>
         public static byte[] GetChecksum(string path) {
             using (FileStream fs = File.OpenRead(path))
-                return ChecksumHasher.ComputeHash(fs);
+                return ComputeHash(fs);
         }
 
         /// <summary>
@@ -165,7 +172,7 @@ namespace Celeste.Mod {
 
             long pos = stream.Position;
             stream.Seek(0, SeekOrigin.Begin);
-            byte[] hash = ChecksumHasher.ComputeHash(stream);
+            byte[] hash = ComputeHash(stream);
             stream.Seek(pos, SeekOrigin.Begin);
             return hash;
         }
@@ -185,7 +192,7 @@ namespace Celeste.Mod {
                 }
                 */
                 void AddStream(Stream stream) {
-                    data.AddRange(ChecksumHasher.ComputeHash(stream));
+                    data.AddRange(ComputeHash(stream));
                 }
 
                 // Add all mod containers (or .DLLs).
@@ -208,7 +215,7 @@ namespace Celeste.Mod {
                 }
 
                 // Return the final hash.
-                return _InstallationHash = ChecksumHasher.ComputeHash(data.ToArray());
+                return _InstallationHash = ComputeHash(data.ToArray());
             }
         }
         public static string InstallationHashShort {


### PR DESCRIPTION
I suspect that this is the cause of false-positive updates that sometimes appear, especially for large mods: the hash that comes out is wrong, because multiple hashes are computed at the same time.