### PR TITLE
Fix Lua `debug.traceback` references leaking

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 	branch = reorganize
 [submodule "external/NLua"]
 	path = external/NLua
-	url = https://github.com/Popax21/NLua
+	url = https://github.com/EverestAPI/NLua


### PR DESCRIPTION
Submodule update corresponding to https://github.com/EverestAPI/NLua/pull/1 and reflecting that repo now being in the Everest org.