### PR TITLE
Log when mod DLL cannot be loaded (issue #522)

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
@@ -503,6 +503,7 @@ namespace Celeste.Mod {
                 if (!string.IsNullOrEmpty(meta.DLL)) {
                     if (meta.AssemblyContext.LoadAssemblyFromModPath(meta.DLL) is not Assembly asm) {
                         // Don't register a module - this will cause dependencies to not load
+                        Logger.Error("loader", $"Could not load DLL {meta.DLL} for mod {meta.Name}");
                         ModsWithAssemblyLoadFailures.Add(meta);
                         return false;
                     }


### PR DESCRIPTION
Log an error when the DLL of a mod could not be loaded.

Closes #522