### PR TITLE
Prevent leftovers MenuButtons when rebuilding menu

### DIFF
--- a/Celeste.Mod.mm/Mod/Core/CoreModuleSettings.cs
+++ b/Celeste.Mod.mm/Mod/Core/CoreModuleSettings.cs
@@ -80,7 +80,7 @@ namespace Celeste.Mod.Core {
                         Engine.Commands.Enabled = false;
                 }
 
-                ((patch_OuiMainMenu) (Engine.Scene as Overworld)?.GetUI<OuiMainMenu>())?.RebuildMainAndTitle();
+                ((patch_OuiMainMenu) (Engine.Scene as Overworld)?.GetUI<OuiMainMenu>())?.NeedsRebuild();
             }
         }
 
@@ -237,7 +237,7 @@ namespace Celeste.Mod.Core {
                 _MainMenuMode = value;
                 if (value != originalValue) {
                     // the main menu mode was changed; rebuild the main menu
-                    ((patch_OuiMainMenu) (Engine.Scene as Overworld)?.GetUI<OuiMainMenu>())?.RebuildMainAndTitle();
+                    ((patch_OuiMainMenu) (Engine.Scene as Overworld)?.GetUI<OuiMainMenu>())?.NeedsRebuild();
                 }
             }
         }
@@ -266,7 +266,7 @@ namespace Celeste.Mod.Core {
                 _WarnOnEverestYamlErrors = value;
 
                 // rebuild the main menu to make sure we show/hide the yaml error notice.
-                ((patch_OuiMainMenu) (Engine.Scene as Overworld)?.GetUI<OuiMainMenu>())?.RebuildMainAndTitle();
+                ((patch_OuiMainMenu) (Engine.Scene as Overworld)?.GetUI<OuiMainMenu>())?.NeedsRebuild();
             }
         }
 

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
@@ -237,7 +237,7 @@ namespace Celeste.Mod {
                         LoadDir(e.FullPath);
                     else if (e.FullPath.EndsWith(".zip"))
                         LoadZip(e.FullPath);
-                    ((patch_OuiMainMenu) (AssetReloadHelper.ReturnToScene as Overworld)?.GetUI<OuiMainMenu>())?.RebuildMainAndTitle();
+                    ((patch_OuiMainMenu) (AssetReloadHelper.ReturnToScene as Overworld)?.GetUI<OuiMainMenu>())?.NeedsRebuild();
                 })));
             }
 

--- a/Celeste.Mod.mm/Mod/UI/OuiDependencyDownloader.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiDependencyDownloader.cs
@@ -523,7 +523,7 @@ namespace Celeste.Mod.UI {
         public void Exit() {
             task = null;
             Lines.Clear();
-            MainThreadHelper.Schedule(() => ((patch_OuiMainMenu) Overworld.GetUI<OuiMainMenu>())?.RebuildMainAndTitle());
+            MainThreadHelper.Schedule(() => ((patch_OuiMainMenu) Overworld.GetUI<OuiMainMenu>())?.NeedsRebuild());
             Audio.Play(SFX.ui_main_button_back);
             Overworld.Goto<OuiModOptions>();
         }

--- a/Celeste.Mod.mm/Patches/OuiMainMenu.cs
+++ b/Celeste.Mod.mm/Patches/OuiMainMenu.cs
@@ -28,6 +28,8 @@ namespace Celeste {
             }
         }
 
+        private bool needsRebuild = false;
+
         public extern void orig_CreateButtons();
         public new void CreateButtons() {
             orig_CreateButtons();
@@ -37,7 +39,22 @@ namespace Celeste {
             UpdateLayout();
         }
 
-        public void RebuildMainAndTitle() {
+        public void NeedsRebuild() {
+            needsRebuild = true;
+        }
+
+        public extern void orig_Update();
+        public new void Update() {
+            // rebuild only on update to prevent multiple rebuilds per frame
+            if (needsRebuild) {
+                RebuildMainAndTitle();
+                needsRebuild = false;
+            }
+
+            orig_Update();
+        }
+
+        private void RebuildMainAndTitle() {
             Overworld oui = Overworld;
             oui.UIs.Remove(oui.GetUI<OuiTitleScreen>());
             Oui title = new OuiTitleScreen() {
@@ -55,6 +72,8 @@ namespace Celeste {
                 break;
             }
 
+            // this cannot be called more than once per frame, otherwise the
+            // scene keeps orphaned menu buttons which messes with selection
             CreateButtons();
 
             if (selected is MainMenuClimb) {


### PR DESCRIPTION
Defer `RebuildMainAndTitle()` right before `Update()`, so `CreateButtons()` is only called once per frame.

When `CreateButtons()` is called more than once per frame, it creates orphaned buttons (not linked to the `OuiMainMenu`) which are not cleaned up properly, causing selection issues in the main menu.

The method `RebuildMainAndTitle()` is now `private` to prevent direct usage.

Closes issues #430 (and #766 which is a duplicate)