### PR TITLE
Avoiding creating/deleting files directly in the installation dir at runtime

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Updater.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Updater.cs
@@ -440,9 +440,12 @@ namespace Celeste.Mod {
                     }
 
                     // We have to create BuildIsXYZ.txt manually, as this "install" will never actually be run
-                    File.Delete(Path.Combine(legacyRefInstall, "BuildIsFNA.txt"));
-                    File.Delete(Path.Combine(legacyRefInstall, "BuildIsXNA.txt"));
-                    File.WriteAllText(Path.Combine(legacyRefInstall, Flags.VanillaIsFNA ? "BuildIsFNA.txt" : "BuildIsXNA.txt"), string.Empty);
+                    string correctFile = Path.Combine(legacyRefInstall, Flags.VanillaIsFNA ? "BuildIsFNA.txt" : "BuildIsXNA.txt");
+                    string wrongFile = Path.Combine(legacyRefInstall, Flags.VanillaIsFNA ? "BuildIsXNA.txt" : "BuildIsFNA.txt");
+                    if (File.Exists(wrongFile))
+                        File.Delete(wrongFile);
+                    if (!File.Exists(correctFile))
+                        File.WriteAllText(correctFile, string.Empty);
                 }), 0);
             }
 

--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -85,6 +85,11 @@ namespace Celeste.Mod {
         public static string PathGame { get; internal set; }
 
         /// <summary>
+        /// The path to the directory holding temporary files.
+        /// </summary>
+        public static string PathTmp { get; internal set; }
+
+        /// <summary>
         /// The path to the Celeste /Saves directory.
         /// </summary>
         public static string PathSettings => patch_UserIO.GetSaveFilePath();
@@ -325,6 +330,7 @@ namespace Celeste.Mod {
             ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
 
             PathGame = Path.GetDirectoryName(typeof(Celeste).Assembly.Location);
+            PathTmp = Environment.GetEnvironmentVariable("EVEREST_TMPDIR") ?? PathGame;
 
             // .NET hates it when strong-named dependencies get updated.
             AppDomain.CurrentDomain.AssemblyResolve += (asmSender, asmArgs) => {

--- a/Celeste.Mod.mm/Mod/Helpers/FakeFileStream.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/FakeFileStream.cs
@@ -8,7 +8,7 @@ namespace Celeste.Mod.Helpers {
 
         // I'm overcomplicating this. -ade
 
-        private static readonly string Dummy = Path.Combine(Everest.PathGame, "FileProxyStreamDummy.txt");
+        private static readonly string Dummy = Path.Combine(Everest.PathTmp, "FileProxyStreamDummy.txt");
 
         public readonly Stream Inner;
 

--- a/Celeste.Mod.mm/Mod/UI/OuiDependencyDownloader.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiDependencyDownloader.cs
@@ -422,7 +422,7 @@ namespace Celeste.Mod.UI {
         }
 
         private void downloadDependency(ModUpdateInfo mod, EverestModuleMetadata installedVersion) {
-            string downloadDestination = Path.Combine(Everest.PathGame, $"dependency-download.zip");
+            string downloadDestination = Path.Combine(Everest.PathTmp, $"dependency-download.zip");
             try {
                 // 1. Download
                 Func<int, long, int, bool> progressCallback = (position, length, speed) => {

--- a/Celeste.Mod.mm/Mod/UI/OuiModUpdateList.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiModUpdateList.cs
@@ -286,7 +286,7 @@ namespace Celeste.Mod.UI {
             ongoingUpdateCancelled = false;
 
             // we will download the mod to Celeste_Directory/[update.GetHashCode()].zip at first.
-            string zipPath = Path.Combine(Everest.PathGame, $"modupdate-{update.GetHashCode()}.zip");
+            string zipPath = Path.Combine(Everest.PathTmp, $"modupdate-{update.GetHashCode()}.zip");
 
             try {
                 // download it...

--- a/Celeste.Mod.mm/Patches/Celeste.cs
+++ b/Celeste.Mod.mm/Patches/Celeste.cs
@@ -38,13 +38,14 @@ namespace Celeste {
                 Thread.CurrentThread.Name = "Main Thread";
             }
 
-            if (File.Exists("BuildIsXNA.txt"))
-                File.Delete("BuildIsXNA.txt");
-            if (File.Exists("BuildIsFNA.txt"))
-                File.Delete("BuildIsFNA.txt");
-
             // we cannot use Everest.Flags.IsFNA at this point because flags aren't initialized yet.
-            File.WriteAllText($"BuildIs{(typeof(Game).Assembly.FullName.Contains("FNA") ? "FNA" : "XNA")}.txt", "");
+            bool isFNA = typeof(Game).Assembly.FullName.Contains("FNA");
+            string correctFile = $"BuildIs{(isFNA ? "FNA" : "XNA")}.txt";
+            string wrongFile = $"BuildIs{(isFNA ? "XNA" : "FNA")}.txt";
+            if (File.Exists(wrongFile))
+                File.Delete(wrongFile);
+            if (!File.Exists(correctFile))
+                File.WriteAllText(correctFile, "");
 
             if (File.Exists("everest-launch.txt")) {
                 args =


### PR DESCRIPTION
The installation dir needs to be read-only on NixOS. I can work around writing to an existing file by making it a symlink, but I cannot work around creating/deleting a file directly under the installation dir. This is a fix that attempts to resolve this.

**Not tested. Please check for problems before merging.**