### PR TITLE
Add Entity Collider Components to Entities

### DIFF
--- a/Celeste.Mod.mm/Mod/Entities/EntityCollider.cs
+++ b/Celeste.Mod.mm/Mod/Entities/EntityCollider.cs
@@ -11,7 +11,7 @@ namespace Celeste.Mod.Entities {
 
         public Collider Collider;
 
-        public EntityCollider(Action<T> onEntityAction, Collider collider)
+        public EntityCollider(Action<T> onEntityAction, Collider collider = null)
             : base(active: true, visible: true) {
             OnEntityAction = onEntityAction;
             Collider = collider;

--- a/Celeste.Mod.mm/Mod/Entities/EntityCollider.cs
+++ b/Celeste.Mod.mm/Mod/Entities/EntityCollider.cs
@@ -11,9 +11,9 @@ namespace Celeste.Mod.Entities {
     [Tracked(false)]
     public class EntityCollider<T> : Component where T : Entity {
         /// <summary>
-        /// Provides a simple way to know the Entity type of the specific Collider without Reflection
+        /// Provides a simple way to know the Entity type of the specific Collider
         /// </summary>
-        public readonly Type entityType = typeof(T);
+        public Type EntityType => typeof(T);
 
         /// <summary>
         /// The Action invoked on Collision, with the Component collided with passed as a parameter

--- a/Celeste.Mod.mm/Mod/Entities/EntityCollider.cs
+++ b/Celeste.Mod.mm/Mod/Entities/EntityCollider.cs
@@ -1,0 +1,51 @@
+﻿using Monocle;
+using System;
+using Microsoft.Xna.Framework;
+
+namespace Celeste.Mod.Entities {
+    [Tracked(false)]
+    public class EntityCollider<T> : Component where T : Entity {
+        public readonly string entityType = typeof(T).Name;
+
+        public Action<T> OnEntityAction;
+
+        public Collider Collider;
+
+        public EntityCollider(Action<T> onEntityAction, Collider collider)
+            : base(active: true, visible: true) {
+            OnEntityAction = onEntityAction;
+            Collider = collider;
+        }
+
+        public override void Added(Entity entity) {
+            if (!Engine.Scene.Tracker.IsEntityTracked<T>()) {
+                patch_Tracker.AddEntityToTracker(typeof(T));
+            }
+            base.Added(entity);
+        }
+
+        public override void Update() {
+            if (OnEntityAction == null) {
+                return;
+            }
+
+            Collider collider = Entity.Collider;
+            if (Collider != null) {
+                Entity.Collider = Collider;
+            }
+
+            Entity.CollideDo(OnEntityAction);
+
+            Entity.Collider = collider;
+        }
+
+        public override void DebugRender(Camera camera) {
+            if (Collider != null) {
+                Collider collider = Entity.Collider;
+                Entity.Collider = Collider;
+                Collider.Render(camera, Color.HotPink);
+                Entity.Collider = collider;
+            }
+        }
+    }
+}

--- a/Celeste.Mod.mm/Mod/Entities/EntityCollider.cs
+++ b/Celeste.Mod.mm/Mod/Entities/EntityCollider.cs
@@ -16,7 +16,7 @@ namespace Celeste.Mod.Entities {
         public Type EntityType => typeof(T);
 
         /// <summary>
-        /// The Action invoked on Collision, with the Component collided with passed as a parameter
+        /// The Action invoked on Collision, with the Entity collided with passed as a parameter
         /// </summary>
         public Action<T> OnEntityAction;
 

--- a/Celeste.Mod.mm/Mod/Entities/EntityCollider.cs
+++ b/Celeste.Mod.mm/Mod/Entities/EntityCollider.cs
@@ -1,6 +1,7 @@
 ﻿using Monocle;
 using System;
 using Microsoft.Xna.Framework;
+using static System.Formats.Asn1.AsnWriter;
 
 namespace Celeste.Mod.Entities {
     /// <summary>
@@ -30,7 +31,13 @@ namespace Celeste.Mod.Entities {
 
         public override void Added(Entity entity) {
             base.Added(entity);
-            (Scene?.Tracker as patch_Tracker).Refresh();
+            //Only called if Component is added post Scene Begin and Entity Adding and Awake time.
+            if (Scene != null) {
+                if (!Scene.Tracker.IsEntityTracked<T>()) {
+                    patch_Tracker.AddTypeToTracker(typeof(T));
+                }
+                (Scene.Tracker as patch_Tracker).Refresh();
+            }
         }
 
         public override void EntityAdded(Scene scene) {

--- a/Celeste.Mod.mm/Mod/Entities/EntityCollider.cs
+++ b/Celeste.Mod.mm/Mod/Entities/EntityCollider.cs
@@ -1,7 +1,6 @@
 ﻿using Monocle;
 using System;
 using Microsoft.Xna.Framework;
-using static System.Formats.Asn1.AsnWriter;
 
 namespace Celeste.Mod.Entities {
     /// <summary>

--- a/Celeste.Mod.mm/Mod/Entities/EntityCollider.cs
+++ b/Celeste.Mod.mm/Mod/Entities/EntityCollider.cs
@@ -30,7 +30,7 @@ namespace Celeste.Mod.Entities {
 
         public override void EntityAdded(Scene scene) {
             if (!scene.Tracker.IsEntityTracked<T>()) {
-                (scene.Tracker as patch_Tracker).AddEntityToTracker(typeof(T));
+                patch_Tracker.AddTypeToTracker(typeof(T));
             }
             base.EntityAdded(scene);
         }

--- a/Celeste.Mod.mm/Mod/Entities/EntityCollider.cs
+++ b/Celeste.Mod.mm/Mod/Entities/EntityCollider.cs
@@ -13,7 +13,7 @@ namespace Celeste.Mod.Entities {
         /// <summary>
         /// Provides a simple way to know the Entity type of the specific Collider without Reflection
         /// </summary>
-        public readonly string entityType = typeof(T).Name;
+        public readonly Type entityType = typeof(T);
 
         /// <summary>
         /// The Action invoked on Collision, with the Component collided with passed as a parameter

--- a/Celeste.Mod.mm/Mod/Entities/EntityCollider.cs
+++ b/Celeste.Mod.mm/Mod/Entities/EntityCollider.cs
@@ -29,7 +29,7 @@ namespace Celeste.Mod.Entities {
         }
 
         public override void EntityAdded(Scene scene) {
-            if (scene.Tracker.IsEntityTracked<T>()) {
+            if (!scene.Tracker.IsEntityTracked<T>()) {
                 (scene.Tracker as patch_Tracker).AddEntityToTracker(typeof(T));
             }
             base.EntityAdded(scene);

--- a/Celeste.Mod.mm/Mod/Entities/EntityCollider.cs
+++ b/Celeste.Mod.mm/Mod/Entities/EntityCollider.cs
@@ -17,11 +17,11 @@ namespace Celeste.Mod.Entities {
             Collider = collider;
         }
 
-        public override void Added(Entity entity) {
-            if (!Engine.Scene.Tracker.IsEntityTracked<T>()) {
-                patch_Tracker.AddEntityToTracker(typeof(T));
+        public override void EntityAdded(Scene scene) {
+            if (scene.Tracker.IsEntityTracked<T>()) {
+                (scene.Tracker as patch_Tracker).AddEntityToTracker(typeof(T));
             }
-            base.Added(entity);
+            base.EntityAdded(scene);
         }
 
         public override void Update() {

--- a/Celeste.Mod.mm/Mod/Entities/EntityCollider.cs
+++ b/Celeste.Mod.mm/Mod/Entities/EntityCollider.cs
@@ -3,10 +3,21 @@ using System;
 using Microsoft.Xna.Framework;
 
 namespace Celeste.Mod.Entities {
+    /// <summary>
+    /// Allows for Collision with any type of entity in the game, similar to a PlayerCollider or PufferCollider.
+    /// Performs the Action provided on collision. 
+    /// </summary>
+    /// <typeparam name="T">The specific type of Entity this component should try to collide with</typeparam>
     [Tracked(false)]
     public class EntityCollider<T> : Component where T : Entity {
+        /// <summary>
+        /// Provides a simple way to know the Entity type of the specific Collider without Reflection
+        /// </summary>
         public readonly string entityType = typeof(T).Name;
 
+        /// <summary>
+        /// The Action invoked on Collision, with the Component collided with passed as a parameter
+        /// </summary>
         public Action<T> OnEntityAction;
 
         public Collider Collider;

--- a/Celeste.Mod.mm/Mod/Entities/EntityCollider.cs
+++ b/Celeste.Mod.mm/Mod/Entities/EntityCollider.cs
@@ -28,11 +28,20 @@ namespace Celeste.Mod.Entities {
             Collider = collider;
         }
 
+        public override void Added(Entity entity) {
+            base.Added(entity);
+            (Scene?.Tracker as patch_Tracker).Refresh();
+        }
+
         public override void EntityAdded(Scene scene) {
             if (!scene.Tracker.IsEntityTracked<T>()) {
                 patch_Tracker.AddTypeToTracker(typeof(T));
             }
             base.EntityAdded(scene);
+        }
+
+        public override void EntityAwake() {
+            (Scene.Tracker as patch_Tracker).Refresh();
         }
 
         public override void Update() {

--- a/Celeste.Mod.mm/Mod/Entities/EntityCollider.cs
+++ b/Celeste.Mod.mm/Mod/Entities/EntityCollider.cs
@@ -8,13 +8,7 @@ namespace Celeste.Mod.Entities {
     /// Performs the Action provided on collision. 
     /// </summary>
     /// <typeparam name="T">The specific type of Entity this component should try to collide with</typeparam>
-    [Tracked(false)]
     public class EntityCollider<T> : Component where T : Entity {
-        /// <summary>
-        /// Provides a simple way to know the Entity type of the specific Collider
-        /// </summary>
-        public Type EntityType => typeof(T);
-
         /// <summary>
         /// The Action invoked on Collision, with the Entity collided with passed as a parameter
         /// </summary>

--- a/Celeste.Mod.mm/Mod/Entities/EntityCollider.cs
+++ b/Celeste.Mod.mm/Mod/Entities/EntityCollider.cs
@@ -29,7 +29,7 @@ namespace Celeste.Mod.Entities {
                 if (!Scene.Tracker.IsEntityTracked<T>()) {
                     patch_Tracker.AddTypeToTracker(typeof(T));
                 }
-                patch_Tracker.Refresh();
+                patch_Tracker.Refresh(Scene);
             }
         }
 
@@ -41,7 +41,7 @@ namespace Celeste.Mod.Entities {
         }
 
         public override void EntityAwake() {
-            patch_Tracker.Refresh();
+            patch_Tracker.Refresh(Scene);
         }
 
         public override void Update() {

--- a/Celeste.Mod.mm/Mod/Entities/EntityCollider.cs
+++ b/Celeste.Mod.mm/Mod/Entities/EntityCollider.cs
@@ -29,7 +29,7 @@ namespace Celeste.Mod.Entities {
                 if (!Scene.Tracker.IsEntityTracked<T>()) {
                     patch_Tracker.AddTypeToTracker(typeof(T));
                 }
-                (Scene.Tracker as patch_Tracker).Refresh();
+                patch_Tracker.Refresh();
             }
         }
 
@@ -41,7 +41,7 @@ namespace Celeste.Mod.Entities {
         }
 
         public override void EntityAwake() {
-            (Scene.Tracker as patch_Tracker).Refresh();
+            patch_Tracker.Refresh();
         }
 
         public override void Update() {

--- a/Celeste.Mod.mm/Mod/Entities/EntityColliderByComponent.cs
+++ b/Celeste.Mod.mm/Mod/Entities/EntityColliderByComponent.cs
@@ -17,11 +17,11 @@ namespace Celeste.Mod.Entities {
             Collider = collider;
         }
 
-        public override void Added(Entity entity) {
-            if (!Engine.Scene.Tracker.IsComponentTracked<T>()) {
-                patch_Tracker.AddComponentToTracker(typeof(T));
+        public override void EntityAdded(Scene scene) {
+            if (scene.Tracker.IsComponentTracked<T>()) {
+                (scene.Tracker as patch_Tracker).AddComponentToTracker(typeof(T));
             }
-            base.Added(entity);
+            base.EntityAdded(scene);
         }
 
         public override void Update() {

--- a/Celeste.Mod.mm/Mod/Entities/EntityColliderByComponent.cs
+++ b/Celeste.Mod.mm/Mod/Entities/EntityColliderByComponent.cs
@@ -1,0 +1,51 @@
+﻿using Monocle;
+using System;
+using Microsoft.Xna.Framework;
+
+namespace Celeste.Mod.Entities {
+    [Tracked(false)]
+    public class EntityColliderByComponent<T> : Component where T : Component {
+        public readonly string componentType = typeof(T).Name;
+
+        public Action<T> OnComponentAction;
+
+        public Collider Collider;
+
+        public EntityColliderByComponent(Action<T> onComponentAction, Collider collider = null)
+            : base(active: true, visible: true) {
+            OnComponentAction = onComponentAction;
+            Collider = collider;
+        }
+
+        public override void Added(Entity entity) {
+            if (!Engine.Scene.Tracker.IsComponentTracked<T>()) {
+                patch_Tracker.AddComponentToTracker(typeof(T));
+            }
+            base.Added(entity);
+        }
+
+        public override void Update() {
+            if (OnComponentAction == null) {
+                return;
+            }
+
+            Collider collider = Entity.Collider;
+            if (Collider != null) {
+                Entity.Collider = Collider;
+            }
+
+            Entity.CollideDoByComponent(OnComponentAction);
+
+            Entity.Collider = collider;
+        }
+
+        public override void DebugRender(Camera camera) {
+            if (Collider != null) {
+                Collider collider = Entity.Collider;
+                Entity.Collider = Collider;
+                Collider.Render(camera, Color.HotPink);
+                Entity.Collider = collider;
+            }
+        }
+    }
+}

--- a/Celeste.Mod.mm/Mod/Entities/EntityColliderByComponent.cs
+++ b/Celeste.Mod.mm/Mod/Entities/EntityColliderByComponent.cs
@@ -14,7 +14,7 @@ namespace Celeste.Mod.Entities {
         /// <summary>
         /// Provides a simple way to know the Component type of the specific Collider without Reflection
         /// </summary>
-        public readonly string componentType = typeof(T).Name;
+        public readonly Type componentType = typeof(T);
 
         /// <summary>
         /// The Action invoked on Collision, with the Component collided with passed as a parameter

--- a/Celeste.Mod.mm/Mod/Entities/EntityColliderByComponent.cs
+++ b/Celeste.Mod.mm/Mod/Entities/EntityColliderByComponent.cs
@@ -12,9 +12,9 @@ namespace Celeste.Mod.Entities {
     [Tracked(false)]
     public class EntityColliderByComponent<T> : Component where T : Component {
         /// <summary>
-        /// Provides a simple way to know the Component type of the specific Collider without Reflection
+        /// Provides a simple way to know the Component type of the specific Collider
         /// </summary>
-        public readonly Type componentType = typeof(T);
+        public Type ComponentType => typeof(T);
 
         /// <summary>
         /// The Action invoked on Collision, with the Component collided with passed as a parameter

--- a/Celeste.Mod.mm/Mod/Entities/EntityColliderByComponent.cs
+++ b/Celeste.Mod.mm/Mod/Entities/EntityColliderByComponent.cs
@@ -1,6 +1,7 @@
 ﻿using Monocle;
 using System;
 using Microsoft.Xna.Framework;
+using static System.Formats.Asn1.AsnWriter;
 
 namespace Celeste.Mod.Entities {
     /// <summary>
@@ -31,7 +32,13 @@ namespace Celeste.Mod.Entities {
 
         public override void Added(Entity entity) {
             base.Added(entity);
-            (Scene?.Tracker as patch_Tracker).Refresh();
+            //Only called if Component is added post Scene Begin and Entity Adding and Awake time.
+            if (Scene != null) {
+                if (!Scene.Tracker.IsComponentTracked<T>()) {
+                    patch_Tracker.AddTypeToTracker(typeof(T));
+                }
+                (Scene.Tracker as patch_Tracker).Refresh();
+            }
         }
 
         public override void EntityAdded(Scene scene) {

--- a/Celeste.Mod.mm/Mod/Entities/EntityColliderByComponent.cs
+++ b/Celeste.Mod.mm/Mod/Entities/EntityColliderByComponent.cs
@@ -29,11 +29,20 @@ namespace Celeste.Mod.Entities {
             Collider = collider;
         }
 
+        public override void Added(Entity entity) {
+            base.Added(entity);
+            (Scene?.Tracker as patch_Tracker).Refresh();
+        }
+
         public override void EntityAdded(Scene scene) {
             if (!scene.Tracker.IsComponentTracked<T>()) {
                 patch_Tracker.AddTypeToTracker(typeof(T));
             }
             base.EntityAdded(scene);
+        }
+
+        public override void EntityAwake() {
+            (Scene.Tracker as patch_Tracker).Refresh();
         }
 
         public override void Update() {

--- a/Celeste.Mod.mm/Mod/Entities/EntityColliderByComponent.cs
+++ b/Celeste.Mod.mm/Mod/Entities/EntityColliderByComponent.cs
@@ -30,7 +30,7 @@ namespace Celeste.Mod.Entities {
         }
 
         public override void EntityAdded(Scene scene) {
-            if (scene.Tracker.IsComponentTracked<T>()) {
+            if (!scene.Tracker.IsComponentTracked<T>()) {
                 (scene.Tracker as patch_Tracker).AddComponentToTracker(typeof(T));
             }
             base.EntityAdded(scene);

--- a/Celeste.Mod.mm/Mod/Entities/EntityColliderByComponent.cs
+++ b/Celeste.Mod.mm/Mod/Entities/EntityColliderByComponent.cs
@@ -1,7 +1,6 @@
 ﻿using Monocle;
 using System;
 using Microsoft.Xna.Framework;
-using static System.Formats.Asn1.AsnWriter;
 
 namespace Celeste.Mod.Entities {
     /// <summary>

--- a/Celeste.Mod.mm/Mod/Entities/EntityColliderByComponent.cs
+++ b/Celeste.Mod.mm/Mod/Entities/EntityColliderByComponent.cs
@@ -9,13 +9,7 @@ namespace Celeste.Mod.Entities {
     /// Performs the Action provided on collision. 
     /// </summary>
     /// <typeparam name="T">The specific type of Component this component should try to collide with</typeparam>
-    [Tracked(false)]
     public class EntityColliderByComponent<T> : Component where T : Component {
-        /// <summary>
-        /// Provides a simple way to know the Component type of the specific Collider
-        /// </summary>
-        public Type ComponentType => typeof(T);
-
         /// <summary>
         /// The Action invoked on Collision, with the Component collided with passed as a parameter
         /// </summary>

--- a/Celeste.Mod.mm/Mod/Entities/EntityColliderByComponent.cs
+++ b/Celeste.Mod.mm/Mod/Entities/EntityColliderByComponent.cs
@@ -31,7 +31,7 @@ namespace Celeste.Mod.Entities {
 
         public override void EntityAdded(Scene scene) {
             if (!scene.Tracker.IsComponentTracked<T>()) {
-                (scene.Tracker as patch_Tracker).AddComponentToTracker(typeof(T));
+                patch_Tracker.AddTypeToTracker(typeof(T));
             }
             base.EntityAdded(scene);
         }

--- a/Celeste.Mod.mm/Mod/Entities/EntityColliderByComponent.cs
+++ b/Celeste.Mod.mm/Mod/Entities/EntityColliderByComponent.cs
@@ -3,10 +3,22 @@ using System;
 using Microsoft.Xna.Framework;
 
 namespace Celeste.Mod.Entities {
+    /// <summary>
+    /// Allows for Collision with any type of entity in the game, similar to a PlayerCollider or PufferCollider.
+    /// Collision is done by component, as in, it will get all the components of the type and try to collide with their entities.
+    /// Performs the Action provided on collision. 
+    /// </summary>
+    /// <typeparam name="T">The specific type of Component this component should try to collide with</typeparam>
     [Tracked(false)]
     public class EntityColliderByComponent<T> : Component where T : Component {
+        /// <summary>
+        /// Provides a simple way to know the Component type of the specific Collider without Reflection
+        /// </summary>
         public readonly string componentType = typeof(T).Name;
 
+        /// <summary>
+        /// The Action invoked on Collision, with the Component collided with passed as a parameter
+        /// </summary>
         public Action<T> OnComponentAction;
 
         public Collider Collider;

--- a/Celeste.Mod.mm/Mod/Entities/EntityColliderByComponent.cs
+++ b/Celeste.Mod.mm/Mod/Entities/EntityColliderByComponent.cs
@@ -30,7 +30,7 @@ namespace Celeste.Mod.Entities {
                 if (!Scene.Tracker.IsComponentTracked<T>()) {
                     patch_Tracker.AddTypeToTracker(typeof(T));
                 }
-                (Scene.Tracker as patch_Tracker).Refresh();
+                patch_Tracker.Refresh();
             }
         }
 
@@ -42,7 +42,7 @@ namespace Celeste.Mod.Entities {
         }
 
         public override void EntityAwake() {
-            (Scene.Tracker as patch_Tracker).Refresh();
+            patch_Tracker.Refresh();
         }
 
         public override void Update() {

--- a/Celeste.Mod.mm/Mod/Entities/EntityColliderByComponent.cs
+++ b/Celeste.Mod.mm/Mod/Entities/EntityColliderByComponent.cs
@@ -30,7 +30,7 @@ namespace Celeste.Mod.Entities {
                 if (!Scene.Tracker.IsComponentTracked<T>()) {
                     patch_Tracker.AddTypeToTracker(typeof(T));
                 }
-                patch_Tracker.Refresh();
+                patch_Tracker.Refresh(Scene);
             }
         }
 
@@ -42,7 +42,7 @@ namespace Celeste.Mod.Entities {
         }
 
         public override void EntityAwake() {
-            patch_Tracker.Refresh();
+            patch_Tracker.Refresh(Scene);
         }
 
         public override void Update() {

--- a/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
@@ -92,7 +92,7 @@ namespace Monocle {
             bool? trackedEntity = typeof(Entity).IsAssignableFrom(type) ? true : typeof(Component).IsAssignableFrom(type) ? false : null;
             if (trackedEntity == null) {
                 // this is neither an entity nor a component. Help!
-                throw new Exception("Type '" + type.Name + "' cannot be Tracked because it does not derive from Entity or Component");
+                throw new Exception("Type '" + type.Name + "' cannot be Tracked" + (trackedAsType != type ? "As" : "") + " because it does not derive from Entity or Component");
             }
             // copy the registered types for the target type
             ((bool)trackedEntity ? StoredEntityTypes : StoredComponentTypes).Add(type);

--- a/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
@@ -166,8 +166,8 @@ namespace Monocle {
             foreach (Entity entity in Engine.Scene.Entities) {
                 foreach (Component component in entity.Components) {
                     Type componentType = component.GetType();
-                    if (Components[componentType].Contains(component)
-                        || !TrackedComponentTypes.TryGetValue(componentType, out List<Type> componentTypes)) {
+                    if (!TrackedComponentTypes.TryGetValue(componentType, out List<Type> componentTypes)
+                        || Components[componentType].Contains(component)) {
                         continue;
                     }
                     foreach (Type trackedType in componentTypes) {
@@ -175,8 +175,8 @@ namespace Monocle {
                     }
                 }
                 Type entityType = entity.GetType();
-                if (Entities[entityType].Contains(entity)
-                    || !TrackedEntityTypes.TryGetValue(entityType, out List<Type> entityTypes)) {
+                if (!TrackedEntityTypes.TryGetValue(entityType, out List<Type> entityTypes)
+                    || Entities[entityType].Contains(entity)) {
                     continue;
                 }
                 foreach (Type trackedType in entityTypes) {

--- a/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
@@ -135,19 +135,6 @@ namespace Monocle {
                 // this is neither an entity nor a component. Help!
                 throw new Exception("Type '" + type.Name + "' cannot be TrackedAs because it does not derive from Entity or Component");
             }
-            RefreshTracker(type);
-        }
-
-        public static void RefreshTracker(Type type) {
-            if (typeof(Entity).IsAssignableFrom(type) && !Engine.Scene.Tracker.Entities.ContainsKey(type)) {
-                Engine.Scene.Tracker.Entities.Add(type, new List<Entity>());
-            }
-            else if (typeof(Component).IsAssignableFrom(type) && !Engine.Scene.Tracker.Components.ContainsKey(type)) {
-                Engine.Scene.Tracker.Components.Add(type, new List<Component>());
-            } else {
-                throw new Exception("Type '" + type.Name + "' does not derive from Entity or Component");
-            }
-            RefreshTrackerLists();
         }
 
         public static void RefreshTracker() {

--- a/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
@@ -162,9 +162,7 @@ namespace Monocle {
             if (components != null && !components.ContainsKey(type)) {
                 List<Component> list = new();
                 foreach (Entity entity in Engine.Scene.Entities) {
-                    foreach (Component component in entity.Components.Where((c) => c.GetType() == type)) {
-                        list.Add(component);
-                    }
+                    list.AddRange(entity.Components.Where((c) => c.GetType() == type));
                 }
                 components[type] = list;
             }

--- a/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
@@ -48,8 +48,7 @@ namespace Monocle {
             _temporaryAllTypes ??= GetAllTypesUncached();
             
             List<Type> subclasses = new();
-            foreach (Type otherType in _temporaryAllTypes)
-            {
+            foreach (Type otherType in _temporaryAllTypes) {
                 if (type != otherType && type.IsAssignableFrom(otherType))
                     subclasses.Add(otherType);
             }
@@ -95,8 +94,8 @@ namespace Monocle {
                 throw new Exception("Type '" + type.Name + "' cannot be Tracked" + (trackedAsType != type ? "As" : "") + " because it does not derive from Entity or Component");
             }
             // copy the registered types for the target type
-            ((bool)trackedEntity ? StoredEntityTypes : StoredComponentTypes).Add(type);
-            Dictionary<Type, List<Type>> tracked = (bool)trackedEntity ? TrackedEntityTypes : TrackedComponentTypes;
+            ((bool) trackedEntity ? StoredEntityTypes : StoredComponentTypes).Add(type);
+            Dictionary<Type, List<Type>> tracked = (bool) trackedEntity ? TrackedEntityTypes : TrackedComponentTypes;
             if (!type.IsAbstract) {
                 if (!tracked.TryGetValue(type, out List<Type> value)) {
                     value = new List<Type>();

--- a/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
@@ -140,7 +140,7 @@ namespace Monocle {
             }
             Dictionary<Type, List<Entity>> entities = Engine.Scene?.Tracker.Entities;
             if (entities != null && !entities.ContainsKey(type)) {
-                entities[type] = Engine.Scene.Entities.Where((Entity e) => e.GetType() == type).ToList();
+                entities[type] = Engine.Scene.Entities.Where((e) => e.GetType() == type).ToList();
             }
         }
 
@@ -162,8 +162,7 @@ namespace Monocle {
             if (components != null && !components.ContainsKey(type)) {
                 List<Component> list = new List<Component>();
                 foreach (Entity entity in Engine.Scene.Entities) {
-                    Component component = entity.Components.FirstOrDefault((c) => c.GetType() == type);
-                    if (component != null) {
+                    foreach (Component component in entity.Components.Where((c) => c.GetType() == type)) {
                         list.Add(component);
                     }
                 }

--- a/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
@@ -124,16 +124,11 @@ namespace Monocle {
             _temporaryAllTypes = null;
         }
 
-        public static void AddTypeToTracker(Type type, bool inheritAll) {
-            if (inheritAll) {
-                AddTypeToTracker(type, GetSubclasses(type).ToArray());
-            }
-            else {
-                AddTypeToTracker(type);
-            }
+        public static void AddTypeToTracker(Type type, Type trackedAs = null, bool inheritAll = false) {
+            AddTypeToTracker(type, trackedAs, inheritAll ? GetSubclasses(type).ToArray() : Array.Empty<Type>());
         }
 
-        public static void AddTypeToTracker(Type type, params Type[] subtypes) {
+        public static void AddTypeToTracker(Type type, Type trackedAs = null, params Type[] subtypes) {
             if (typeof(Entity).IsAssignableFrom(type)) {
                 StoredEntityTypes.Add(type);
                 if (!type.IsAbstract) {
@@ -141,7 +136,8 @@ namespace Monocle {
                         value = new List<Type>();
                         TrackedEntityTypes.Add(type, value);
                     }
-                    value.AddRange(TrackedEntityTypes.TryGetValue(type, out List<Type> list) ? list : new List<Type>());
+                    value.AddRange(TrackedEntityTypes.TryGetValue(trackedAs != null && trackedAs.IsAssignableFrom(type)
+                        ? trackedAs : type, out List<Type> list) ? list : new List<Type>());
                     TrackedEntityTypes[type] = value.Distinct().ToList();
                 }
                 foreach (Type subtype in subtypes) {
@@ -150,7 +146,8 @@ namespace Monocle {
                             value = new List<Type>();
                             TrackedEntityTypes.Add(subtype, value);
                         }
-                        value.AddRange(TrackedEntityTypes.TryGetValue(type, out List<Type> list) ? list : new List<Type>());
+                        value.AddRange(TrackedEntityTypes.TryGetValue(trackedAs != null && trackedAs.IsAssignableFrom(type)
+                            ? trackedAs : type, out List<Type> list) ? list : new List<Type>());
                         TrackedEntityTypes[subtype] = value.Distinct().ToList();
                     }
                 }
@@ -162,7 +159,8 @@ namespace Monocle {
                         value = new List<Type>();
                         TrackedComponentTypes.Add(type, value);
                     }
-                    value.AddRange(TrackedComponentTypes.TryGetValue(type, out List<Type> list) ? list : new List<Type>());
+                    value.AddRange(TrackedComponentTypes.TryGetValue(trackedAs != null && trackedAs.IsAssignableFrom(type)
+                        ? trackedAs : type, out List<Type> list) ? list : new List<Type>());
                     TrackedComponentTypes[type] = value.Distinct().ToList();
                 }
                 foreach(Type subtype in subtypes) {
@@ -171,7 +169,8 @@ namespace Monocle {
                             value = new List<Type>();
                             TrackedComponentTypes.Add(subtype, value);
                         }
-                        value.AddRange(TrackedComponentTypes.TryGetValue(type, out List<Type> list) ? list : new List<Type>());
+                        value.AddRange(TrackedComponentTypes.TryGetValue(trackedAs != null && trackedAs.IsAssignableFrom(type)
+                            ? trackedAs : type, out List<Type> list) ? list : new List<Type>());
                         TrackedComponentTypes[subtype] = value.Distinct().ToList();
                     }
                 }

--- a/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
@@ -155,23 +155,25 @@ namespace Monocle {
             RefreshTrackerLists();
         }
 
-        private static void RefreshTrackerLists() {
+        private void RefreshTrackerLists() {
             foreach (Entity entity in Engine.Scene.Entities) {
                 foreach (Component component in entity.Components) {
                     Type componentType = component.GetType();
-                    if (!TrackedComponentTypes.TryGetValue(componentType, out List<Type> componentTypes)) {
+                    if (Components[componentType].Contains(component)
+                        || !TrackedComponentTypes.TryGetValue(componentType, out List<Type> componentTypes)) {
                         continue;
                     }
                     foreach (Type trackedType in componentTypes) {
-                        Engine.Scene.Tracker.Components[trackedType].Add(component);
+                        Components[trackedType].Add(component);
                     }
                 }
                 Type entityType = entity.GetType();
-                if (!TrackedEntityTypes.TryGetValue(entityType, out List<Type> entityTypes)) {
+                if (Entities[entityType].Contains(entity)
+                    || !TrackedEntityTypes.TryGetValue(entityType, out List<Type> entityTypes)) {
                     continue;
                 }
                 foreach (Type trackedType in entityTypes) {
-                    Engine.Scene.Tracker.Entities[trackedType].Add(entity);
+                    Entities[trackedType].Add(entity);
                 }
             }
         }

--- a/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
@@ -124,7 +124,7 @@ namespace Monocle {
             _temporaryAllTypes = null;
         }
 
-        public static void AddEntityToTracker(Type type, params Type[] subTypes) {
+        public void AddEntityToTracker(Type type, params Type[] subTypes) {
             StoredEntityTypes.Add(type);
             if (!TrackedEntityTypes.TryGetValue(type, out List<Type> value)) {
                 TrackedEntityTypes[type] = new List<Type> { type };
@@ -138,13 +138,12 @@ namespace Monocle {
                     subvalue.Add(type);
                 }
             }
-            Dictionary<Type, List<Entity>> entities = Engine.Scene?.Tracker.Entities;
-            if (entities != null && !entities.ContainsKey(type)) {
-                entities[type] = Engine.Scene.Entities.Where((e) => e.GetType() == type).ToList();
+            if (!Entities.ContainsKey(type)) {
+                Entities[type] = Engine.Scene.Entities.Where((e) => e.GetType() == type).ToList();
             }
         }
 
-        public static void AddComponentToTracker(Type type, params Type[] subTypes) {
+        public void AddComponentToTracker(Type type, params Type[] subTypes) {
             StoredComponentTypes.Add(type);
             if (!TrackedComponentTypes.TryGetValue(type, out List<Type> value)) {
                 TrackedComponentTypes[type] = new List<Type> { type };
@@ -158,13 +157,12 @@ namespace Monocle {
                     subvalue.Add(type);
                 }
             }
-            Dictionary<Type, List<Component>> components = Engine.Scene?.Tracker.Components;
-            if (components != null && !components.ContainsKey(type)) {
+            if (!Components.ContainsKey(type)) {
                 List<Component> list = new();
                 foreach (Entity entity in Engine.Scene.Entities) {
                     list.AddRange(entity.Components.Where((c) => c.GetType() == type));
                 }
-                components[type] = list;
+                Components[type] = list;
             }
         }
     }

--- a/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
@@ -150,19 +150,37 @@ namespace Monocle {
             } else if (!value.Contains(type)) {
                 value.Add(type);
             }
-            foreach (Type subType in subTypes) {
-                if (!TrackedComponentTypes.TryGetValue(subType, out List<Type> subvalue)) {
-                    TrackedComponentTypes[subType] = new List<Type> { type };
-                } else if (!subvalue.Contains(type)) {
-                    subvalue.Add(type);
+
+        public static void RefreshTracker() {
+            foreach (Type entityType in StoredEntityTypes) {
+                if (!Engine.Scene.Tracker.Entities.ContainsKey(entityType)) {
+                    Engine.Scene.Tracker.Entities.Add(entityType, new List<Entity>());
                 }
             }
-            if (!Components.ContainsKey(type)) {
-                List<Component> list = new();
+            List<Component> components = new List<Component>();
                 foreach (Entity entity in Engine.Scene.Entities) {
-                    list.AddRange(entity.Components.Where((c) => c.GetType() == type));
+                components.AddRange(entity.Components);
+                Type entityType = entity.GetType();
+                if (!TrackedEntityTypes.TryGetValue(entityType, out List<Type> value)) {
+                    continue;
                 }
-                Components[type] = list;
+                foreach (Type item in value) {
+                    Engine.Scene.Tracker.Entities[item].Add(entity);
+                }
+            }
+            foreach (Type componentType in StoredComponentTypes) {
+                if (!Engine.Scene.Tracker.Components.ContainsKey(componentType)) {
+                    Engine.Scene.Tracker.Components.Add(componentType, new List<Component>());
+                }
+            }
+            foreach (Component component in components) {
+                Type componentType = component.GetType();
+                if (!TrackedComponentTypes.TryGetValue(componentType, out List<Type> value)) {
+                    continue;
+                }
+                foreach (Type item in value) {
+                    Engine.Scene.Tracker.Components[item].Add(component);
+                }
             }
         }
     }

--- a/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
@@ -160,7 +160,7 @@ namespace Monocle {
             }
             Dictionary<Type, List<Component>> components = Engine.Scene?.Tracker.Components;
             if (components != null && !components.ContainsKey(type)) {
-                List<Component> list = new List<Component>();
+                List<Component> list = new();
                 foreach (Entity entity in Engine.Scene.Entities) {
                     foreach (Component component in entity.Components.Where((c) => c.GetType() == type)) {
                         list.Add(component);

--- a/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
@@ -137,42 +137,49 @@ namespace Monocle {
             if (typeof(Entity).IsAssignableFrom(type)) {
                 StoredEntityTypes.Add(type);
                 if (!type.IsAbstract) {
-                    if (!TrackedEntityTypes.ContainsKey(type)) {
-                        TrackedEntityTypes.Add(type, new List<Type>());
+                    if (!TrackedEntityTypes.TryGetValue(type, out List<Type> value)) {
+                        value = new List<Type>();
+                        TrackedEntityTypes.Add(type, value);
                     }
-                    TrackedEntityTypes[type].AddRange(TrackedEntityTypes.TryGetValue(type, out List<Type> list) ? list : new List<Type>());
-                    TrackedEntityTypes[type] = TrackedEntityTypes[type].Distinct().ToList();
+                    value.AddRange(TrackedEntityTypes.TryGetValue(type, out List<Type> list) ? list : new List<Type>());
+                    TrackedEntityTypes[type] = value.Distinct().ToList();
                 }
                 foreach (Type subtype in subtypes) {
                     if (!subtype.IsAbstract) {
-                        if (!TrackedEntityTypes.ContainsKey(subtype))
-                            TrackedEntityTypes.Add(subtype, new List<Type>());
-                        TrackedEntityTypes[subtype].AddRange(TrackedEntityTypes.TryGetValue(type, out List<Type> list) ? list : new List<Type>());
-                        TrackedEntityTypes[subtype] = TrackedEntityTypes[subtype].Distinct().ToList();
+                        if (!TrackedEntityTypes.TryGetValue(subtype, out List<Type> value)) {
+                            value = new List<Type>();
+                            TrackedEntityTypes.Add(subtype, value);
+                        }
+                        value.AddRange(TrackedEntityTypes.TryGetValue(type, out List<Type> list) ? list : new List<Type>());
+                        TrackedEntityTypes[subtype] = value.Distinct().ToList();
                     }
                 }
             }
             else if (typeof(Component).IsAssignableFrom(type)) {
                 StoredComponentTypes.Add(type);
                 if (!type.IsAbstract) {
-                    if (!TrackedComponentTypes.ContainsKey(type)) {
-                        TrackedComponentTypes.Add(type, new List<Type>());
+                    if (!TrackedComponentTypes.TryGetValue(type, out List<Type> value)) {
+                        value = new List<Type>();
+                        TrackedComponentTypes.Add(type, value);
                     }
-                    TrackedComponentTypes[type].AddRange(TrackedComponentTypes.TryGetValue(type, out List<Type> list) ? list : new List<Type>());
-                    TrackedComponentTypes[type] = TrackedComponentTypes[type].Distinct().ToList();
+                    value.AddRange(TrackedComponentTypes.TryGetValue(type, out List<Type> list) ? list : new List<Type>());
+                    TrackedComponentTypes[type] = value.Distinct().ToList();
                 }
                 foreach(Type subtype in subtypes) {
                     if (!subtype.IsAbstract) {
-                        if (!TrackedComponentTypes.ContainsKey(subtype))
-                            TrackedComponentTypes.Add(subtype, new List<Type>());
-                        TrackedComponentTypes[subtype].AddRange(TrackedComponentTypes.TryGetValue(type, out List<Type> list) ? list : new List<Type>());
-                        TrackedComponentTypes[subtype] = TrackedComponentTypes[subtype].Distinct().ToList();
+                        if (!TrackedComponentTypes.TryGetValue(subtype, out List<Type> value)) {
+                            value = new List<Type>();
+                            TrackedComponentTypes.Add(subtype, value);
+                        }
+                        value.AddRange(TrackedComponentTypes.TryGetValue(type, out List<Type> list) ? list : new List<Type>());
+                        TrackedComponentTypes[subtype] = value.Distinct().ToList();
                     }
                 }
             }
             else {
                 throw new Exception("Type '" + type.Name + "' cannot be TrackedAs because it does not derive from Entity or Component");
             }
+            RefreshTracker(type);
         }
 
         public static void RefreshTracker(Type type) {
@@ -199,12 +206,12 @@ namespace Monocle {
                 }
             }
             RefreshTrackerLists();
-            }
+        }
 
         private static void RefreshTrackerLists() {
             foreach (Entity entity in Engine.Scene.Entities) {
                 foreach (Component component in entity.Components) {
-                Type componentType = component.GetType();
+                    Type componentType = component.GetType();
                     if (!TrackedComponentTypes.TryGetValue(componentType, out List<Type> componentTypes)) {
                         continue;
                     }

--- a/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
@@ -146,6 +146,7 @@ namespace Monocle {
         /// Must be called if a type is added to the tracker manually and if the active scene changes.
         /// If called back to back without a type added to the Tracker, it won't go through again, for performance.
         /// <paramref name="force"/> will make ensure the Refresh happens, even if run back to back.
+        /// Due to only the active Scene's Tracker's refreshed state is changed, <paramref name="force"/> must be true if a different scene becomes active.
         /// </summary>
         public void Refresh(bool force = false) {
             if (!Unrefreshed && !force) {

--- a/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
@@ -137,15 +137,19 @@ namespace Monocle {
             }
         }
 
-        public static void RefreshTracker() {
+        /// <summary>
+        /// Ensures the current scene's tracker contains all entities of all tracked Types.
+        /// Must be called if a type is added to the tracker manually and if the active scene changes.
+        /// </summary>
+        public void Refresh() {
             foreach (Type entityType in StoredEntityTypes) {
-                if (!Engine.Scene.Tracker.Entities.ContainsKey(entityType)) {
-                    Engine.Scene.Tracker.Entities.Add(entityType, new List<Entity>());
+                if (!Entities.ContainsKey(entityType)) {
+                    Entities.Add(entityType, new List<Entity>());
                 }
             }
             foreach (Type componentType in StoredComponentTypes) {
-                if (!Engine.Scene.Tracker.Components.ContainsKey(componentType)) {
-                    Engine.Scene.Tracker.Components.Add(componentType, new List<Component>());
+                if (!Components.ContainsKey(componentType)) {
+                    Components.Add(componentType, new List<Component>());
                 }
             }
             RefreshTrackerLists();

--- a/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
@@ -188,7 +188,7 @@ namespace Monocle {
             else if (typeof(Component).IsAssignableFrom(type) && !Engine.Scene.Tracker.Components.ContainsKey(type)) {
                 Engine.Scene.Tracker.Components.Add(type, new List<Component>());
             } else {
-                throw new Exception("Type '" + type.Name + "' cannot be TrackedAs because it does not derive from Entity or Component");
+                throw new Exception("Type '" + type.Name + "' does not derive from Entity or Component");
             }
             RefreshTrackerLists();
         }

--- a/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
@@ -40,13 +40,24 @@ namespace Monocle {
 
         private static Type[] GetAllTypesUncached() => FakeAssembly.GetFakeEntryAssembly().GetTypesSafe();
 
-        private bool Unrefreshed;
-        
+        //can it overflow?
+        public static int TrackedTypeVersion;
+
+        private int currentVersion;
+
+        public extern void orig_ctor();
+
+        [MonoModConstructor]
+        public void ctor() {
+            orig_ctor();
+            currentVersion = TrackedTypeVersion;
+        }
+
         [MonoModReplace]
         private static List<Type> GetSubclasses(Type type) {
             bool shouldNullOutCache = _temporaryAllTypes is null;
             _temporaryAllTypes ??= GetAllTypesUncached();
-            
+
             List<Type> subclasses = new();
             foreach (Type otherType in _temporaryAllTypes) {
                 if (type != otherType && type.IsAssignableFrom(otherType))
@@ -57,14 +68,14 @@ namespace Monocle {
             // Let's do that now instead.
             if (shouldNullOutCache)
                 _temporaryAllTypes = null;
-            
+
             return subclasses;
         }
 
         public static extern void orig_Initialize();
         public new static void Initialize() {
             _temporaryAllTypes = GetAllTypesUncached();
-            
+
             orig_Initialize();
 
             // search for entities with [TrackedAs]
@@ -75,8 +86,6 @@ namespace Monocle {
                     AddTypeToTracker(type, trackedAs.TrackedAsType, trackedAs.Inherited);
                 }
             }
-            (Engine.Scene.Tracker as patch_Tracker).Unrefreshed = false;
-
             // don't hold references to all the types anymore
             _temporaryAllTypes = null;
         }
@@ -86,13 +95,13 @@ namespace Monocle {
         }
 
         public static void AddTypeToTracker(Type type, Type trackedAs = null, params Type[] subtypes) {
-            (Engine.Scene.Tracker as patch_Tracker).Unrefreshed = true;
             Type trackedAsType = trackedAs != null && trackedAs.IsAssignableFrom(type) ? trackedAs : type;
             bool? trackedEntity = typeof(Entity).IsAssignableFrom(type) ? true : typeof(Component).IsAssignableFrom(type) ? false : null;
             if (trackedEntity == null) {
                 // this is neither an entity nor a component. Help!
                 throw new Exception("Type '" + type.Name + "' cannot be Tracked" + (trackedAsType != type ? "As" : "") + " because it does not derive from Entity or Component");
             }
+            bool updated = false;
             // copy the registered types for the target type
             ((bool) trackedEntity ? StoredEntityTypes : StoredComponentTypes).Add(type);
             Dictionary<Type, List<Type>> tracked = (bool) trackedEntity ? TrackedEntityTypes : TrackedComponentTypes;
@@ -101,8 +110,13 @@ namespace Monocle {
                     value = new List<Type>();
                     tracked.Add(type, value);
                 }
+                int cnt = value.Count;
                 value.AddRange(tracked.TryGetValue(trackedAsType, out List<Type> list) ? list : new List<Type>());
-                tracked[type] = value.Distinct().ToList();
+                var result = value.Distinct().ToList();
+                tracked[type] = result;
+                if (cnt != result.Count) {
+                    updated = true;
+                }
             }
             // do the same for subclasses
             foreach (Type subtype in subtypes) {
@@ -111,9 +125,17 @@ namespace Monocle {
                         value = new List<Type>();
                         tracked.Add(subtype, value);
                     }
+                    int cnt = value.Count;
                     value.AddRange(tracked.TryGetValue(trackedAsType, out List<Type> list) ? list : new List<Type>());
-                    tracked[subtype] = value.Distinct().ToList();
+                    var result = value.Distinct().ToList();
+                    tracked[subtype] = result;
+                    if (cnt != result.Count) {
+                        updated = true;
+                    }
                 }
+            }
+            if (updated) {
+                TrackedTypeVersion++;
             }
         }
 
@@ -125,10 +147,10 @@ namespace Monocle {
         /// Due to only the active Scene's Tracker's refreshed state is changed, <paramref name="force"/> must be true if a different scene becomes active.
         /// </summary>
         public void Refresh(bool force = false) {
-            if (!Unrefreshed && !force) {
+            if (currentVersion == TrackedTypeVersion && !force) {
                 return;
             }
-            Unrefreshed = false;
+            currentVersion = TrackedTypeVersion;
             foreach (Type entityType in StoredEntityTypes) {
                 if (!Entities.ContainsKey(entityType)) {
                     Entities.Add(entityType, new List<Entity>());

--- a/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
@@ -123,5 +123,52 @@ namespace Monocle {
             // don't hold references to all the types anymore
             _temporaryAllTypes = null;
         }
+
+        public static void AddEntityToTracker(Type type, params Type[] subTypes) {
+            StoredEntityTypes.Add(type);
+            if (!TrackedEntityTypes.TryGetValue(type, out List<Type> value)) {
+                TrackedEntityTypes[type] = new List<Type> { type };
+            } else if (!value.Contains(type)) {
+                value.Add(type);
+            }
+            foreach (Type subType in subTypes) {
+                if (!TrackedEntityTypes.TryGetValue(subType, out List<Type> subvalue)) {
+                    TrackedEntityTypes[subType] = new List<Type> { type };
+                } else if (!subvalue.Contains(type)) {
+                    subvalue.Add(type);
+                }
+            }
+            Dictionary<Type, List<Entity>> entities = Engine.Scene?.Tracker.Entities;
+            if (entities != null && !entities.ContainsKey(type)) {
+                entities[type] = Engine.Scene.Entities.Where((Entity e) => e.GetType() == type).ToList();
+            }
+        }
+
+        public static void AddComponentToTracker(Type type, params Type[] subTypes) {
+            StoredComponentTypes.Add(type);
+            if (!TrackedComponentTypes.TryGetValue(type, out List<Type> value)) {
+                TrackedComponentTypes[type] = new List<Type> { type };
+            } else if (!value.Contains(type)) {
+                value.Add(type);
+            }
+            foreach (Type subType in subTypes) {
+                if (!TrackedComponentTypes.TryGetValue(subType, out List<Type> subvalue)) {
+                    TrackedComponentTypes[subType] = new List<Type> { type };
+                } else if (!subvalue.Contains(type)) {
+                    subvalue.Add(type);
+                }
+            }
+            Dictionary<Type, List<Component>> components = Engine.Scene?.Tracker.Components;
+            if (components != null && !components.ContainsKey(type)) {
+                List<Component> list = new List<Component>();
+                foreach (Entity entity in Engine.Scene.Entities) {
+                    Component component = entity.Components.FirstOrDefault((c) => c.GetType() == type);
+                    if (component != null) {
+                        list.Add(component);
+                    }
+                }
+                components[type] = list;
+            }
+        }
     }
 }

--- a/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
@@ -140,6 +140,7 @@ namespace Monocle {
         /// If called back to back without a type added to the Tracker, it won't go through again, for performance.
         /// <paramref name="force"/> will make ensure the Refresh happens, even if run back to back.
         /// Only the <paramref name="toUpdate"/>'s Tracker's refreshed state is changed.
+        /// If <paramref name="toUpdate"/> is null, it will default to Engine.Scene.
         /// </summary>
         public static void Refresh(Scene toUpdate = null, bool force = false) {
             Scene scene = toUpdate ?? Engine.Scene;

--- a/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
@@ -135,45 +135,46 @@ namespace Monocle {
         }
 
         /// <summary>
-        /// Ensures the current scene's tracker contains all entities of all tracked Types.
-        /// Must be called if a type is added to the tracker manually and if the active scene changes.
+        /// Ensures the <paramref name="scene"/>'s tracker contains all entities of all tracked Types from the <paramref name="scene"/>.
+        /// Must be called if a type is added to the tracker manually and if the <paramref name="scene"/>'s Tracker isn't refreshed.
         /// If called back to back without a type added to the Tracker, it won't go through again, for performance.
         /// <paramref name="force"/> will make ensure the Refresh happens, even if run back to back.
-        /// Due to only the active Scene's Tracker's refreshed state is changed, <paramref name="force"/> must be true if a different scene becomes active.
+        /// Only the <paramref name="scene"/>'s Tracker's refreshed state is changed.
         /// </summary>
-        public void Refresh(bool force = false) {
-            if (currentVersion >= TrackedTypeVersion && !force) {
+        public static void Refresh(Scene scene = null, bool force = false) {
+            scene ??= Engine.Scene;
+            if ((scene.Tracker as patch_Tracker).currentVersion >= TrackedTypeVersion && !force) {
                 return;
             }
-            currentVersion = TrackedTypeVersion;
+            (scene.Tracker as patch_Tracker).currentVersion = TrackedTypeVersion;
             foreach (Type entityType in StoredEntityTypes) {
-                if (!Entities.ContainsKey(entityType)) {
-                    Entities.Add(entityType, new List<Entity>());
+                if (!scene.Tracker.Entities.ContainsKey(entityType)) {
+                    scene.Tracker.Entities.Add(entityType, new List<Entity>());
                 }
             }
             foreach (Type componentType in StoredComponentTypes) {
-                if (!Components.ContainsKey(componentType)) {
-                    Components.Add(componentType, new List<Component>());
+                if (!scene.Tracker.Components.ContainsKey(componentType)) {
+                    scene.Tracker.Components.Add(componentType, new List<Component>());
                 }
             }
-            foreach (Entity entity in Engine.Scene.Entities) {
+            foreach (Entity entity in scene.Entities) {
                 foreach (Component component in entity.Components) {
                     Type componentType = component.GetType();
                     if (!TrackedComponentTypes.TryGetValue(componentType, out List<Type> componentTypes)
-                        || Components[componentType].Contains(component)) {
+                        || scene.Tracker.Components[componentType].Contains(component)) {
                         continue;
                     }
                     foreach (Type trackedType in componentTypes) {
-                        Components[trackedType].Add(component);
+                        scene.Tracker.Components[trackedType].Add(component);
                     }
                 }
                 Type entityType = entity.GetType();
                 if (!TrackedEntityTypes.TryGetValue(entityType, out List<Type> entityTypes)
-                    || Entities[entityType].Contains(entity)) {
+                    || scene.Tracker.Entities[entityType].Contains(entity)) {
                     continue;
                 }
                 foreach (Type trackedType in entityTypes) {
-                    Entities[trackedType].Add(entity);
+                    scene.Tracker.Entities[trackedType].Add(entity);
                 }
             }
         }

--- a/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
@@ -135,14 +135,14 @@ namespace Monocle {
         }
 
         /// <summary>
-        /// Ensures the <paramref name="scene"/>'s tracker contains all entities of all tracked Types from the <paramref name="scene"/>.
-        /// Must be called if a type is added to the tracker manually and if the <paramref name="scene"/>'s Tracker isn't refreshed.
+        /// Ensures the <paramref name="toUpdate"/>'s tracker contains all entities of all tracked Types from the <paramref name="toUpdate"/>.
+        /// Must be called if a type is added to the tracker manually and if the <paramref name="toUpdate"/>'s Tracker isn't refreshed.
         /// If called back to back without a type added to the Tracker, it won't go through again, for performance.
         /// <paramref name="force"/> will make ensure the Refresh happens, even if run back to back.
-        /// Only the <paramref name="scene"/>'s Tracker's refreshed state is changed.
+        /// Only the <paramref name="toUpdate"/>'s Tracker's refreshed state is changed.
         /// </summary>
-        public static void Refresh(Scene scene = null, bool force = false) {
-            scene ??= Engine.Scene;
+        public static void Refresh(Scene toUpdate = null, bool force = false) {
+            Scene scene = toUpdate ?? Engine.Scene;
             if ((scene.Tracker as patch_Tracker).currentVersion >= TrackedTypeVersion && !force) {
                 return;
             }

--- a/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
@@ -40,9 +40,14 @@ namespace Monocle {
 
         private static Type[] GetAllTypesUncached() => FakeAssembly.GetFakeEntryAssembly().GetTypesSafe();
 
-        //can it overflow?
+        /// <summary>
+        /// Represents the amount of Types added by external callers to the Tracked Types
+        /// </summary>
         public static int TrackedTypeVersion;
 
+        /// <summary>
+        /// Represents the amount of Types currently added to the tracker from Types added externally
+        /// </summary>
         private int currentVersion;
 
         public extern void orig_ctor();
@@ -79,6 +84,7 @@ namespace Monocle {
             orig_Initialize();
 
             // search for entities with [TrackedAs]
+            int oldVersion = TrackedTypeVersion;
             foreach (Type type in _temporaryAllTypes) {
                 object[] customAttributes = type.GetCustomAttributes(typeof(TrackedAsAttribute), inherit: false);
                 foreach (object customAttribute in customAttributes) {
@@ -86,6 +92,7 @@ namespace Monocle {
                     AddTypeToTracker(type, trackedAs.TrackedAsType, trackedAs.Inherited);
                 }
             }
+            TrackedTypeVersion = oldVersion;
             // don't hold references to all the types anymore
             _temporaryAllTypes = null;
         }

--- a/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
@@ -40,14 +40,8 @@ namespace Monocle {
 
         private static Type[] GetAllTypesUncached() => FakeAssembly.GetFakeEntryAssembly().GetTypesSafe();
 
-        /// <summary>
-        /// Represents the amount of Types added by external callers to the Tracked Types
-        /// </summary>
-        public static int TrackedTypeVersion;
+        private static int TrackedTypeVersion;
 
-        /// <summary>
-        /// Represents the amount of Types currently added to the tracker from Types added externally
-        /// </summary>
         private int currentVersion;
 
         public extern void orig_ctor();

--- a/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
@@ -112,11 +112,8 @@ namespace Monocle {
                 }
                 int cnt = value.Count;
                 value.AddRange(tracked.TryGetValue(trackedAsType, out List<Type> list) ? list : new List<Type>());
-                var result = value.Distinct().ToList();
-                tracked[type] = result;
-                if (cnt != result.Count) {
-                    updated = true;
-                }
+                List<Type> result = tracked[type] = value.Distinct().ToList();
+                updated = cnt != result.Count;
             }
             // do the same for subclasses
             foreach (Type subtype in subtypes) {
@@ -127,11 +124,8 @@ namespace Monocle {
                     }
                     int cnt = value.Count;
                     value.AddRange(tracked.TryGetValue(trackedAsType, out List<Type> list) ? list : new List<Type>());
-                    var result = value.Distinct().ToList();
-                    tracked[subtype] = result;
-                    if (cnt != result.Count) {
-                        updated = true;
-                    }
+                    List<Type> result = tracked[subtype] = value.Distinct().ToList();
+                    updated = cnt != result.Count;
                 }
             }
             if (updated) {
@@ -147,7 +141,7 @@ namespace Monocle {
         /// Due to only the active Scene's Tracker's refreshed state is changed, <paramref name="force"/> must be true if a different scene becomes active.
         /// </summary>
         public void Refresh(bool force = false) {
-            if (currentVersion == TrackedTypeVersion && !force) {
+            if (currentVersion >= TrackedTypeVersion && !force) {
                 return;
             }
             currentVersion = TrackedTypeVersion;


### PR DESCRIPTION
While making this to fulfill an idea for a single part of my mod, I instead generalized the idea and made it in such a way that having it in Everest would be useful for anyone.

The 2 components added, EntityCollider and EntityColliderByComponent, work in the same way a PlayerCollider or PufferCollider work in vanilla, except they are made so they can instead collide with any entity as defined with the generic type parameter. Entity Collider collides based on Entity, EntityColliderByComponent collides based on if an entity has the component of type.

Additionally, two methods were added to patch_Tracker: AddEntityToTracker and AddColliderToTracker. This allows for any type that is not normally tracked to become tracked and have its entities added to the Tracker. This is done in conjunction to the Entity Colliders due to performance, so it's not required to look through the Scene's Entities every single Update call. Some entities, like Springs, aren't tracked, but are a good candidate for something you'd want to collide with. This is why these methods were made. If anyone thinks this can be unsafe, anyone can find any entity anyways by going through Scene.Entities, so it does not add any vulnerability to normally untracked entities.