### PR TITLE
Unlock all areas if Cheat Mode is enabled

### DIFF
--- a/Celeste.Mod.mm/Patches/SaveData.cs
+++ b/Celeste.Mod.mm/Patches/SaveData.cs
@@ -485,7 +485,7 @@ namespace Celeste {
                     if (UnlockedAreas_Unsafe < lastCompleted + 1 && set.MaxArea >= lastCompleted + 1) {
                         UnlockedAreas_Unsafe = lastCompleted + 1;
                     }
-                    if (DebugMode) {
+                    if (DebugMode || CheatMode) {
                         UnlockedAreas_Unsafe = set.MaxArea;
                     }
 
@@ -493,7 +493,7 @@ namespace Celeste {
                     if (set.UnlockedAreas < lastCompleted + 1 && set.MaxArea >= lastCompleted + 1) {
                         set.UnlockedAreas = lastCompleted + 1;
                     }
-                    if (DebugMode) {
+                    if (DebugMode || CheatMode) {
                         set.UnlockedAreas = set.MaxArea;
                     }
                 }


### PR DESCRIPTION
Fixes an inconsistency with vanilla. Vanilla unlocks all levels if Cheat Mode is enabled in `SaveData.AfterInitialize`. Everest does the same when the save file is a debug save file, but it does not include Cheat Mode.
Normally this isn't a problem as inputting the cheat code in Prologue explicitly unlocks all areas, however the `cheat` command just sets toggles the `SaveData.CheatMode` field without updating the unlocked levels.

The most likely cause of this being omitted is due to it *literally not being there* at the time the method was first written (commit d26c41b), and I guess it was just missed, or this situation never occurred. *(which is kinda crazy ngl)*

@0x0ade included a screenshot of Celeste 1.1.5.0 demonstrating that `SaveData.CheatMode` is not used by `SaveData.AfterInitialize`.

### Celeste 1.1.5.0:
![SaveData.AfterInitialize in Celeste 1.1.5.0](https://github.com/user-attachments/assets/e694f6a2-2741-486b-8e86-06876dff1d74)

### Celeste 1.4.0.0:
![SaveData.AfterInitialize in Celeste 1.4.0.0](https://github.com/user-attachments/assets/d3199b41-3c02-45e7-acc4-06edd23a4eaf)

