### PR TITLE
Reload vanillla portraits on map exit

### DIFF
--- a/Celeste.Mod.mm/Patches/Level.cs
+++ b/Celeste.Mod.mm/Patches/Level.cs
@@ -589,7 +589,7 @@ namespace Celeste {
             GFX.PortraitsSpriteBank = new SpriteBank(GFX.Portraits, Path.Combine("Graphics", "Portraits.xml"));
 
             // if we are not entering PICO-8 or the Reflection Fall cutscene...
-            if (!(patch_Engine.NextScene is Pico8.Emulator) && !(patch_Engine.NextScene is OverworldReflectionsFall)) {
+            if (patch_Engine.NextScene is not Pico8.Emulator && patch_Engine.NextScene is not OverworldReflectionsFall) {
                 // break all links between this level and its entities.
                 foreach (Entity entity in Entities) {
                     ((patch_Entity) entity).DissociateFromScene();

--- a/Celeste.Mod.mm/Patches/Level.cs
+++ b/Celeste.Mod.mm/Patches/Level.cs
@@ -20,6 +20,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 
@@ -581,6 +582,11 @@ namespace Celeste {
         public extern void orig_End();
         public override void End() {
             orig_End();
+
+            // reload the vanilla Portraits.xml in case it was overridden by a map
+            // else, if the Portraits.xml doesn't have portrait_madeline defined,
+            // the game will crash when trying to load a save file (since it shows madeline's portrait)
+            GFX.PortraitsSpriteBank = new SpriteBank(GFX.Portraits, Path.Combine("Graphics", "Portraits.xml"));
 
             // if we are not entering PICO-8 or the Reflection Fall cutscene...
             if (!(patch_Engine.NextScene is Pico8.Emulator) && !(patch_Engine.NextScene is OverworldReflectionsFall)) {

--- a/Celeste.Mod.mm/Patches/Level.cs
+++ b/Celeste.Mod.mm/Patches/Level.cs
@@ -589,7 +589,7 @@ namespace Celeste {
             GFX.PortraitsSpriteBank = new SpriteBank(GFX.Portraits, Path.Combine("Graphics", "Portraits.xml"));
 
             // if we are not entering PICO-8 or the Reflection Fall cutscene...
-            if (patch_Engine.NextScene is not Pico8.Emulator && patch_Engine.NextScene is not OverworldReflectionsFall) {
+            if (patch_Engine.NextScene is not (Pico8.Emulator or OverworldReflectionsFall)) {
                 // break all links between this level and its entities.
                 foreach (Entity entity in Entities) {
                     ((patch_Entity) entity).DissociateFromScene();


### PR DESCRIPTION
If a map overrides `Portraits.xml`, the change persists until another map is loaded or the game is restarted.
If the new `Portraits.xml` does not define `portrait_madeline`, this can cause a crash if the player then exits the map and tries to pick a new save file.

This happens because the save file slot renders a Madeline portrait, and the new `Portraits.xml` does not define it.
If the player opens another map whose `Portraits.xml` defines `portrait_madeline` (or opens a vanilla map), then the crash is prevented, as `portrait_madeline` now exists.

> [!NOTE]
> An interesting caveat is that this allows the mapper to change how the save file portraits look by changing `portraits_madeline` instead of removing it. At least, until the player opens another map in the same save file.

This PR fixes that by reloading the vanilla `Portraits.xml` when exiting a level. 

*(also another note, the random diff lines which change nothing are likely due to Rider making line endings consistent - CRLF -> LF)*