### PR TITLE
Fix `MapData.Reload()` erasing metadata for alt-sides

### DIFF
--- a/Celeste.Mod.mm/Patches/MapData.cs
+++ b/Celeste.Mod.mm/Patches/MapData.cs
@@ -214,11 +214,14 @@ namespace Celeste {
             // merge metadata, with .meta.yaml taking priority
             metaParsed = MapMeta.Add(metaParsedFromFile, metaParsed);
 
+            // merge metadata with the existing meta, with the previously merged metadata taking priority
+            MapMeta combinedMeta = MapMeta.Add(metaParsed, area.Meta);
+
             // apply metadata to AreaData
             if (mode == AreaMode.Normal) {
-                metaParsed.ApplyTo(area);
-                for (int i = 0; i < metaParsed.Modes.Length; i++) {
-                    metaParsed.Modes[i]?.ApplyTo(area, (AreaMode) i);
+                combinedMeta.ApplyTo(area);
+                for (int i = 0; i < combinedMeta.Modes.Length; i++) {
+                    combinedMeta.Modes[i]?.ApplyTo(area, (AreaMode) i);
                 }
                 Area = area.ToKey();
 
@@ -233,7 +236,6 @@ namespace Celeste {
                     Dreaming = area.Dreaming
                 };
             } else {
-                MapMeta combinedMeta = MapMeta.Add(metaParsed, area.Meta);
                 area.Mode[(int) mode].MapMeta = combinedMeta;
                 combinedMeta.Modes[(int) mode]?.ApplyTo(area, mode);
             }


### PR DESCRIPTION
Opening the debug map calls `MapData.Reload()`, which inadvertently wipes the metadata for B- and C-sides.

This PR seems to fix that from my testing.