### PR TITLE
Sort Mod Options Alphabetically

### DIFF
--- a/Celeste.Mod.mm/Mod/UI/OuiModOptions.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiModOptions.cs
@@ -117,8 +117,13 @@ namespace Celeste.Mod.UI {
                 }
             }
 
-            // reorder Mod Options according to the modoptionsorder.txt file.
             List<EverestModule> modules = new List<EverestModule>(Everest._Modules);
+            // sort by Mod names and move everest to the beginning
+            EverestModule everest = modules[0];
+            modules.RemoveAt(0);
+            modules = modules.OrderBy(module => module.Metadata.Name).ToList();
+            modules.Insert(0, everest);
+            // reorder Mod Options according to the modoptionsorder.txt file.
             if (Everest.Loader._ModOptionsOrder != null && Everest.Loader._ModOptionsOrder.Count > 0) {
                 foreach (string modName in Everest.Loader._ModOptionsOrder) {
                     if (modName.Equals("Everest", StringComparison.InvariantCultureIgnoreCase)) {

--- a/Celeste.Mod.mm/Mod/UI/OuiModOptions.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiModOptions.cs
@@ -120,9 +120,9 @@ namespace Celeste.Mod.UI {
             List<EverestModule> modules = new List<EverestModule>(Everest._Modules);
             // sort by Mod names and move everest to the beginning
             EverestModule everest = modules[0];
-            modules.RemoveAt(0);
+            modules.Remove(CoreModule.Instance);
             modules = modules.OrderBy(module => module.Metadata.Name).ToList();
-            modules.Insert(0, everest);
+            modules.Insert(0, CoreModule.Instance);
             // reorder Mod Options according to the modoptionsorder.txt file.
             if (Everest.Loader._ModOptionsOrder != null && Everest.Loader._ModOptionsOrder.Count > 0) {
                 foreach (string modName in Everest.Loader._ModOptionsOrder) {


### PR DESCRIPTION
I often find myself looking for the options of a specific mod i added but not remembering the full name of the mod. It would make finding these settings a lot easier if the options were sorted alphabetically as i often do remember the first letter or two. I would also be fine with adding an extra option to toggle between load order and alphabetical sort incase this is too big of a change which might confuse long time users that are used to their current order. (myers seems to add some random diff for some reason even though i didn't change anything in those lines)