### PR TITLE
Hotfix `[TrackedAs(typeof(UntrackedType))]`

### DIFF
--- a/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
@@ -119,14 +119,14 @@ namespace Monocle {
             }
             bool updated = false;
             // copy the registered types for the target type
-            (trackedEntity ? StoredEntityTypes : StoredComponentTypes).Add(type);
+            var knownTypes = trackedEntity ? StoredEntityTypes : StoredComponentTypes;
             Dictionary<Type, List<Type>> tracked = trackedEntity ? TrackedEntityTypes : TrackedComponentTypes;
-            if (AddSpecificType(type, trackedAsType, tracked)) {
+            if (AddSpecificType(type, trackedAsType, tracked, knownTypes)) {
                 updated = true;
             }
             // do the same for subclasses
             foreach (Type subtype in subtypes) {
-                if (trackedAsType.IsAssignableFrom(subtype) && AddSpecificType(subtype, trackedAsType, tracked)) {
+                if (trackedAsType.IsAssignableFrom(subtype) && AddSpecificType(subtype, trackedAsType, tracked, knownTypes)) {
                     updated = true;
                 }
             }
@@ -135,10 +135,15 @@ namespace Monocle {
             }
         }
 
-        private static bool AddSpecificType(Type type, Type trackedAsType, Dictionary<Type, List<Type>> tracked) {
+        private static bool AddSpecificType(Type type, Type trackedAsType, Dictionary<Type, List<Type>> tracked, HashSet<Type> knownTypes) {
             if (type.IsAbstract) {
                 return false;
             }
+
+            // Make sure the tracker knows about both the type and trackedAs type, to fix scenarios like `[TrackedAs(typeof(UntrackedType))]`
+            knownTypes.Add(type);
+            knownTypes.Add(trackedAsType);
+            
             if (!tracked.TryGetValue(type, out List<Type> value)) {
                 value = new List<Type>();
                 tracked.Add(type, value);


### PR DESCRIPTION
My previous Tracker PR caused a crash when using `[TrackedAs(typeof(UntrackedType))]`, which happens with some modded boosters.

Before the previous PR, `[TrackedAs(typeof(Booster))]` would be no-op. After this hotfix, it makes the tracker track the derived type as `Booster`, even though `Booster` itself is not tracked, which seems to be a saner behavior. 

![image](https://github.com/user-attachments/assets/027f208f-9188-4778-80de-438443c6258b)

When a mod manually tracks `Booster`, modded entities tracked as `Booster` will also work correctly now, whereas previously they would *not* be tracked:

![image](https://github.com/user-attachments/assets/f10a2270-4c90-4764-8992-2dac3527ac1d)
