### PR TITLE
Fix incorrect MonoModReplace on properties

### DIFF
--- a/Celeste.Mod.mm/Patches/Distort.cs
+++ b/Celeste.Mod.mm/Patches/Distort.cs
@@ -6,12 +6,8 @@ namespace Celeste {
 
         private static float anxiety = 0f;
         
-        [MonoModReplace]
         public new static float Anxiety {
-            get 
-            {
-                return anxiety;
-            }
+            [MonoModReplace]
             set 
             {
                 anxiety = value;

--- a/Celeste.Mod.mm/Patches/MenuButton.cs
+++ b/Celeste.Mod.mm/Patches/MenuButton.cs
@@ -12,8 +12,8 @@ namespace Celeste {
         private bool selected;
         private Tween tween;
 
-        [MonoModReplace]
-        public new Color SelectionColor { 
+        public new Color SelectionColor {
+            [MonoModReplace]
             get 
             {
                 if (selected) {


### PR DESCRIPTION
This caused MonoMod to generate new orig_get and set methods for the Anxiety property of Distort.cs and the SelectionColor property of MenuButton.cs. Moving the MonoModReplace attribute to the getter/setter and not the property fixes this. Hotfix for #836 