### PR TITLE
add session sliders

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Events.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Events.cs
@@ -182,9 +182,9 @@ namespace Celeste.Mod {
             }
 
             public static class Session {
-                public static event Action<patch_Session.Slider, float?> OnSliderChanged;
-                internal static void SliderChanged(patch_Session.Slider slider, float? previous)
-                    => OnSliderChanged?.Invoke(slider, previous);
+                public static event Action<patch_Session, patch_Session.Slider, float?> OnSliderChanged;
+                internal static void SliderChanged(patch_Session session, patch_Session.Slider slider, float? previous)
+                    => OnSliderChanged?.Invoke(session, slider, previous);
             }
 
             public static class Player {

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Events.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Events.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using _Decal = Celeste.Decal;
 using _EventTrigger = Celeste.EventTrigger;
 using _Level = Celeste.Level;
+using _Session = Celeste.Session;
 using _OuiJournal = Celeste.OuiJournal;
 using _OuiMainMenu = Celeste.OuiMainMenu;
 using _Player = Celeste.Player;
@@ -164,20 +165,26 @@ namespace Celeste.Mod {
                 internal static void LoadLevel(_Level level, _Player.IntroTypes playerIntro, bool isFromLoader)
                     => OnLoadLevel?.Invoke(level, playerIntro, isFromLoader);
 
-                public delegate void EnterHandler(Session session, bool fromSaveData);
+                public delegate void EnterHandler(_Session session, bool fromSaveData);
                 public static event EnterHandler OnEnter;
-                internal static void Enter(Session session, bool fromSaveData)
+                internal static void Enter(_Session session, bool fromSaveData)
                     => OnEnter?.Invoke(session, fromSaveData);
 
-                public delegate void ExitHandler(_Level level, LevelExit exit, LevelExit.Mode mode, Session session, HiresSnow snow);
+                public delegate void ExitHandler(_Level level, LevelExit exit, LevelExit.Mode mode, _Session session, HiresSnow snow);
                 public static event ExitHandler OnExit;
-                internal static void Exit(_Level level, LevelExit exit, LevelExit.Mode mode, Session session, HiresSnow snow)
+                internal static void Exit(_Level level, LevelExit exit, LevelExit.Mode mode, _Session session, HiresSnow snow)
                     => OnExit?.Invoke(level, exit, mode, session, snow);
 
                 public delegate void CompleteHandler(_Level level);
                 public static event CompleteHandler OnComplete;
                 internal static void Complete(_Level level)
                     => OnComplete?.Invoke(level);
+            }
+
+            public static class Session {
+                public static event Action<patch_Session.Slider, float?> OnSliderChanged;
+                internal static void SliderChanged(patch_Session.Slider slider, float? previous)
+                    => OnSliderChanged?.Invoke(slider, previous);
             }
 
             public static class Player {

--- a/Celeste.Mod.mm/Patches/Session.cs
+++ b/Celeste.Mod.mm/Patches/Session.cs
@@ -54,7 +54,7 @@ namespace Celeste {
         private Dictionary<string, Slider> _Sliders;
 
         [XmlIgnore]
-        public IReadOnlyDictionary<string, Slider> Sliders;
+        public IReadOnlyDictionary<string, Slider> Sliders => _Sliders;
 
         /// <summary>
         /// Used internally for serialization; getting or setting this will cause issues.
@@ -90,7 +90,7 @@ namespace Celeste {
         private void ctor() {
             JustStarted = true;
             InArea = true;
-            Sliders = _Sliders = new Dictionary<string, Slider>();
+            _Sliders = new Dictionary<string, Slider>();
         }
 
         [PatchSessionOrigCtor]


### PR DESCRIPTION
analogy: `Flags` : `bool` :: `Counters` : `int` :: `Sliders` : `float`

api developed in conversation with @JaThePlayer as this affects Session Expressions.

- `Slider`s are a class so that they can be cached
- there is an event for setting sliders, which also provides the previous value if it exists
  - keep in mind that getting a slider may create it, which is the only case when the previous value is `null`
  - also keep in mind that setting a slider by name when it previously did not exist will fire the changed event twice
- i spent so long on the serialization it was so painful. did you know `[Obselete]` has an undocumented interaction where it disables serialisation? did you know `SlidersSerializationOnly` has to be an array because it does some wacky stuff with lists that breaks things?

future work:
- make counters work this way too?
- some sort of triggers to interact with sliders/counters in some basic way?