### PR TITLE
Allow modded Ouis to specify if they play custom mountain music

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
@@ -777,11 +777,7 @@ namespace Celeste.Mod {
                     // we already are in the overworld. Register new Ouis real quick!
                     if (Engine.Instance != null && Engine.Scene is Overworld overworld && typeof(Oui).IsAssignableFrom(type) && !type.IsAbstract) {
                         Logger.Verbose("core", $"Instantiating UI from {meta}: {type.FullName}");
-
-                        Oui oui = (Oui) Activator.CreateInstance(type);
-                        oui.Visible = false;
-                        overworld.Add(oui);
-                        overworld.UIs.Add(oui);
+                        ((patch_Overworld) overworld).RegisterOui(type);
                     }
                 }
                 // We should run the map data processors again if new berry types are registered, so that CoreMapDataProcessor assigns them checkpoint IDs and orders.

--- a/Celeste.Mod.mm/Mod/UI/OuiPropertiesAttribute.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiPropertiesAttribute.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace Celeste.Mod.UI {
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public class OuiPropertiesAttribute : Attribute {
+        /// <summary>
+        /// Whether the mountain music for the current map should play in this menu.
+        /// </summary>
+        public bool PlayCustomMusic { get; }
+
+        /// <summary>
+        /// Configures extra properties for this Oui.
+        /// </summary>
+        /// <param name="playCustomMusic">A list of unique identifiers for this Backdrop.</param>
+        public OuiPropertiesAttribute(bool playCustomMusic = false) {
+            PlayCustomMusic = playCustomMusic;
+        }
+    }
+}

--- a/Celeste.Mod.mm/Patches/Overworld.cs
+++ b/Celeste.Mod.mm/Patches/Overworld.cs
@@ -1,10 +1,18 @@
 ﻿#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
 
+using Celeste;
 using Celeste.Mod;
 using Celeste.Mod.Meta;
 using Celeste.Mod.UI;
+using Mono.Cecil;
 using Monocle;
+using MonoMod;
+using MonoMod.Cil;
+using MonoMod.InlineRT;
+using MonoMod.Utils;
+using System;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace Celeste {
     class patch_Overworld : Overworld {
@@ -13,6 +21,8 @@ namespace Celeste {
 #pragma warning disable CS0649 // variable defined in vanilla
         private Snow3D Snow3D;
 #pragma warning restore CS0649
+
+        public Dictionary<Type, OuiPropertiesAttribute> UIProperties { get; set; }
 
         public patch_Overworld(OverworldLoader loader)
             : base(loader) {
@@ -54,9 +64,7 @@ namespace Celeste {
                     return;
                 }
 
-                if (SaveData.Instance != null && (IsCurrent<OuiChapterSelect>() || IsCurrent<OuiChapterPanel>()
-                    || IsCurrent<OuiMapList>() || IsCurrent<OuiMapSearch>() || IsCurrent<OuiJournal>())) {
-
+                if (SaveData.Instance != null && IsCurrent(o => UIProperties?.GetValueOrDefault(o.GetType())?.PlayCustomMusic ?? false)) {
                     string backgroundMusic = mountainMetadata?.BackgroundMusic;
                     string backgroundAmbience = mountainMetadata?.BackgroundAmbience;
                     if (backgroundMusic != null || backgroundAmbience != null) {
@@ -78,6 +86,35 @@ namespace Celeste {
                 }
             }
         }
+
+        public bool IsCurrent(Func<Oui, bool> predicate) {
+            if (Current != null) {
+                return predicate(Current);
+            }
+            return predicate(Last);
+        }
+
+        public Oui RegisterOui(Type type) {
+            Oui oui = (Oui) Activator.CreateInstance(type);
+            oui.Visible = false;
+            Add(oui);
+            UIs.Add(oui);
+            UIProperties ??= new() {
+                { typeof(OuiChapterSelect), new(true) },
+                { typeof(OuiChapterPanel), new(true) },
+                { typeof(OuiMapList), new(true) },
+                { typeof(OuiMapSearch), new(true) },
+                { typeof(OuiJournal), new(true) }
+            };
+            foreach (OuiPropertiesAttribute attrib in type.GetCustomAttributes<OuiPropertiesAttribute>()) {
+                UIProperties[type] = attrib;
+            }
+            return oui;
+        }
+
+        [MonoModIgnore]
+        [PatchOverworldRegisterOui]
+        public new extern void ReloadMenus(StartMode startMode = StartMode.Titlescreen);
 
         public extern void orig_ReloadMountainStuff();
         public new void ReloadMountainStuff() {
@@ -105,6 +142,41 @@ namespace Celeste {
                 SetNormalMusic();
                 customizedChapterSelectMusic = false;
             }
+        }
+    }
+}
+
+namespace MonoMod {
+    /// <summary>
+    /// Adjust the Overworld.ReloadMenus method to use the RegisterOui function, rather than registering manually
+    /// </summary>
+    [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchOverworldRegisterOuiFunction))]
+    class PatchOverworldRegisterOuiAttribute : Attribute { }
+
+    static partial class MonoModRules {
+        public static void PatchOverworldRegisterOuiFunction(ILContext il, CustomAttribute attrib) {
+            MethodDefinition registerOuiMethod = MonoModRule.Modder.Module.GetType("Celeste.Overworld").FindMethod(nameof(patch_Overworld.RegisterOui));
+            //MethodInfo registerOuiMethod = typeof(patch_Overworld).GetMethod(nameof(patch_Overworld.RegisterOui));
+            
+            ILCursor c = new(il);
+            c.GotoNext(MoveType.Before,
+                instr => instr.MatchLdloc(4),
+                instr => instr.MatchCall("System.Activator", nameof(Activator.CreateInstance)));
+            // We have Oui oui = (Oui)Activator.CreateInstance(type);
+            // Replace the right side of the equals with our register function
+
+            // this.
+            c.EmitLdarg0();
+            // Skip past `type` argument
+            c.GotoNext().GotoNext();
+            c.Remove();
+            c.Remove();
+            // RegisterOui()
+            c.EmitCall(registerOuiMethod);
+            // Skip past the "Oui oui ="
+            c.GotoNext().GotoNext();
+            // The next 10 instructions are already present in RegisterOui and can be removed
+            c.RemoveRange(10);
         }
     }
 }


### PR DESCRIPTION
Adds an attribute that classes extending Oui can use to specify some extra config information. Currently this is only specify if custom mountain music plays there. The old behavior hardcodes a couple of vanilla/Everest Ouis.