### PR TITLE
Log warnings on unintended extensions

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Content.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Content.cs
@@ -725,108 +725,316 @@ namespace Celeste.Mod {
             public static string GuessType(string file, out Type type, out string format) {
                 type = typeof(object);
                 format = Path.GetExtension(file) ?? "";
-                if (format.Length >= 1)
-                    format = format.Substring(1);
 
-                // Assign game asset types
-                if (format == "dll") {
+                if (format.Length < 1)
+                    return file;
+
+                format = format[1..];
+
+                ReadOnlySpan<char> fileSpan = file.AsSpan();
+                int fileSeparator = fileSpan.LastIndexOf('/') + 1;
+
+                // folder with / at the end
+                ReadOnlySpan<char> directorySpan = fileSpan[..fileSeparator]; // don't use Path.GetDirectoryName as it replaces '/' with '\' :catplush:
+                // file
+                ReadOnlySpan<char> fileNameSpan = fileSpan[fileSeparator..];
+                // file without extension
+                ReadOnlySpan<char> fileNameOnlySpan = Path.GetFileNameWithoutExtension(fileNameSpan);
+
+                bool shouldSendWarning = true;
+
+                if (MatchExtension(fileNameSpan, "dll", ref shouldSendWarning)) {
                     type = typeof(AssetTypeAssembly);
+                    return fileSpan.ToString();
+                }
 
-                } else if (format == "png") {
+                if (MatchExtension(fileNameSpan, "png", ref shouldSendWarning)) {
                     type = typeof(Texture2D);
-                    file = file.Substring(0, file.Length - 4);
+                    return fileSpan[..^4].ToString();
+                }
 
-                } else if (format == "obj") {
+                if (MatchExtension(fileNameSpan, "obj", ref shouldSendWarning, isTextBased: true)) {
                     type = typeof(ObjModel);
-                    file = file.Substring(0, file.Length - 4);
+                    return fileSpan[..^4].ToString();
+                }
 
-                } else if (file.EndsWith(".obj.export")) {
+                if (MatchExtension(fileNameSpan, "obj.export", ref shouldSendWarning)) {
                     type = typeof(AssetTypeObjModelExport);
-                    file = file.Substring(0, file.Length - 7);
+                    return fileSpan[..^7].ToString();
+                }
 
-                } else if (file == "metadata.yaml" || file == "multimetadata.yaml" || file == "everest.yaml" || file == "everest.yml") {
+                if (MatchExtension(fileNameSpan, "yaml", ref shouldSendWarning, isTextBased: true)
+                    && directorySpan.IsEmpty
+                    && SpanEqualsAny(fileNameOnlySpan, "metadata", "multimetadata", "everest")) {
                     type = typeof(AssetTypeMetadataYaml);
-                    file = file.Substring(0, file.Length - format.Length - 1);
                     format = "yml";
+                    return fileSpan[..^5].ToString();
+                }
 
-                } else if (file == "DecalRegistry.xml") {
-                    type = typeof(AssetTypeDecalRegistry);
-                    file = file.Substring(0, file.Length - 4);
+                if (MatchExtension(fileNameSpan, "yml", ref shouldSendWarning, isTextBased: true)
+                    && directorySpan.IsEmpty
+                    && SpanEquals(fileNameOnlySpan, "everest")) {
+                    type = typeof(AssetTypeMetadataYaml);
+                    return fileSpan[..^4].ToString();
+                }
 
-                } else if (file == "Graphics/Sprites.xml" || file == "Graphics/SpritesGui.xml" || file == "Graphics/Portraits.xml") {
-                    type = typeof(AssetTypeSpriteBank);
-                    file = file.Substring(0, file.Length - 4);
-
-                } else if (file.StartsWith("Dialog/")) {
-                    if (format == "txt") {
-                        type = typeof(AssetTypeDialog);
-                        file = file.Substring(0, file.Length - 4);
-                    } else if (file.EndsWith(".txt.export")) {
-                        type = typeof(AssetTypeDialogExport);
-                        file = file.Substring(0, file.Length - 7);
-                    } else if (format == "fnt") {
-                        type = typeof(AssetTypeFont);
-                        file = file.Substring(0, file.Length - 4);
+                if (MatchExtension(fileNameSpan, "xml", ref shouldSendWarning, isTextBased: true)) {
+                    if (directorySpan.IsEmpty && SpanEquals(fileNameOnlySpan, "DecalRegistry")) {
+                        type = typeof(AssetTypeDecalRegistry);
+                        return fileSpan[..^4].ToString();
                     }
-
-                } else if (file.StartsWith("Maps/") && format == "bin") {
-                    type = typeof(AssetTypeMap);
-                    file = file.Substring(0, file.Length - 4);
-
-                } else if (file.StartsWith("Tutorials/") && format == "bin") {
-                    type = typeof(AssetTypeTutorial);
-                    file = file.Substring(0, file.Length - 4);
-
-                } else if (file.StartsWith("Audio/")) {
-                    if (format == "bank") {
-                        type = typeof(AssetTypeBank);
-                        file = file.Substring(0, file.Length - 5);
-                    } else if (file.EndsWith(".guids.txt")) {
-                        type = typeof(AssetTypeGUIDs);
-                        file = file.Substring(0, file.Length - 4);
-                    } else if (file.EndsWith(".GUIDs.txt")) { // Default FMOD casing
-                        type = typeof(AssetTypeGUIDs);
-                        file = file.Substring(0, file.Length - 4 - 6);
-                        file += ".guids";
+                    if (SpanEquals(directorySpan, "Graphics/") && SpanEqualsAny(fileNameOnlySpan, "Sprites", "SpritesGui", "Portraits")) {
+                        type = typeof(AssetTypeSpriteBank);
+                        return fileSpan[..^4].ToString();
                     }
+                }
 
-                } else if (file == ".everestignore") {
+                if (directorySpan.IsEmpty && fileNameOnlySpan.IsEmpty && MatchExtension(fileNameSpan, "everestignore", ref shouldSendWarning, isTextBased: true)) {
                     type = typeof(AssetTypeEverestIgnore);
-                    file = "";
+                    return "";
+                }
 
-                } else if (OnGuessType != null) {
-                    // Parse custom types from mods
-                    Delegate[] ds = OnGuessType.GetInvocationList();
-                    for (int i = 0; i < ds.Length; i++) {
-                        string fileMod = ((TypeGuesser) ds[i])(file, out Type typeMod, out string formatMod);
+                if (directorySpan.StartsWith("Dialog/")) {
+                    if (MatchExtension(fileNameSpan, "txt", ref shouldSendWarning, isTextBased: true)) {
+                        type = typeof(AssetTypeDialog);
+                        return fileSpan[..^4].ToString();
+                    }
+                    if (MatchMultipartExtension(fileNameSpan, "txt.export", ref shouldSendWarning)) {
+                        type = typeof(AssetTypeDialogExport);
+                        return fileSpan[..^7].ToString();
+                    }
+                    if (MatchExtension(fileNameSpan, "fnt", ref shouldSendWarning, isTextBased: true)) {
+                        type = typeof(AssetTypeFont);
+                        return fileSpan[..^4].ToString();
+                    }
+                }
+
+                if (MatchExtension(fileNameSpan, "bin", ref shouldSendWarning)) {
+                    if (directorySpan.StartsWith("Maps/")) {
+                        type = typeof(AssetTypeMap);
+                        return fileSpan[..^4].ToString();
+                    }
+                    if (directorySpan.StartsWith("Tutorials/")) {
+                        type = typeof(AssetTypeTutorial);
+                        return fileSpan[..^4].ToString();
+                    }
+                }
+
+                if (directorySpan.StartsWith("Audio/")) {
+                    if (MatchExtension(fileNameSpan, "bank", ref shouldSendWarning)) {
+                        type = typeof(AssetTypeBank);
+                        return fileSpan[..^5].ToString();
+                    }
+                    if (MatchMultipartExtension(fileNameSpan, "guids.txt", ref shouldSendWarning, isTextBased: true)) {
+                        type = typeof(AssetTypeGUIDs);
+                        return fileSpan[..^4].ToString();
+                    }
+                    if (MatchMultipartExtension(fileNameSpan, "GUIDs.txt", ref shouldSendWarning, isTextBased: true)) {
+                        // default fmod casing
+                        type = typeof(AssetTypeGUIDs);
+
+                        Span<char> newFileSpan = fileSpan[..^4].ToArray();
+
+                        for (int i = 1; i <= 5; i++)
+                            newFileSpan[^i] = char.ToLower(newFileSpan[^i]);
+
+                        return newFileSpan.ToString();
+                    }
+                }
+
+                if (OnGuessType != null) {
+                    // parse custom types from mods
+                    foreach (Delegate typeGuesser in OnGuessType.GetInvocationList()) {
+                        string fileMod = ((TypeGuesser) typeGuesser)(file, out Type typeMod, out string formatMod);
+
                         if (fileMod == null || typeMod == null || formatMod == null)
                             continue;
+
                         file = fileMod;
                         type = typeMod;
                         format = formatMod;
-                        break;
+
+                        return file;
                     }
                 }
 
-                // Assign supported generic types if we haven't found a more specific one
-                if (type == typeof(object)) {
-                    if (format == "lua") {
-                        type = typeof(AssetTypeLua);
-                        file = file.Substring(0, file.Length - 4);
-                    } else if (format == "txt") {
-                        type = typeof(AssetTypeText);
-                        file = file.Substring(0, file.Length - 4);
-                    } else if (format == "xml") {
-                        type = typeof(AssetTypeXml);
-                        file = file.Substring(0, file.Length - 4);
-                    } else if (format == "yml" || format == "yaml") {
-                        type = typeof(AssetTypeYaml);
-                        file = file.Substring(0, file.Length - format.Length - 1);
-                        format = "yml";
+                // assign supported generic types if we haven't found a more specific one
+                if (MatchExtension(fileNameSpan, "lua", ref shouldSendWarning, isTextBased: true)) {
+                    type = typeof(AssetTypeLua);
+                    return fileSpan[..^4].ToString();
+                }
+                if (MatchExtension(fileNameSpan, "txt", ref shouldSendWarning, isTextBased: true)) {
+                    type = typeof(AssetTypeText);
+                    return fileSpan[..^4].ToString();
+                }
+                if (MatchExtension(fileNameSpan, "xml", ref shouldSendWarning, isTextBased: true)) {
+                    type = typeof(AssetTypeXml);
+                    return fileSpan[..^4].ToString();
+                }
+                if (MatchExtension(fileNameSpan, "yml", ref shouldSendWarning, isTextBased: true)) {
+                    type = typeof(AssetTypeYaml);
+                    return fileSpan[..^4].ToString();
+                }
+                if (MatchExtension(fileNameSpan, "yaml", ref shouldSendWarning, isTextBased: true)) {
+                    type = typeof(AssetTypeYaml);
+                    format = "yml";
+                    return fileSpan[..^5].ToString();
+                }
+
+                return fileSpan.ToString();
+            }
+
+            private static bool SpanEqualsAny(ReadOnlySpan<char> left, params string[] right) {
+                foreach (string expected in right)
+                    if (left.Equals(expected, StringComparison.Ordinal))
+                        return true;
+                return false;
+            }
+
+            private static bool SpanEquals(ReadOnlySpan<char> left, string right)
+                => left.Equals(right, StringComparison.Ordinal);
+
+            /// <summary>
+            ///   Match a file extension, and log a warning if the file extension is duplicated.<br/>
+            ///   If the file is text-based, log a warning if the file has an extra <c>.txt</c> extension.
+            /// </summary>
+            /// <param name="fileName">
+            ///   The file name to check, with the extensions.
+            /// </param>
+            /// <param name="expectedExtension">
+            ///   The extension to check for, without the leading dot.
+            /// </param>
+            /// <param name="shouldSendWarning">
+            ///   Whether a warning should be sent about the file name extension(s).
+            /// </param>
+            /// <param name="isTextBased">
+            ///   Whether the file is text-based, and to check for an extra <c>.txt</c> extension.
+            /// </param>
+            private static bool MatchExtension(
+                ReadOnlySpan<char> fileName,
+                ReadOnlySpan<char> expectedExtension,
+                ref bool shouldSendWarning,
+                bool isTextBased = false)
+            {
+                ReadOnlySpan<char> extension = Path.GetExtension(fileName);
+
+                if (extension.IsEmpty)
+                    return false;
+
+                // remove the leading dot
+                extension = extension[1..];
+
+                if (extension.Equals(expectedExtension, StringComparison.Ordinal)) {
+                    // this is silly, but it works
+                    extension = Path.GetExtension(Path.GetFileNameWithoutExtension(fileName));
+
+                    if (shouldSendWarning && !extension.IsEmpty && extension[1..].Equals(expectedExtension, StringComparison.Ordinal)) {
+                        Logger.Warn("Content", $"\"{fileName}\" has a doubled extension! It may not be handled correctly.");
+                        shouldSendWarning = false;
+                    }
+
+                    return true;
+                }
+
+                if (!shouldSendWarning)
+                    // we don't care anymore if a warning has already been logged
+                    return false;
+
+                if (isTextBased && extension.Equals("txt", StringComparison.Ordinal)) {
+                    extension = Path.GetExtension(Path.GetFileNameWithoutExtension(fileName));
+
+                    if (!extension.IsEmpty && extension[1..].Equals(expectedExtension, StringComparison.Ordinal)) {
+                        Logger.Warn("Content", $"\"{fileName}\" has an extra \".txt\" extension! It may not be handled correctly.");
+                        shouldSendWarning = false;
                     }
                 }
 
-                return file;
+                return false;
+            }
+
+            /// <summary>
+            ///   Match a multipart file extension, and log a warning if the last part of the file extension is duplicated.<br/>
+            ///   If the file is text-based, log a warning if the file has an extra <c>.txt</c> extension.
+            /// </summary>
+            /// <param name="fileName">
+            ///   The file name to check, with the extensions.
+            /// </param>
+            /// <param name="expectedExtension">
+            ///   The multipart extension to check for, without the leading dot.
+            /// </param>
+            /// <param name="shouldSendWarning">
+            ///   Whether a warning should be sent about the file name extension(s).
+            /// </param>
+            /// <param name="isTextBased">
+            ///   Whether the file is text-based, and to check for an extra <c>.txt</c> extension.
+            /// </param>
+            private static bool MatchMultipartExtension(
+                ReadOnlySpan<char> fileName,
+                ReadOnlySpan<char> expectedExtension,
+                ref bool shouldSendWarning,
+                bool isTextBased = false)
+            {
+                // use the simpler function if this is just a singlepart extension
+                if (expectedExtension.IndexOf('.') == -1)
+                    return MatchExtension(fileName, expectedExtension, ref shouldSendWarning, isTextBased);
+
+                // find all indices of '.'
+                List<int> expectedExtensionDotIndices = new List<int>();
+                for (int i = expectedExtension.Length - 1; i >= 0; i--)
+                    if (expectedExtension[i] == '.')
+                        expectedExtensionDotIndices.Add(i);
+
+                List<int> fileNameDotIndices = new List<int>();
+                for (int i = Path.GetFileName(fileName).Length - 1; i >= 0; i--)
+                    if (fileName[i] == '.')
+                        fileNameDotIndices.Add(i);
+
+                if (fileNameDotIndices.Count - expectedExtensionDotIndices.Count < 1)
+                    // the file name doesn't have enough extension parts to match
+                    // fileName must have at least one more dot than expectedExtension
+                    return false;
+
+                // find the dot which would be where the extension should be
+                int expectedExtensionIndex = fileNameDotIndices[expectedExtensionDotIndices.Count];
+
+                // (+1 to remove the leading dot)
+                if (fileName[(expectedExtensionIndex + 1)..].Equals(expectedExtension, StringComparison.Ordinal))
+                    // extensions match perfectly
+                    return true;
+
+                if (!shouldSendWarning)
+                    // we don't care anymore if a warning has already been logged
+                    return false;
+
+                // move past the extra extension and try to match
+                if ((fileNameDotIndices.Count - 1) - expectedExtensionDotIndices.Count < 1)
+                    // there's no more extension parts to check for
+                    return false;
+
+                expectedExtensionIndex = fileNameDotIndices[expectedExtensionDotIndices.Count + 1];
+                int actualExtensionIndex = fileNameDotIndices[0];
+
+                // the intended extension
+                ReadOnlySpan<char> intendedExtension = fileName[(expectedExtensionIndex + 1)..actualExtensionIndex];
+                // the actual extension (so a .txt or a duplicate extension)
+                ReadOnlySpan<char> actualExtension = fileName[(actualExtensionIndex + 1)..];
+                // (+1 to remove the leading dot)
+
+                if (intendedExtension.Equals(expectedExtension, StringComparison.Ordinal)) {
+                    // there's an extra extension at the end - check whether it's a duplicated extension or
+                    // an extra .txt extension if it's a text-based file - but only if we haven't warned about this one yet
+
+                    ReadOnlySpan<char> lastIntendedExtensionPart = expectedExtension[expectedExtensionDotIndices[0]..];
+                    if (actualExtension.Equals(lastIntendedExtensionPart, StringComparison.Ordinal)) {
+                        Logger.Warn("Content", $"\"{fileName}\" has a doubled extension! It may not be handled correctly.");
+                        shouldSendWarning = false;
+                    } else if (actualExtension.Equals("txt", StringComparison.Ordinal)) {
+                        Logger.Warn("Content", $"\"{fileName}\" has an extra \".txt\" extension! It may not be handled correctly.");
+                        shouldSendWarning = false;
+                    }
+                }
+
+                return false;
             }
 
             private static void RecrawlMod(ModContent mod) {

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Content.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Content.cs
@@ -741,29 +741,29 @@ namespace Celeste.Mod {
                 // file without extension
                 ReadOnlySpan<char> fileNameOnlySpan = Path.GetFileNameWithoutExtension(fileNameSpan);
 
-                bool shouldSendWarning = true;
+                bool warningAlreadySent = false;
 
-                if (MatchExtension(fileNameSpan, "dll", ref shouldSendWarning)) {
+                if (MatchExtension(fileSpan, fileNameSpan, "dll", ref warningAlreadySent)) {
                     type = typeof(AssetTypeAssembly);
                     return fileSpan.ToString();
                 }
 
-                if (MatchExtension(fileNameSpan, "png", ref shouldSendWarning)) {
+                if (MatchExtension(fileSpan, fileNameSpan, "png", ref warningAlreadySent)) {
                     type = typeof(Texture2D);
                     return fileSpan[..^4].ToString();
                 }
 
-                if (MatchExtension(fileNameSpan, "obj", ref shouldSendWarning, isTextBased: true)) {
+                if (MatchExtension(fileSpan, fileNameSpan, "obj", ref warningAlreadySent, isTextBased: true)) {
                     type = typeof(ObjModel);
                     return fileSpan[..^4].ToString();
                 }
 
-                if (MatchExtension(fileNameSpan, "obj.export", ref shouldSendWarning)) {
+                if (MatchExtension(fileSpan, fileNameSpan, "obj.export", ref warningAlreadySent)) {
                     type = typeof(AssetTypeObjModelExport);
                     return fileSpan[..^7].ToString();
                 }
 
-                if (MatchExtension(fileNameSpan, "yaml", ref shouldSendWarning, isTextBased: true)
+                if (MatchExtension(fileSpan, fileNameSpan, "yaml", ref warningAlreadySent, isTextBased: true)
                     && directorySpan.IsEmpty
                     && SpanEqualsAny(fileNameOnlySpan, "metadata", "multimetadata", "everest")) {
                     type = typeof(AssetTypeMetadataYaml);
@@ -771,14 +771,14 @@ namespace Celeste.Mod {
                     return fileSpan[..^5].ToString();
                 }
 
-                if (MatchExtension(fileNameSpan, "yml", ref shouldSendWarning, isTextBased: true)
+                if (MatchExtension(fileSpan, fileNameSpan, "yml", ref warningAlreadySent, isTextBased: true)
                     && directorySpan.IsEmpty
                     && SpanEquals(fileNameOnlySpan, "everest")) {
                     type = typeof(AssetTypeMetadataYaml);
                     return fileSpan[..^4].ToString();
                 }
 
-                if (MatchExtension(fileNameSpan, "xml", ref shouldSendWarning, isTextBased: true)) {
+                if (MatchExtension(fileSpan, fileNameSpan, "xml", ref warningAlreadySent, isTextBased: true)) {
                     if (directorySpan.IsEmpty && SpanEquals(fileNameOnlySpan, "DecalRegistry")) {
                         type = typeof(AssetTypeDecalRegistry);
                         return fileSpan[..^4].ToString();
@@ -789,27 +789,27 @@ namespace Celeste.Mod {
                     }
                 }
 
-                if (directorySpan.IsEmpty && fileNameOnlySpan.IsEmpty && MatchExtension(fileNameSpan, "everestignore", ref shouldSendWarning, isTextBased: true)) {
+                if (directorySpan.IsEmpty && fileNameOnlySpan.IsEmpty && MatchExtension(fileSpan, fileNameSpan, "everestignore", ref warningAlreadySent, isTextBased: true)) {
                     type = typeof(AssetTypeEverestIgnore);
                     return "";
                 }
 
                 if (directorySpan.StartsWith("Dialog/")) {
-                    if (MatchExtension(fileNameSpan, "txt", ref shouldSendWarning, isTextBased: true)) {
+                    if (MatchExtension(fileSpan, fileNameSpan, "txt", ref warningAlreadySent, isTextBased: true)) {
                         type = typeof(AssetTypeDialog);
                         return fileSpan[..^4].ToString();
                     }
-                    if (MatchMultipartExtension(fileNameSpan, "txt.export", ref shouldSendWarning)) {
+                    if (MatchMultipartExtension(fileSpan, fileNameSpan, "txt.export", ref warningAlreadySent)) {
                         type = typeof(AssetTypeDialogExport);
                         return fileSpan[..^7].ToString();
                     }
-                    if (MatchExtension(fileNameSpan, "fnt", ref shouldSendWarning, isTextBased: true)) {
+                    if (MatchExtension(fileSpan, fileNameSpan, "fnt", ref warningAlreadySent, isTextBased: true)) {
                         type = typeof(AssetTypeFont);
                         return fileSpan[..^4].ToString();
                     }
                 }
 
-                if (MatchExtension(fileNameSpan, "bin", ref shouldSendWarning)) {
+                if (MatchExtension(fileSpan, fileNameSpan, "bin", ref warningAlreadySent)) {
                     if (directorySpan.StartsWith("Maps/")) {
                         type = typeof(AssetTypeMap);
                         return fileSpan[..^4].ToString();
@@ -821,15 +821,15 @@ namespace Celeste.Mod {
                 }
 
                 if (directorySpan.StartsWith("Audio/")) {
-                    if (MatchExtension(fileNameSpan, "bank", ref shouldSendWarning)) {
+                    if (MatchExtension(fileSpan, fileNameSpan, "bank", ref warningAlreadySent)) {
                         type = typeof(AssetTypeBank);
                         return fileSpan[..^5].ToString();
                     }
-                    if (MatchMultipartExtension(fileNameSpan, "guids.txt", ref shouldSendWarning, isTextBased: true)) {
+                    if (MatchMultipartExtension(fileSpan, fileNameSpan, "guids.txt", ref warningAlreadySent, isTextBased: true)) {
                         type = typeof(AssetTypeGUIDs);
                         return fileSpan[..^4].ToString();
                     }
-                    if (MatchMultipartExtension(fileNameSpan, "GUIDs.txt", ref shouldSendWarning, isTextBased: true)) {
+                    if (MatchMultipartExtension(fileSpan, fileNameSpan, "GUIDs.txt", ref warningAlreadySent, isTextBased: true)) {
                         // default fmod casing
                         type = typeof(AssetTypeGUIDs);
 
@@ -859,23 +859,23 @@ namespace Celeste.Mod {
                 }
 
                 // assign supported generic types if we haven't found a more specific one
-                if (MatchExtension(fileNameSpan, "lua", ref shouldSendWarning, isTextBased: true)) {
+                if (MatchExtension(fileSpan, fileNameSpan, "lua", ref warningAlreadySent, isTextBased: true)) {
                     type = typeof(AssetTypeLua);
                     return fileSpan[..^4].ToString();
                 }
-                if (MatchExtension(fileNameSpan, "txt", ref shouldSendWarning, isTextBased: true)) {
+                if (MatchExtension(fileSpan, fileNameSpan, "txt", ref warningAlreadySent, isTextBased: true)) {
                     type = typeof(AssetTypeText);
                     return fileSpan[..^4].ToString();
                 }
-                if (MatchExtension(fileNameSpan, "xml", ref shouldSendWarning, isTextBased: true)) {
+                if (MatchExtension(fileSpan, fileNameSpan, "xml", ref warningAlreadySent, isTextBased: true)) {
                     type = typeof(AssetTypeXml);
                     return fileSpan[..^4].ToString();
                 }
-                if (MatchExtension(fileNameSpan, "yml", ref shouldSendWarning, isTextBased: true)) {
+                if (MatchExtension(fileSpan, fileNameSpan, "yml", ref warningAlreadySent, isTextBased: true)) {
                     type = typeof(AssetTypeYaml);
                     return fileSpan[..^4].ToString();
                 }
-                if (MatchExtension(fileNameSpan, "yaml", ref shouldSendWarning, isTextBased: true)) {
+                if (MatchExtension(fileSpan, fileNameSpan, "yaml", ref warningAlreadySent, isTextBased: true)) {
                     type = typeof(AssetTypeYaml);
                     format = "yml";
                     return fileSpan[..^5].ToString();
@@ -898,22 +898,26 @@ namespace Celeste.Mod {
             ///   Match a file extension, and log a warning if the file extension is duplicated.<br/>
             ///   If the file is text-based, log a warning if the file has an extra <c>.txt</c> extension.
             /// </summary>
+            /// <param name="filePath">
+            ///   The path of the file. Used when logging the warning.
+            /// </param>
             /// <param name="fileName">
             ///   The file name to check, with the extensions.
             /// </param>
             /// <param name="expectedExtension">
             ///   The extension to check for, without the leading dot.
             /// </param>
-            /// <param name="shouldSendWarning">
-            ///   Whether a warning should be sent about the file name extension(s).
+            /// <param name="warningAlreadySent">
+            ///   Whether a warning has already been sent about the file name extension(s).
             /// </param>
             /// <param name="isTextBased">
             ///   Whether the file is text-based, and to check for an extra <c>.txt</c> extension.
             /// </param>
             private static bool MatchExtension(
+                ReadOnlySpan<char> filePath,
                 ReadOnlySpan<char> fileName,
                 ReadOnlySpan<char> expectedExtension,
-                ref bool shouldSendWarning,
+                ref bool warningAlreadySent,
                 bool isTextBased = false)
             {
                 ReadOnlySpan<char> extension = Path.GetExtension(fileName);
@@ -928,15 +932,15 @@ namespace Celeste.Mod {
                     // this is silly, but it works
                     extension = Path.GetExtension(Path.GetFileNameWithoutExtension(fileName));
 
-                    if (shouldSendWarning && !extension.IsEmpty && extension[1..].Equals(expectedExtension, StringComparison.Ordinal)) {
-                        Logger.Warn("Content", $"\"{fileName}\" has a doubled extension! It may not be handled correctly.");
-                        shouldSendWarning = false;
+                    if (!warningAlreadySent && !extension.IsEmpty && extension[1..].Equals(expectedExtension, StringComparison.Ordinal)) {
+                        Logger.Warn("Content", $"\"{filePath}\" has a doubled extension! It may not be handled correctly.");
+                        warningAlreadySent = true;
                     }
 
                     return true;
                 }
 
-                if (!shouldSendWarning)
+                if (warningAlreadySent)
                     // we don't care anymore if a warning has already been logged
                     return false;
 
@@ -944,8 +948,8 @@ namespace Celeste.Mod {
                     extension = Path.GetExtension(Path.GetFileNameWithoutExtension(fileName));
 
                     if (!extension.IsEmpty && extension[1..].Equals(expectedExtension, StringComparison.Ordinal)) {
-                        Logger.Warn("Content", $"\"{fileName}\" has an extra \".txt\" extension! It may not be handled correctly.");
-                        shouldSendWarning = false;
+                        Logger.Warn("Content", $"\"{filePath}\" has an extra \".txt\" extension! It may not be handled correctly.");
+                        warningAlreadySent = true;
                     }
                 }
 
@@ -956,27 +960,31 @@ namespace Celeste.Mod {
             ///   Match a multipart file extension, and log a warning if the last part of the file extension is duplicated.<br/>
             ///   If the file is text-based, log a warning if the file has an extra <c>.txt</c> extension.
             /// </summary>
+            /// <param name="filePath">
+            ///   The path of the file. Used when logging the warning.
+            /// </param>
             /// <param name="fileName">
             ///   The file name to check, with the extensions.
             /// </param>
             /// <param name="expectedExtension">
             ///   The multipart extension to check for, without the leading dot.
             /// </param>
-            /// <param name="shouldSendWarning">
-            ///   Whether a warning should be sent about the file name extension(s).
+            /// <param name="warningAlreadySent">
+            ///   Whether a warning has already been sent about the file name extension(s).
             /// </param>
             /// <param name="isTextBased">
             ///   Whether the file is text-based, and to check for an extra <c>.txt</c> extension.
             /// </param>
             private static bool MatchMultipartExtension(
+                ReadOnlySpan<char> filePath,
                 ReadOnlySpan<char> fileName,
                 ReadOnlySpan<char> expectedExtension,
-                ref bool shouldSendWarning,
+                ref bool warningAlreadySent,
                 bool isTextBased = false)
             {
                 // use the simpler function if this is just a singlepart extension
                 if (expectedExtension.IndexOf('.') == -1)
-                    return MatchExtension(fileName, expectedExtension, ref shouldSendWarning, isTextBased);
+                    return MatchExtension(filePath, fileName, expectedExtension, ref warningAlreadySent, isTextBased);
 
                 // find all indices of '.'
                 List<int> expectedExtensionDotIndices = new List<int>();
@@ -1002,7 +1010,7 @@ namespace Celeste.Mod {
                     // extensions match perfectly
                     return true;
 
-                if (!shouldSendWarning)
+                if (warningAlreadySent)
                     // we don't care anymore if a warning has already been logged
                     return false;
 
@@ -1026,11 +1034,11 @@ namespace Celeste.Mod {
 
                     ReadOnlySpan<char> lastIntendedExtensionPart = expectedExtension[expectedExtensionDotIndices[0]..];
                     if (actualExtension.Equals(lastIntendedExtensionPart, StringComparison.Ordinal)) {
-                        Logger.Warn("Content", $"\"{fileName}\" has a doubled extension! It may not be handled correctly.");
-                        shouldSendWarning = false;
+                        Logger.Warn("Content", $"\"{filePath}\" has a doubled extension! It may not be handled correctly.");
+                        warningAlreadySent = true;
                     } else if (actualExtension.Equals("txt", StringComparison.Ordinal)) {
-                        Logger.Warn("Content", $"\"{fileName}\" has an extra \".txt\" extension! It may not be handled correctly.");
-                        shouldSendWarning = false;
+                        Logger.Warn("Content", $"\"{filePath}\" has an extra \".txt\" extension! It may not be handled correctly.");
+                        warningAlreadySent = true;
                     }
                 }
 


### PR DESCRIPTION
This PR logs warnings when a file has a doubled file extension (like `example.png.png`) or a text-based file with an extra .txt extension (`everest.yaml.txt`).
Additionally rewritten to use `Span<T>`s and more modern syntax. I haven't run any benchmarks however.
Tested with several mods and example file names.

I put `example.txt.txt`, `example.yaml.txt` and `Audio/test.guids.txt.txt`, and the logs yield the following:
```
(12/24/2024 01:17:29) [Everest] [Warn] [Content] "example.txt.txt" has a doubled extension! It may not be handled correctly.
(12/24/2024 01:17:29) [Everest] [Warn] [Content] "example.yaml.txt" has an extra ".txt" extension! It may not be handled correctly.
(12/24/2024 01:17:29) [Everest] [Warn] [Content] "test.guids.txt.txt" has an extra ".txt" extension! It may not be handled correctly.
```

## Extra considerations
- Should the span helpers be public? They seem useful for mods to use.
- A sore point is that I can't find a sensible way to include which mod has those bad assets, and I can't just change the public API...