### PR TITLE
Dispose the zip file after disposing its entries

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Content.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Content.cs
@@ -469,10 +469,10 @@ namespace Celeste.Mod {
 
         protected override void Dispose(bool disposing) {
             base.Dispose(disposing);
-            Zip.Dispose();
             foreach (ZipPoolEntry pooled in Pool) {
                 Interlocked.Exchange(ref pooled.Value, null)?.Dispose();
             }
+            Zip.Dispose();
         }
     }
 


### PR DESCRIPTION
Apparently this fixes the issue where in-game mod updates just don't work for come mods (like CommunalHelper/BounceHelper), and from empirical testing this seems to fix this.

The true cause is not known however; see [this Celestecord message](https://discord.com/channels/403698615446536203/429775439423209472/1327036477166718996) for context.