### PR TITLE
Add option to lock file to current levelset (#588)

### DIFF
--- a/Celeste.Mod.mm/Content/Dialog/English.txt
+++ b/Celeste.Mod.mm/Content/Dialog/English.txt
@@ -48,6 +48,9 @@
 	MENU_TITLESCREEN_RESTART_VANILLA= Restarting into orig/Celeste.exe
 	MENU_TITLESCREEN_RESTART_VANILLA_SAVES_WARN= WARNING: Because of OS limitations, saves won't be shared!
 
+# Save file slot options
+	MENU_SAVEFILE_LOCKED= Locked
+
 # Extra Key Mapping
     KEY_CONFIG_ADDING= PRESS ADDITIONAL KEY FOR
     KEY_CONFIG_ADDITION_HINT= Press SHIFT + CONFIRM to add or remove additional keys

--- a/Celeste.Mod.mm/Mod/Core/CoreModule.cs
+++ b/Celeste.Mod.mm/Mod/Core/CoreModule.cs
@@ -70,6 +70,7 @@ namespace Celeste.Mod.Core {
         public override void Load() {
             Everest.Events.Celeste.OnExiting += FileProxyStream.DeleteDummy;
             Everest.Events.MainMenu.OnCreateButtons += CreateMainMenuButtons;
+            Everest.Events.FileSelectSlot.OnCreateButtons += CreateFileSelectSlotButtons;
             Everest.Events.Level.OnCreatePauseMenuButtons += CreatePauseMenuButtons;
             nluaAssemblyGetTypesHook = new ILHook(typeof(Lua).Assembly.GetType("NLua.Extensions.TypeExtensions").GetMethod("GetExtensionMethods"), patchNLuaAssemblyGetTypes);
             nluaObjectTranslatorFindType = new Hook(typeof(ObjectTranslator).GetMethod("FindType", BindingFlags.NonPublic | BindingFlags.Instance), hookNLuaObjectTranslatorFindType);
@@ -192,6 +193,7 @@ namespace Celeste.Mod.Core {
         public override void Unload() {
             Everest.Events.Celeste.OnExiting -= FileProxyStream.DeleteDummy;
             Everest.Events.MainMenu.OnCreateButtons -= CreateMainMenuButtons;
+            Everest.Events.FileSelectSlot.OnCreateButtons -= CreateFileSelectSlotButtons;
             Everest.Events.Level.OnCreatePauseMenuButtons -= CreatePauseMenuButtons;
             nluaAssemblyGetTypesHook?.Dispose();
             nluaAssemblyGetTypesHook = null;
@@ -222,6 +224,26 @@ namespace Celeste.Mod.Core {
                 Audio.Play(SFX.ui_main_whoosh_large_in);
                 menu.Overworld.Goto<OuiModOptions>();
             }));
+        }
+
+        private void CreateFileSelectSlotButtons(List<patch_OuiFileSelectSlot.Button> buttons, OuiFileSelectSlot slot, EverestModuleSaveData modSaveData, bool fileExists) {
+            if (!fileExists || slot.Corrupted) return;
+
+            CoreModuleSaveData coreModuleSaveData = modSaveData as CoreModuleSaveData;
+
+            patch_OuiFileSelectSlot.Button existingFileButton = new patch_OuiFileSelectSlot.Button {
+                Label = Dialog.Clean("MENU_SAVEFILE_LOCKED") + " : " + (coreModuleSaveData.IsLocked ? "ON" : "OFF"),
+                Scale = 0.7f
+            };
+            // `Action` references `existingFileButton` so the declarations can't be merged together
+            existingFileButton.Action = () => {
+                coreModuleSaveData.IsLocked = !coreModuleSaveData.IsLocked;
+                Audio.Play("event:/ui/main/button_toggle_" + (coreModuleSaveData.IsLocked ? "on" : "off"));
+                existingFileButton.Label = Dialog.Clean("MENU_SAVEFILE_LOCKED") + " : " + (coreModuleSaveData.IsLocked ? "ON" : "OFF");
+                WriteSaveData(slot.FileSlot, SerializeSaveData(slot.FileSlot));
+            };
+
+            buttons.Insert(buttons.Count - 2, existingFileButton); // Keep "Rename" and "Delete" buttons at the bottom
         }
 
         public void CreatePauseMenuButtons(Level level, patch_TextMenu menu, bool minimal) {

--- a/Celeste.Mod.mm/Mod/Core/CoreModuleSaveData.cs
+++ b/Celeste.Mod.mm/Mod/Core/CoreModuleSaveData.cs
@@ -3,5 +3,6 @@
 
         public int WhateverCount { get; set; } = 1337;
 
+        public bool IsLocked { get; set; } = false;
     }
 }

--- a/Celeste.Mod.mm/Mod/Helpers/Commands.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/Commands.cs
@@ -2,6 +2,7 @@ using Microsoft.Xna.Framework.Input;
 using Monocle;
 using System;
 using Celeste.Mod.UI;
+using Celeste.Mod.Core;
 
 namespace Celeste.Mod.Helpers {
     internal static class Commands {
@@ -48,6 +49,11 @@ namespace Celeste.Mod.Helpers {
             else {
                 OuiModOptions.Instance.Overworld.Goto<OuiSoundTest>();
             }
+        }
+
+        [Command("lock", "toggle lock mode for the current savefile")]
+        public static void ToggleLock() {
+            CoreModule.SaveData.IsLocked = !CoreModule.SaveData.IsLocked;
         }
     }
 

--- a/Celeste.Mod.mm/Patches/OuiChapterSelect.cs
+++ b/Celeste.Mod.mm/Patches/OuiChapterSelect.cs
@@ -3,6 +3,7 @@
 #pragma warning disable CS0169 // The field is never used
 
 using Celeste.Mod;
+using Celeste.Mod.Core;
 using Celeste.Mod.UI;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
@@ -179,36 +180,40 @@ namespace Celeste {
             _keys = keys;
 
             if (Focused && !disableInput && display) {
-                if (Input.Pause.Pressed || Input.ESC.Pressed) {
-                    Overworld.Maddy.Hide(true);
-                    Audio.Play(SFX.ui_main_button_select);
-                    Audio.Play(SFX.ui_main_whoosh_large_in);
-                    OuiMapList list = Overworld.Goto<OuiMapList>();
-                    list.OuiIcons = icons;
-                    return;
-                } else if (Input.QuickRestart.Pressed) {
-                    Overworld.Maddy.Hide(true);
-                    Audio.Play(SFX.ui_main_button_select);
-                    Audio.Play(SFX.ui_main_whoosh_large_in);
-                    OuiMapSearch list = Overworld.Goto<OuiMapSearch>();
-                    list.OuiIcons = icons;
-                    return;
+                if (!CoreModule.SaveData.IsLocked) {
+                    if (Input.Pause.Pressed || Input.ESC.Pressed) {
+                        Overworld.Maddy.Hide(true);
+                        Audio.Play(SFX.ui_main_button_select);
+                        Audio.Play(SFX.ui_main_whoosh_large_in);
+                        OuiMapList list = Overworld.Goto<OuiMapList>();
+                        list.OuiIcons = icons;
+                        return;
+                    } else if (Input.QuickRestart.Pressed) {
+                        Overworld.Maddy.Hide(true);
+                        Audio.Play(SFX.ui_main_button_select);
+                        Audio.Play(SFX.ui_main_whoosh_large_in);
+                        OuiMapSearch list = Overworld.Goto<OuiMapSearch>();
+                        list.OuiIcons = icons;
+                        return;
+                    }
                 }
             }
 
             // note: Engine.DeltaTime is removed from inputDelay before being compared to zero in the orig method.
             if (Focused && display && !disableInput && inputDelay <= Engine.DeltaTime) {
-                if (Input.MenuUp.Pressed) {
-                    Audio.Play(SFX.ui_world_chapter_pane_contract);
-                    Audio.Play(SFX.ui_world_icon_roll_left);
-                    Overworld.Goto<OuiHelper_ChapterSelect_LevelSet>().Direction = -1;
-                    return;
-                }
-                if (Input.MenuDown.Pressed) {
-                    Audio.Play(SFX.ui_world_chapter_pane_expand);
-                    Audio.Play(SFX.ui_world_icon_roll_right);
-                    Overworld.Goto<OuiHelper_ChapterSelect_LevelSet>().Direction = +1;
-                    return;
+                if (!CoreModule.SaveData.IsLocked) {
+                    if (Input.MenuUp.Pressed) {
+                        Audio.Play(SFX.ui_world_chapter_pane_contract);
+                        Audio.Play(SFX.ui_world_icon_roll_left);
+                        Overworld.Goto<OuiHelper_ChapterSelect_LevelSet>().Direction = -1;
+                        return;
+                    }
+                    if (Input.MenuDown.Pressed) {
+                        Audio.Play(SFX.ui_world_chapter_pane_expand);
+                        Audio.Play(SFX.ui_world_icon_roll_right);
+                        Overworld.Goto<OuiHelper_ChapterSelect_LevelSet>().Direction = +1;
+                        return;
+                    }
                 }
 
                 // We don't want to copy the entire Update method, but still prevent the option from going out of bounds.
@@ -257,8 +262,14 @@ namespace Celeste {
 
         public extern void orig_Render();
         public override void Render() {
-
             orig_Render();
+            if (CoreModule.SaveData.IsLocked && levelsetEase > 0f) {
+                Vector2 pos = new Vector2(1920f - 64f * Ease.CubeOut(maplistEase), 1080f - 128f);
+                string line = patch_Dialog.CleanLevelSet(currentLevelSet);
+                ActiveFont.DrawOutline(line, pos, new Vector2(1f, 0.5f), Vector2.One * 0.7f, Color.White * Ease.CubeOut(maplistEase), 2f, Color.Black * Ease.CubeOut(maplistEase));
+                return;
+            }
+
             if (maplistEase > 0f) {
                 Vector2 pos = new Vector2(128f * Ease.CubeOut(maplistEase), 1080f - 128f);
                 if (journalEnabled)
@@ -287,6 +298,5 @@ namespace Celeste {
                 Input.GuiDirection(new Vector2(0f, +1f)).DrawCentered(pos + new Vector2(-lineSize.X * 0.5f, +lineSize.Y * 0.5f + 16f), Color.White * Ease.CubeOut(maplistEase), 0.5f);
             }
         }
-
     }
 }

--- a/Celeste.Mod.mm/Patches/OuiFileSelectSlot.cs
+++ b/Celeste.Mod.mm/Patches/OuiFileSelectSlot.cs
@@ -222,7 +222,7 @@ namespace Celeste {
             orig_Update();
 
             if (newGameLevelSetPicker != null && selected && fileSelect.Selected && fileSelect.Focused &&
-                !StartingGame && tween == null && inputDelay <= 0f && !StartingGame && !deleting) {
+                !StartingGame && tween == null && inputDelay <= 0f && !deleting) {
 
                 // currently highlighted option is the level set picker, call its Update() method to handle Left and Right presses.
                 newGameLevelSetPicker.Update(buttons[buttonIndex] == newGameLevelSetPicker);


### PR DESCRIPTION
Adds an option to lock an existing save file to its current levelset (preventing the user from switching levelset).

This option can be toggled from the `FileSelectSlot` OUI, or using the `lock` command (like the `assist` or `variants` commands).

The lock status is saved in the `CoreModuleSaveData`.

I'm wondering if adding a button can causes issues in TASes, if they don't expect it.

Closes #588.