### PR TITLE
Anonymize project paths

### DIFF
--- a/Celeste.Mod.mm/Celeste.Mod.mm.csproj
+++ b/Celeste.Mod.mm/Celeste.Mod.mm.csproj
@@ -93,4 +93,9 @@
     <Move SourceFiles="@(SplashBinaries)" DestinationFolder="$(PublishDir)\EverestSplash\" />
   </Target>
 
+  <!-- Anonymize paths -->
+  <PropertyGroup>
+    <PathMap>$(MSBuildProjectDirectory)=Celeste.Mod.mm/</PathMap>
+  </PropertyGroup>
+
 </Project>

--- a/DiscordGameSDK/DiscordGameSDK.csproj
+++ b/DiscordGameSDK/DiscordGameSDK.csproj
@@ -5,4 +5,9 @@
     <RootNamespace>Discord</RootNamespace>
     <LangVersion>9</LangVersion>
   </PropertyGroup>
+
+  <!-- Anonymize paths -->
+  <PropertyGroup>
+    <PathMap>$(MSBuildProjectDirectory)=DiscordGameSDK/</PathMap>
+  </PropertyGroup>
 </Project>

--- a/EverestSplash/EverestSplash.csproj
+++ b/EverestSplash/EverestSplash.csproj
@@ -53,4 +53,9 @@
         <CreateAppHost AppHostSourcePath="$(AppHost_osx-x64)" AppHostDestinationPath="$(AppHostIntermediatePath_osx-x64)" AppBinaryName="$(AssemblyName)$(TargetExt)" IntermediateAssembly="@(IntermediateAssembly->'%(FullPath)')" />
     </Target>
 
+    <!-- Anonymize paths -->
+    <PropertyGroup>
+        <PathMap>$(MSBuildProjectDirectory)=EverestSplash/</PathMap>
+    </PropertyGroup>
+
 </Project>

--- a/MiniInstaller/MiniInstaller.csproj
+++ b/MiniInstaller/MiniInstaller.csproj
@@ -66,4 +66,9 @@
     <CreateAppHost AppHostSourcePath="$(AppHost_osx-x64)" AppHostDestinationPath="$(AppHostIntermediatePath_osx-x64)" AppBinaryName="$(AssemblyName)$(TargetExt)" IntermediateAssembly="@(IntermediateAssembly->'%(FullPath)')" />
   </Target>
 
+  <!-- Anonymize paths -->
+  <PropertyGroup>
+    <PathMap>$(MSBuildProjectDirectory)=MiniInstaller/</PathMap>
+  </PropertyGroup>
+
 </Project>

--- a/NETCoreifier/NETCoreifier.csproj
+++ b/NETCoreifier/NETCoreifier.csproj
@@ -13,4 +13,9 @@
     <ProjectReference Include="..\external\MonoMod\src\MonoMod.Utils\MonoMod.Utils.csproj" />
   </ItemGroup>
 
+  <!-- Anonymize paths -->
+  <PropertyGroup>
+    <PathMap>$(MSBuildProjectDirectory)=NETCoreifier/</PathMap>
+  </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
Adds a `<PathMap>` tag to all `.csproj`s to anonymize project paths when building Everest.
Useful when distributing test Everest builds.