### PR TITLE
Added String method for non-empty string values

### DIFF
--- a/Celeste.Mod.mm/Patches/EntityData.cs
+++ b/Celeste.Mod.mm/Patches/EntityData.cs
@@ -21,8 +21,8 @@ namespace Celeste {
         /// <returns></returns>
         public string String(string key, string defaultValue = null) {
             if (Values != null && Values.TryGetValue(key, out object value)
-                && value is string val && val.Trim().Length > 0) {
-                    return val;
+                && value != null && value.ToString().Trim().Length > 0) {
+                    return value.ToString();
             }
             return defaultValue;
         }

--- a/Celeste.Mod.mm/Patches/EntityData.cs
+++ b/Celeste.Mod.mm/Patches/EntityData.cs
@@ -21,7 +21,7 @@ namespace Celeste {
         /// <returns></returns>
         public string String(string key, string defaultValue = null) {
             string valueStr;
-            if (Values != null && Values.TryGetValue(key, out object value) && !string.IsNullOrEmpty(valueStr = value?.ToString())) {
+            if (Values != null && Values.TryGetValue(key, out object value) && !string.IsNullOrWhiteSpace(valueStr = value?.ToString())) {
                     return valueStr;
             }
             return defaultValue;

--- a/Celeste.Mod.mm/Patches/EntityData.cs
+++ b/Celeste.Mod.mm/Patches/EntityData.cs
@@ -21,7 +21,7 @@ namespace Celeste {
         /// <returns></returns>
         public string String(string key, string defaultValue = null) {
             if (Values != null && Values.TryGetValue(key, out object value)
-                && value is string val && !string.IsNullOrWhiteSpace(val)) {
+                && value is string val && val.Trim().Length > 0) {
                     return val;
             }
             return defaultValue;

--- a/Celeste.Mod.mm/Patches/EntityData.cs
+++ b/Celeste.Mod.mm/Patches/EntityData.cs
@@ -20,8 +20,7 @@ namespace Celeste {
         /// <param name="defaultValue"></param>
         /// <returns></returns>
         public string String(string key, string defaultValue = null) {
-            if (Values != null && Values.TryGetValue(key, out object value)
-                && value != null && value.ToString().Trim().Length > 0) {
+            if (Values != null && Values.TryGetValue(key, out object value) && !string.IsNullOrEmpty(value?.ToString())) {
                     return value.ToString();
             }
             return defaultValue;

--- a/Celeste.Mod.mm/Patches/EntityData.cs
+++ b/Celeste.Mod.mm/Patches/EntityData.cs
@@ -20,8 +20,9 @@ namespace Celeste {
         /// <param name="defaultValue"></param>
         /// <returns></returns>
         public string String(string key, string defaultValue = null) {
-            if (Values != null && Values.TryGetValue(key, out object value) && !string.IsNullOrEmpty(value?.ToString())) {
-                    return value.ToString();
+            string valueStr;
+            if (Values != null && Values.TryGetValue(key, out object value) && !string.IsNullOrEmpty(valueStr = value?.ToString())) {
+                    return valueStr;
             }
             return defaultValue;
         }

--- a/Celeste.Mod.mm/Patches/EntityData.cs
+++ b/Celeste.Mod.mm/Patches/EntityData.cs
@@ -20,9 +20,9 @@ namespace Celeste {
         /// <param name="defaultValue"></param>
         /// <returns></returns>
         public string String(string key, string defaultValue = null) {
-            if (Values != null && Values.TryGetValue(key, out object value)) {
-                if (!string.IsNullOrWhiteSpace((string) value))
-                    return value.ToString();
+            if (Values != null && Values.TryGetValue(key, out object value)
+                && value is string val && !string.IsNullOrWhiteSpace(val)) {
+                    return val;
             }
             return defaultValue;
         }

--- a/Celeste.Mod.mm/Patches/EntityData.cs
+++ b/Celeste.Mod.mm/Patches/EntityData.cs
@@ -12,5 +12,19 @@ namespace Celeste {
             return orig_Has(key);
         }
 
+        /// <summary>
+        /// Get the <see cref="T:System.String" /> value associated with a key.
+        /// An Empty or pure Whitespace value will result in the <paramref name="defaultValue"/> to be returned.
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="defaultValue"></param>
+        /// <returns></returns>
+        public string String(string key, string defaultValue = null) {
+            if (Values != null && Values.TryGetValue(key, out object value)) {
+                if (!string.IsNullOrWhiteSpace((string) value))
+                    return value.ToString();
+            }
+            return defaultValue;
+        }
     }
 }


### PR DESCRIPTION
Entity Data objects when getting values out can be a little finicky when trying to get a pure string value out, especially if the value is an empty string. 

It is useful to have this method for one-line assignments for such cases where a string that isn't set is empty, but the Attr method would still return that empty string instead of using the default value