### PR TITLE
Update MonoMod and other various dependencies

### DIFF
--- a/.azure-pipelines/build.yml
+++ b/.azure-pipelines/build.yml
@@ -21,7 +21,7 @@ steps:
 - task: UseDotNet@2
   displayName: 'Set up .NET'
   inputs: # packageType defaults to sdk
-    version: 9.x # net9.0 required by MonoMod
+    version: 9.0.102 # net9.0 required by MonoMod
 
 - task: DotNetCoreCLI@2
   displayName: 'Restore NuGet packages'

--- a/.azure-pipelines/build.yml
+++ b/.azure-pipelines/build.yml
@@ -21,7 +21,7 @@ steps:
 - task: UseDotNet@2
   displayName: 'Set up .NET'
   inputs: # packageType defaults to sdk
-    version: 8.x
+    version: 9.x # net9.0 required by MonoMod
 
 - task: DotNetCoreCLI@2
   displayName: 'Restore NuGet packages'

--- a/.azure-pipelines/build.yml
+++ b/.azure-pipelines/build.yml
@@ -10,19 +10,24 @@ variables:
   solution: '**/*.sln'
   buildPlatform: 'Any CPU'
   buildConfiguration: 'Release'
+  runtimeVersion: 'net7.0' # Must match TargetFramework in the csprojs
   VANILLA_CACHE: $(Pipeline.Workspace)/vanilla
 
 name: '$(Build.BuildId)+$(Build.BuildIdOffset)'
 
 steps:
-# Pre-build steps.
-- task: NuGetToolInstaller@1
+  # Pre-build steps.
 
-- task: NuGetCommand@2
+- task: UseDotNet@2
+  displayName: 'Set up .NET'
+  inputs: # packageType defaults to sdk
+    version: 8.x
+
+- task: DotNetCoreCLI@2
   displayName: 'Restore NuGet packages'
-  retryCountOnTaskFailure: 2
   inputs:
-    restoreSolution: '$(solution)'
+    command: 'restore'
+    projects: '$(solution)'
 
 - task: PowerShell@2
   displayName: 'Run .azure-pipelines/prebuild.ps1'
@@ -37,14 +42,14 @@ steps:
     publishWebProjects: false
     zipAfterPublish: false
     projects: '*/*.csproj'
-    arguments: '--configuration $(buildConfiguration) "/p:Configuration=$(buildConfiguration)"'
+    arguments: '--configuration $(buildConfiguration) "/p:Configuration=$(buildConfiguration)" --no-restore'
 
 # Create and "publish" main artifact.
 - task: CopyFiles@2
   displayName: 'Pack main artifact: NETCoreifier'
   continueOnError: true
   inputs:
-    sourceFolder: '$(Build.SourcesDirectory)/NETCoreifier/bin/Release/net7.0/publish'
+    sourceFolder: '$(Build.SourcesDirectory)/NETCoreifier/bin/Release/$(runtimeVersion)/publish'
     contents: '**'
     targetFolder: '$(Build.ArtifactStagingDirectory)/main/'
     cleanTargetFolder: true
@@ -54,7 +59,7 @@ steps:
   displayName: 'Pack main artifact: Celeste.Mod.mm'
   continueOnError: true
   inputs:
-    sourceFolder: '$(Build.SourcesDirectory)/Celeste.Mod.mm/bin/Release/net7.0/publish'
+    sourceFolder: '$(Build.SourcesDirectory)/Celeste.Mod.mm/bin/Release/$(runtimeVersion)/publish'
     contents: '**'
     targetFolder: '$(Build.ArtifactStagingDirectory)/main/'
     cleanTargetFolder: false
@@ -64,7 +69,7 @@ steps:
   displayName: 'Pack main artifact: MiniInstaller'
   continueOnError: true
   inputs:
-    sourceFolder: '$(Build.SourcesDirectory)/MiniInstaller/bin/Release/net7.0/publish'
+    sourceFolder: '$(Build.SourcesDirectory)/MiniInstaller/bin/Release/$(runtimeVersion)/publish'
     contents: '**'
     targetFolder: '$(Build.ArtifactStagingDirectory)/main/'
     cleanTargetFolder: false

--- a/Celeste.Mod.mm/Celeste.Mod.mm.csproj
+++ b/Celeste.Mod.mm/Celeste.Mod.mm.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Cecil" Version="0.11.4" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.5" />
     <ProjectReference Include="..\external\MonoMod\src\MonoMod.Patcher\MonoMod.Patcher.csproj" />
     <ProjectReference Include="..\external\MonoMod\src\MonoMod.Utils\MonoMod.Utils.csproj" />
     <ProjectReference Include="..\external\MonoMod\src\MonoMod.RuntimeDetour\MonoMod.RuntimeDetour.csproj" />
@@ -41,9 +41,9 @@
     <PackageReference Include="DotNetZip" Version="1.16.0" />
     <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Include="YamlDotNet" Version="8.1.2" />
-    <PackageReference Include="Jdenticon-net" Version="2.2.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="YamlDotNet" Version="16.1.3" />
+    <PackageReference Include="Jdenticon-net" Version="3.1.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <ProjectReference Include="..\external\NLua\build\net6.0\NLua.net6.0.csproj" />
     <PackageReference Include="MAB.DotIgnore" Version="3.0.2" />
   </ItemGroup>

--- a/NETCoreifier/NETCoreifier.csproj
+++ b/NETCoreifier/NETCoreifier.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Cecil" Version="0.11.4" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.5" />
     <ProjectReference Include="..\external\MonoMod\src\MonoMod.Patcher\MonoMod.Patcher.csproj" />
     <ProjectReference Include="..\external\MonoMod\src\MonoMod.Utils\MonoMod.Utils.csproj" />
   </ItemGroup>

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For information about mod development, check out the [Everest Wiki](https://gith
     - macOS: Right-click and browse the Celeste app in Finder, then navigate to `Contents`, then `MacOS`.
 - Clone the Everest repo **+ submodules**, either in your IDE or via the CLI.
 - Restore Nuget packages either via your IDE or the command line.
-- Everest requires version 7.0.200 or higher of .NET SDK, as well as the .NET 6.0 runtime, for the build process.
+- Everest requires version 8.0.0 or higher of .NET SDK for the build process.
 
 ### Windows
 - Open the .sln in the repo with Visual Studio

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For information about mod development, check out the [Everest Wiki](https://gith
     - macOS: Right-click and browse the Celeste app in Finder, then navigate to `Contents`, then `MacOS`.
 - Clone the Everest repo **+ submodules**, either in your IDE or via the CLI.
 - Restore Nuget packages either via your IDE or the command line.
-- Everest requires version 8.0.0 or higher of .NET SDK for the build process.
+- Everest requires version 9.0.0 or higher of .NET SDK, as well as the .NET 8.0 runtime, for the build process.
 
 ### Windows
 - Open the .sln in the repo with Visual Studio

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "msbuild-sdks": {
+    "Microsoft.Net.Sdk.IL": "7.0.0"
+  }
+}


### PR DESCRIPTION
Partially replaces #791. Mainly bumps MonoMod to the latest version that doesn't directly target .net9 and other dependencies as well.