### PR TITLE
Clarify `OnLoadLevel` and `OnLoadingThread` events' docs

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Events.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Events.cs
@@ -98,7 +98,7 @@ namespace Celeste.Mod {
                 public delegate void LoadingThreadHandler(_Level level);
                 /// <summary>
                 /// Called at the end of the map loading thread, <see cref="_LevelLoader.LoadingThread()"/>.<br/>
-                /// This event is invoked <b>only once</b>, when entering a map.
+                /// This event is invoked <b>only once</b>, when entering a map from the chapter select screen or from Save and Quit.
                 /// </summary>
                 /// <seealso cref="Level.OnLoadLevel"/>
                 public static event LoadingThreadHandler OnLoadingThread;

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Events.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Events.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using _Decal = Celeste.Decal;
 using _EventTrigger = Celeste.EventTrigger;
+using _LevelLoader = Celeste.LevelLoader;
 using _Level = Celeste.Level;
 using _Session = Celeste.Session;
 using _OuiJournal = Celeste.OuiJournal;
@@ -96,8 +97,10 @@ namespace Celeste.Mod {
             public static class LevelLoader {
                 public delegate void LoadingThreadHandler(_Level level);
                 /// <summary>
-                /// Called at the end of the map loading thread.
+                /// Called at the end of the map loading thread, <see cref="_LevelLoader.LoadingThread()"/>.<br/>
+                /// This event is invoked <b>only once</b>, when entering a map.
                 /// </summary>
+                /// <seealso cref="Level.OnLoadLevel"/>
                 public static event LoadingThreadHandler OnLoadingThread;
                 internal static void LoadingThread(_Level level)
                     => OnLoadingThread?.Invoke(level);
@@ -161,6 +164,11 @@ namespace Celeste.Mod {
                     => OnLoadBackdrop?.InvokeWhileNull<Backdrop>(map, child, above);
 
                 public delegate void LoadLevelHandler(_Level level, _Player.IntroTypes playerIntro, bool isFromLoader);
+                /// <summary>
+                /// Called after <see cref="_Level.LoadLevel"/>.<br/>
+                /// This event is invoked <b>every time</b> a room is entered - transition, respawn, teleport, etc.
+                /// </summary>
+                /// <seealso cref="LevelLoader.OnLoadingThread"/>
                 public static event LoadLevelHandler OnLoadLevel;
                 internal static void LoadLevel(_Level level, _Player.IntroTypes playerIntro, bool isFromLoader)
                     => OnLoadLevel?.Invoke(level, playerIntro, isFromLoader);


### PR DESCRIPTION
This PR will clarify the difference between `Everest.Events.Level.OnLoadLevel` and `Everest.Events.LevelLoader.OnLoadingThread`.

![OnLoadLevel rendered XML docs](https://github.com/user-attachments/assets/4d7d956f-1b42-4616-bad1-ce0cb4f9fe75)

![OnLoadingThread rendered XML docs](https://github.com/user-attachments/assets/f9295c02-87d3-4ebf-9947-ce08403943ab)
