### PR TITLE
Fix Decal Registry code mod hot reload

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Events.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Events.cs
@@ -14,7 +14,6 @@ using _Seeker = Celeste.Seeker;
 using _AngryOshiro = Celeste.AngryOshiro;
 using _SubHudRenderer = Celeste.Mod.UI.SubHudRenderer;
 using Monocle;
-using System.ComponentModel;
 
 namespace Celeste.Mod {
     public static partial class Everest {

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Events.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Events.cs
@@ -14,6 +14,7 @@ using _Seeker = Celeste.Seeker;
 using _AngryOshiro = Celeste.AngryOshiro;
 using _SubHudRenderer = Celeste.Mod.UI.SubHudRenderer;
 using Monocle;
+using System.ComponentModel;
 
 namespace Celeste.Mod {
     public static partial class Everest {
@@ -297,10 +298,24 @@ namespace Celeste.Mod {
             public static class AssetReload {
                 public delegate void ReloadHandler(bool silent);
                 public static event ReloadHandler OnBeforeReload, OnAfterReload;
-                internal static void BeforeReload(bool silent)
-                    => OnBeforeReload?.Invoke(silent);
-                internal static void AfterReload(bool silent)
-                    => OnAfterReload?.Invoke(silent);
+
+                public static event ReloadHandler OnBeforeNextReload, OnAfterNextReload;
+
+                internal static void BeforeReload(bool silent) {
+                    OnBeforeReload?.Invoke(silent);
+                    
+                    var beforeNextReload = OnBeforeNextReload;
+                    OnBeforeNextReload = null;
+                    beforeNextReload?.Invoke(silent);
+                }
+
+                internal static void AfterReload(bool silent) {
+                    OnAfterReload?.Invoke(silent);
+                    
+                    var afterNextReload = OnAfterNextReload;
+                    OnAfterNextReload = null;
+                    afterNextReload?.Invoke(silent);
+                }
 
                 public delegate void ReloadLevelHandler(global::Celeste.Level level);
                 public static ReloadLevelHandler OnReloadLevel;


### PR DESCRIPTION
Fixes a bug where the Decal Registry doesn't get reloaded when a mod adds a new handler at runtime (mostly due to code mod hot reload), which would cause them to not work/use old behavior

Also added new `Everest.Events.AssetReload.OnAfterNextReload` and `OnBeforeNextReload` events, as they were useful here and I've wanted them in Frost Helper iirc, and they just seem useful in general.