### PR TITLE
Add cassette fly check to Player.OnSquish

### DIFF
--- a/Celeste.Mod.mm/Patches/Player.cs
+++ b/Celeste.Mod.mm/Patches/Player.cs
@@ -329,6 +329,10 @@ namespace Celeste {
         [MonoModIgnore]
         [PatchPlayerApproachMaxMove]
         private extern int NormalUpdate();
+
+        [MonoModIgnore]
+        [PatchPlayerOnSquish]
+        protected extern override void OnSquish(CollisionData data);
     }
 
     public static class PlayerExt {
@@ -403,6 +407,12 @@ namespace MonoMod {
     /// </summary>
     [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchPlayerApproachMaxMove))]
     class PatchPlayerApproachMaxMoveAttribute : Attribute { }
+
+    /// <summary>
+    /// Patches the method to skip squish checks for the CassetteFly state
+    /// </summary>
+    [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchPlayerOnSquish))]
+    class PatchPlayerOnSquishAttribute : Attribute { }
 
     static partial class MonoModRules {
 
@@ -600,6 +610,28 @@ namespace MonoMod {
                         throw new Exception($"Unexpected instruction in DeltaTime multiplier calculation: {instr}");
                 }
             }
+        }
+
+        public static void PatchPlayerOnSquish(ILContext context, CustomAttribute attrib) {
+            FieldDefinition f_Player_StateMachine = context.Method.DeclaringType.FindField("StateMachine");
+            MethodDefinition m_StateMachine_get_State = f_Player_StateMachine.FieldType.Resolve().FindMethod("System.Int32 get_State()");
+
+            ILCursor cursor = new ILCursor(context);
+            ILLabel label = cursor.DefineLabel();
+
+            /*
+            Add a cassette fly check at the start of the method:
+            + if (this.StateMachine.State == StCassetteFly)
+            +    return;
+            */
+
+            cursor.EmitLdarg(0);
+            cursor.EmitLdfld(f_Player_StateMachine);
+            cursor.EmitCallvirt(m_StateMachine_get_State);
+            cursor.EmitLdcI4(21);
+            cursor.EmitBneUn(label);
+            cursor.EmitRet();
+            cursor.MarkLabel(label);
         }
     }
 }


### PR DESCRIPTION
The cassette fly state is intended to make the player invincible, but at the moment squish checks are still made against the player. This can cause deaths in modded situations when the return path crosses e.g. block entities.

This patch adds a check at the start of OnSquish to return immediately if the player is in the CassetteFly state.

Here is an example of the behavior [before the change](https://github.com/user-attachments/assets/f28b2689-3826-4885-9ed0-991d3a53587f) and [after the change](https://github.com/user-attachments/assets/7b350c28-b7bc-44f2-b18d-10338ddeadd4).

(This change was made manually in SJ and I thought it'd be helpful to add into Everest as a whole)
