### PR TITLE
Fix incorrect extension matcher

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Content.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Content.cs
@@ -758,7 +758,7 @@ namespace Celeste.Mod {
                     return fileSpan[..^4].ToString();
                 }
 
-                if (MatchExtension(fileSpan, fileNameSpan, "obj.export", ref warningAlreadySent)) {
+                if (MatchMultipartExtension(fileSpan, fileNameSpan, "obj.export", ref warningAlreadySent)) {
                     type = typeof(AssetTypeObjModelExport);
                     return fileSpan[..^7].ToString();
                 }


### PR DESCRIPTION
I managed to miss an extension matcher for `.obj.export` files, which caused some mountain models (for mods like Into The Jungle) to not load correctly.
The fix has been tested and works correctly.