### PR TITLE
Mod Setting visibility and interactibility adjustments

### DIFF
--- a/Celeste.Mod.mm/Mod/Module/EverestModule.cs
+++ b/Celeste.Mod.mm/Mod/Module/EverestModule.cs
@@ -694,33 +694,31 @@ namespace Celeste.Mod {
                 Type propType = prop.PropertyType;
                 object value = prop.GetValue(settingsObject);
 
+                bool disable = propType == typeof(string) || prop.GetCustomAttribute<SettingInGameDisableAttribute>()?.InGame == inGame;
+
                 // Create the matching item based off of the type and attributes.
-                if (propType == typeof(bool)) {
+                if (propType == typeof(bool))
+                {
                     item =
                         new TextMenu.OnOff(name, (bool) value)
-                        .Change(v => prop.SetValue(settingsObject, v))
-                    ;
-
-                } else if (
-                    propType == typeof(int) &&
-                    (attribRange = prop.GetCustomAttribute<SettingRangeAttribute>()) != null
-                ) {
-
+                        .Change(v => prop.SetValue(settingsObject, v));
+                }
+                else if (propType == typeof(int) &&
+                    (attribRange = prop.GetCustomAttribute<SettingRangeAttribute>()) != null)
+                {
                     if (attribRange.LargeRange) {
                         item =
                             new TextMenuExt.IntSlider(name, attribRange.Min, attribRange.Max, (int) value)
-                            .Change(v => prop.SetValue(settingsObject, v))
-                        ;
+                            .Change(v => prop.SetValue(settingsObject, v));
                     } else {
                         item =
                             new TextMenu.Slider(name, i => i.ToString(), attribRange.Min, attribRange.Max, (int) value)
-                            .Change(v => prop.SetValue(settingsObject, v))
-                        ;
+                            .Change(v => prop.SetValue(settingsObject, v));
                     }
-
-                } else if ((propType == typeof(int) || propType == typeof(float)) &&
-                    (attribNumber = prop.GetCustomAttribute<SettingNumberInputAttribute>()) != null) {
-
+                }
+                else if ((propType == typeof(int) || propType == typeof(float)) &&
+                    (attribNumber = prop.GetCustomAttribute<SettingNumberInputAttribute>()) != null)
+                {
                     float currentValue;
                     Action<float> valueSetter;
                     if (propType == typeof(int)) {
@@ -744,9 +742,10 @@ namespace Celeste.Mod {
                                 propType == typeof(float),
                                 allowNegatives
                             );
-                        })
-                    ;
-                } else if (propType.IsEnum) {
+                        });
+                }
+                else if (propType.IsEnum)
+                {
                     Array enumValues = Enum.GetValues(propType);
                     Array.Sort((int[]) enumValues);
                     string enumNamePrefix = $"{nameDefaultPrefix}{prop.Name.ToLowerInvariant()}_";
@@ -758,19 +757,16 @@ namespace Celeste.Mod {
                                 $"modoptions_{propType.Name.ToLowerInvariant()}_{enumName.ToLowerInvariant()}".DialogCleanOrNull() ??
                                 enumName;
                         }, 0, enumValues.Length - 1, (int) value)
