### PR TITLE
Scroll buttons on main menu (issue #793)

### DIFF
--- a/Celeste.Mod.mm/Patches/OuiMainMenu.cs
+++ b/Celeste.Mod.mm/Patches/OuiMainMenu.cs
@@ -29,10 +29,17 @@ namespace Celeste {
         }
 
         private bool needsRebuild = false;
+        private int selectedIndex;
+        private int offsetFactor;
+        private Vector2 regularButtonOffset;
 
         public extern void orig_CreateButtons();
         public new void CreateButtons() {
             orig_CreateButtons();
+
+            // assume the second button have a regular height
+            // only the Climb button is taller
+            regularButtonOffset = buttons[1].ButtonHeight * -Vector2.UnitY;
 
             Everest.Events.MainMenu.CreateButtons(this, buttons);
 
@@ -51,7 +58,37 @@ namespace Celeste {
                 needsRebuild = false;
             }
 
+            // no mode -> vanilla menu, only apply scroll in vanilla menu
+            if (CoreModule.Settings.MainMenuMode == "") {
+                ScrollButtonsIfNeeded();
+            }
+
             orig_Update();
+        }
+
+        //TODO: scrolling is not smooth, implement smooth scrolling
+        private void ScrollButtonsIfNeeded() {
+            int newSelectedIndex = 0;
+            for (int i = 0; i < buttons.Count; i++) {
+                if (buttons[i].Selected) {
+                    newSelectedIndex = i;
+                    break;
+                }
+            }
+
+            // only attempt to scroll if selection changed
+            if (selectedIndex != newSelectedIndex) {
+                int newOffsetFactor = Math.Max(0, newSelectedIndex - 6);
+                // only scroll if needed (7th or further button selected)
+                if (offsetFactor != newOffsetFactor) {
+                    foreach (MenuButton button in buttons) {
+                        // handle wrapping from last to first button, which resets position
+                        button.Position += regularButtonOffset * (newOffsetFactor - offsetFactor);
+                    }
+                    offsetFactor = newOffsetFactor;
+                }
+                selectedIndex = newSelectedIndex;
+            }
         }
 
         private void RebuildMainAndTitle() {


### PR DESCRIPTION
Allow buttons to scroll in the main menu so the currently selected button is always on screen.

Closes #793.