### PR TITLE
Force NoInlining on PlayerSprite.ClearFramesMetadata

### DIFF
--- a/Celeste.Mod.mm/MonoModRules.cs
+++ b/Celeste.Mod.mm/MonoModRules.cs
@@ -36,7 +36,13 @@ namespace MonoMod {
     /// </summary>
     [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchInitblk))]
     class PatchInitblkAttribute : Attribute { }
-#endregion
+
+    /// <summary>
+    /// Forces NoInlining onto a given member.
+    /// </summary>
+    [MonoModCustomMethodAttribute(nameof(MonoModRules.ForceNoInlining))]
+    class ForceNoInliningAttribute : Attribute { }
+    #endregion
 
     static partial class MonoModRules {
 
@@ -218,6 +224,10 @@ namespace MonoMod {
             if (!match) {
                 throw new Exception("No call to _initblk found in " + il.Method.FullName + "!");
             }
+        }
+
+        public static void ForceNoInlining(MethodDefinition method, CustomAttribute attrib) {
+            method.NoInlining = true;
         }
 
         /// <summary>

--- a/Celeste.Mod.mm/Patches/PlayerSprite.cs
+++ b/Celeste.Mod.mm/Patches/PlayerSprite.cs
@@ -1,0 +1,17 @@
+﻿using Celeste;
+using Mono.Cecil;
+using MonoMod;
+using System;
+
+namespace Celeste {
+    public class patch_PlayerSprite : PlayerSprite {
+
+        public patch_PlayerSprite(PlayerSpriteMode mode) : base(mode) {
+            // Do nothing here. MonoMod will ignore this.
+        }
+
+        [MonoModIgnore]
+        [ForceNoInlining]
+        public new extern static void ClearFramesMetadata();
+    }
+}


### PR DESCRIPTION
Applies `[MethodImpl(MethodImplOptions.NoInlining)]` onto `PlayerSprite.ClearFramesMetadata`, so that it can be used by any hooks.