-                        .Change(v => prop.SetValue(settingsObject, v))
-                    ;
-
-                } else if (propType == typeof(string)) {
+                        .Change(v => prop.SetValue(settingsObject, v));
+                }
+                else if (propType == typeof(string))
+                {
                     int maxValueLength = prop.GetCustomAttribute<SettingMaxLengthAttribute>()?.Max ?? 12;
                     int minValueLength = prop.GetCustomAttribute<SettingMinLengthAttribute>()?.Min ?? 1;
 
-                    item = new TextMenu.Button(name + ": " + value) {
-                        Disabled = inGame
-                    };
-
-                    if (!inGame)
-                        item.Pressed(() => {
+                    item =
+                        new TextMenu.Button(name + ": " + value)
+                        .Pressed(() => {
                             Audio.Play(SFX.ui_main_savefile_rename_start);
                             menu.SceneAs<Overworld>().Goto<OuiModOptionString>().Init<OuiModOptions>(
                                 (string) value,
@@ -780,6 +776,10 @@ namespace Celeste.Mod {
                             );
                         });
                 }
+
+                if (item is not null)
+                    item.Disabled = disable;
+
                 return item;
             }
 

--- a/Celeste.Mod.mm/Mod/Module/EverestModule.cs
+++ b/Celeste.Mod.mm/Mod/Module/EverestModule.cs
@@ -761,13 +761,16 @@ namespace Celeste.Mod {
                         .Change(v => prop.SetValue(settingsObject, v))
                     ;
 
-                } else if (!inGame && propType == typeof(string)) {
+                } else if (propType == typeof(string)) {
                     int maxValueLength = prop.GetCustomAttribute<SettingMaxLengthAttribute>()?.Max ?? 12;
                     int minValueLength = prop.GetCustomAttribute<SettingMinLengthAttribute>()?.Min ?? 1;
 
-                    item =
-                        new TextMenu.Button(name + ": " + value)
-                        .Pressed(() => {
+                    item = new TextMenu.Button(name + ": " + value) {
+                        Disabled = inGame
+                    };
+
+                    if (!inGame)
+                        item.Pressed(() => {
                             Audio.Play(SFX.ui_main_savefile_rename_start);
                             menu.SceneAs<Overworld>().Goto<OuiModOptionString>().Init<OuiModOptions>(
                                 (string) value,
@@ -775,8 +778,7 @@ namespace Celeste.Mod {
                                 maxValueLength,
                                 minValueLength
                             );
-                        })
-                    ;
+                        });
                 }
                 return item;
             }

--- a/Celeste.Mod.mm/Mod/Module/EverestModule.cs
+++ b/Celeste.Mod.mm/Mod/Module/EverestModule.cs
@@ -694,7 +694,8 @@ namespace Celeste.Mod {
                 Type propType = prop.PropertyType;
                 object value = prop.GetValue(settingsObject);
 
-                bool disable = propType == typeof(string) || prop.GetCustomAttribute<SettingInGameDisableAttribute>()?.InGame == inGame;
+                bool forceDisableInGame = false;
+                bool disable = prop.GetCustomAttribute<SettingInGameDisableAttribute>()?.InGame == inGame;
 
                 // Create the matching item based off of the type and attributes.
                 if (propType == typeof(bool))
@@ -719,6 +720,7 @@ namespace Celeste.Mod {
                 else if ((propType == typeof(int) || propType == typeof(float)) &&
                     (attribNumber = prop.GetCustomAttribute<SettingNumberInputAttribute>()) != null)
                 {
+                    forceDisableInGame = true;
                     float currentValue;
                     Action<float> valueSetter;
                     if (propType == typeof(int)) {
@@ -761,6 +763,7 @@ namespace Celeste.Mod {
                 }
                 else if (propType == typeof(string))
                 {
+                    forceDisableInGame = true;
                     int maxValueLength = prop.GetCustomAttribute<SettingMaxLengthAttribute>()?.Max ?? 12;
                     int minValueLength = prop.GetCustomAttribute<SettingMinLengthAttribute>()?.Min ?? 1;
 
@@ -778,7 +781,7 @@ namespace Celeste.Mod {
                 }
 
                 if (item is not null)
-                    item.Disabled = disable;
+                    item.Disabled = disable || inGame && forceDisableInGame;
 
                 return item;
             }

--- a/Celeste.Mod.mm/Mod/Module/EverestModuleSettings.cs
+++ b/Celeste.Mod.mm/Mod/Module/EverestModuleSettings.cs
@@ -34,6 +34,17 @@ namespace Celeste.Mod {
     }
 
     /// <summary>
+    /// Whether the option should be disabled in-game or in the main menu.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property)]
+    public class SettingInGameDisableAttribute : Attribute {
+        public bool InGame;
+        public SettingInGameDisableAttribute(bool inGame) {
+            InGame = inGame;
+        }
+    }
+
+    /// <summary>
     /// The integer option range.
     /// If largeRange is set to true, a slider optimized for large integer ranges (going through values at an increasing speed) will be used.
     /// </summary>


### PR DESCRIPTION
This PR will:
- show (but disable) string inputs in-game
- disable number inputs in-game (this fixes a crash if the player tries to adjust it in-game)
- add a `SettingInGameDisableAttribute`, which allows the user to disable a setting in-game or in the main-menu