### PR TITLE
Add dependencies and optional dependencies to the cache checksums

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Relinker.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Relinker.cs
@@ -111,7 +111,7 @@ namespace Celeste.Mod {
                     Assembly asm = null;
 
                     // Try to load the assembly from the cache
-                    if (TryLoadCachedAssembly(meta, asmname, path, symPath, cachePath, cacheChecksumPath, out string[] checksums) is not Assembly cacheAsm) {
+                    if (TryLoadCachedAssembly(meta, asmname, path, symPath, cachePath, cacheChecksumPath, out EverestModuleAssemblyContext.AsmChecksums checksums) is not Assembly cacheAsm) {
                         // Delete cached files
                         File.Delete(cachePath);
                         File.Delete(cacheChecksumPath);
@@ -130,7 +130,7 @@ namespace Celeste.Mod {
                                 // Write the checksums for the cached assembly to be loaded in the future
                                 // Skip this step if the relinker had to fall back to using a temporary output file
                                 if (tmpOutPath == null)
-                                    File.WriteAllLines(cacheChecksumPath, checksums);
+                                    checksums.WriteToFile(cacheChecksumPath);
                             } catch (Exception e) {
                                 Logger.Warn("relinker", $"Failed relinking {meta} - {asmname}");
                                 Logger.LogDetailed(e);
@@ -145,21 +145,15 @@ namespace Celeste.Mod {
                 }
             }
 
-            private static Assembly TryLoadCachedAssembly(EverestModuleMetadata meta, string asmName, string inPath, string inSymPath, string cachePath, string cacheChecksumsPath, out string[] curChecksums) {
+            private static Assembly TryLoadCachedAssembly(EverestModuleMetadata meta, string asmName, string inPath, string inSymPath, string cachePath, string cacheChecksumsPath, out EverestModuleAssemblyContext.AsmChecksums curChecksums) {
                 // Calculate checksums
-                // If the stream originates from a 
-                List<string> checksums = new List<string>();
-                checksums.Add(GameChecksum);
-
-                meta.AssemblyContext.CalcAssemblyCacheChecksums(checksums, inPath, inSymPath);
-
-                curChecksums = checksums.ToArray();
+                curChecksums = meta.AssemblyContext.CalcAssemblyCacheChecksums(inPath, !string.IsNullOrEmpty(meta.PathArchive) ? null : inSymPath);
 
                 // Check if the cached assembly + its checksums exist on disk, and if the checksums match
                 if (!File.Exists(cachePath) || !File.Exists(cacheChecksumsPath))
                     return null;
 
-                if (!ChecksumsEqual(curChecksums, File.ReadAllLines(cacheChecksumsPath)))
+                if (!curChecksums.IsValidWith(EverestModuleAssemblyContext.AsmChecksums.ReadFromFile(cacheChecksumsPath)))
                     return null;
                 
                 Logger.Verbose("relinker", $"Loading cached assembly for {meta} - {asmName}");

--- a/Celeste.Mod.mm/Mod/Module/EverestModuleAssemblyContext.cs
+++ b/Celeste.Mod.mm/Mod/Module/EverestModuleAssemblyContext.cs
@@ -216,20 +216,10 @@ namespace Celeste.Mod {
         /// <returns>The calculated checksums for the file.</returns>
         public AsmChecksums CalcAssemblyCacheChecksums(string path, string symPath) {
             Dictionary<string, string> depChecksums = new();
-            foreach (EverestModuleMetadata depMeta in ModuleMeta.Dependencies) {
-                if (depMeta.Name == CoreModule.NETCoreMetaName || depMeta.Name == "Everest") continue;
-                EverestModule actualModule = Everest.Modules.FirstOrDefault(m => m.Metadata.Name == depMeta.Name, null);
-                if (actualModule == null) continue;
-                depChecksums[depMeta.Name] = actualModule.Metadata.Hash.ToHexadecimalString();
-            }
+            FillChecksums(depChecksums, ModuleMeta.Dependencies);
             
             Dictionary<string, string> optDepChecksums = new();
-            foreach (EverestModuleMetadata optDepMeta in ModuleMeta.OptionalDependencies) {
-                if (optDepMeta.Name == CoreModule.NETCoreMetaName || optDepMeta.Name == "Everest") continue;
-                EverestModule actualModule = Everest.Modules.FirstOrDefault(m => m.Metadata.Name == optDepMeta.Name, null);
-                if (actualModule == null) continue;
-                optDepChecksums[optDepMeta.Name] = actualModule.Metadata.Hash.ToHexadecimalString();
-            }
+            FillChecksums(optDepChecksums, ModuleMeta.OptionalDependencies);
             
             return new AsmChecksums(
                 Everest.Relinker.GameChecksum, 
@@ -237,6 +227,15 @@ namespace Celeste.Mod {
                 symPath != null ? CalcChecksumForFile(symPath) : "",
                 depChecksums,
                 optDepChecksums);
+
+            static void FillChecksums(Dictionary<string, string> dict, List<EverestModuleMetadata> deps) {
+                foreach (EverestModuleMetadata depMeta in deps) {
+                    if (depMeta.Name == CoreModule.NETCoreMetaName || depMeta.Name == "Everest") continue;
+                    EverestModule actualModule = Everest.Modules.FirstOrDefault(m => m.Metadata.Name == depMeta.Name, null);
+                    if (actualModule == null) continue;
+                    dict[depMeta.Name] = actualModule.Metadata.Hash.ToHexadecimalString();
+                }
+            }
         }
 
         /// <summary>
@@ -263,15 +262,20 @@ namespace Celeste.Mod {
                 lines.Add(FileChecksum);
                 lines.Add(SymFileChecksum ?? "");
 
-                foreach ((string metaName, string hash) in DepHashes) {
-                    lines.Add($"{metaName}:{hash}");
-                }
+                WriteAsLines(DepHashes);
+                
                 lines.Add("");
-
-                foreach ((string metaName, string hash) in OptDepHashes) {
-                    lines.Add($"{metaName}:{hash}");
-                }
+                
+                WriteAsLines(OptDepHashes);
+                
                 File.WriteAllLines(path, lines);
+                return;
+
+                void WriteAsLines(Dictionary<string, string> dict) {
+                    foreach ((string metaName, string hash) in dict) {
+                        lines.Add($"{metaName}:{hash}");
+                    }
+                }
             }
 
             /// <summary>
@@ -344,33 +348,28 @@ namespace Celeste.Mod {
                 if (FileChecksum != other.FileChecksum) return false;
                 if (SymFileChecksum != other.SymFileChecksum) return false;
 
-                // A null list indicates no dependencies, thus, it always satisfies the requirements
-                if (DepHashes != null) {
-                    if (other.DepHashes != null) {
-                        foreach ((string metaName, string hash) in DepHashes) {
-                            if (!other.DepHashes.TryGetValue(metaName, out string otherHash)) {
-                                return false;
-                            }
-                            if (hash != otherHash) return false;
-                        }
-                    } else if (DepHashes.Count != 0) 
-                        // Having an empty and null list should be equivalent
-                        return false;
-                }
+                if (!Check(DepHashes, other.DepHashes)) return false;
 
-                if (OptDepHashes != null) {
-                    if (other.OptDepHashes != null) {
-                        foreach ((string metaName, string hash) in OptDepHashes) {
-                            if (!other.OptDepHashes.TryGetValue(metaName, out string otherHash)) {
-                                return false;
-                            }
-                            if (hash != otherHash) return false;
-                        }
-                    } else if (OptDepHashes.Count != 0)
-                        return false;
-                }
+                if (!Check(OptDepHashes, other.OptDepHashes)) return false;
 
                 return true;
+
+                static bool Check(Dictionary<string, string> dict, Dictionary<string, string> otherDict) {
+                    // A null list indicates no dependencies, thus, it always satisfies the requirements
+                    if (dict != null) {
+                        if (otherDict != null) {
+                            foreach ((string metaName, string hash) in dict) {
+                                if (!otherDict.TryGetValue(metaName, out string otherHash)) {
+                                    return false;
+                                }
+                                if (hash != otherHash) return false;
+                            }
+                        } else if (dict.Count != 0)
+                            // Having an empty and null list should be equivalent
+                            return false;
+                    }
+                    return true;
+                }
             }
         }
 

--- a/Celeste.Mod.mm/Mod/Module/EverestModuleAssemblyContext.cs
+++ b/Celeste.Mod.mm/Mod/Module/EverestModuleAssemblyContext.cs
@@ -199,6 +199,181 @@ namespace Celeste.Mod {
                 throw new UnreachableException();
         }
 
+        private string CalcChecksumForFile(string path) {
+            if (!string.IsNullOrEmpty(ModuleMeta.PathArchive)) {
+                return ModuleMeta.Hash.ToHexadecimalString();
+            } else if (!string.IsNullOrEmpty(ModuleMeta.PathDirectory)) {
+                return Everest.GetChecksum(path).ToHexadecimalString();
+            } else throw new UnreachableException();
+        }
+
+        /// <summary>
+        /// Calculates the checksums used to cache the assembly in any relevant
+        /// caches (like the relinker cache).
+        /// </summary>
+        /// <param name="path">The path of the assembly inside of the mod.</param>
+        /// <param name="symPath">The path of the assembly's symbols inside of mod, or null.</param>
+        /// <returns>The calculated checksums for the file.</returns>
+        public AsmChecksums CalcAssemblyCacheChecksums(string path, string symPath) {
+            Dictionary<string, string> depChecksums = new();
+            foreach (EverestModuleMetadata depMeta in ModuleMeta.Dependencies) {
+                if (depMeta.Name == CoreModule.NETCoreMetaName || depMeta.Name == "Everest") continue;
+                EverestModule actualModule = Everest.Modules.FirstOrDefault(m => m.Metadata.Name == depMeta.Name, null);
+                if (actualModule == null) continue;
+                depChecksums[depMeta.Name] = actualModule.Metadata.Hash.ToHexadecimalString();
+            }
+            
+            Dictionary<string, string> optDepChecksums = new();
+            foreach (EverestModuleMetadata optDepMeta in ModuleMeta.OptionalDependencies) {
+                if (optDepMeta.Name == CoreModule.NETCoreMetaName || optDepMeta.Name == "Everest") continue;
+                EverestModule actualModule = Everest.Modules.FirstOrDefault(m => m.Metadata.Name == optDepMeta.Name, null);
+                if (actualModule == null) continue;
+                optDepChecksums[optDepMeta.Name] = actualModule.Metadata.Hash.ToHexadecimalString();
+            }
+            
+            return new AsmChecksums(
+                Everest.Relinker.GameChecksum, 
+                CalcChecksumForFile(path), 
+                symPath != null ? CalcChecksumForFile(symPath) : "",
+                depChecksums,
+                optDepChecksums);
+        }
+
+        /// <summary>
+        /// Represents all the checksum data for an assembly, either from the cache or
+        /// from one that's about to be loaded.
+        /// </summary>
+        public sealed record AsmChecksums(
+            string GameChecksum,
+            string FileChecksum,
+            string SymFileChecksum = "",
+            Dictionary<string, string> DepHashes = null,
+            Dictionary<string, string> OptDepHashes = null) {
+
+            public static readonly AsmChecksums Empty = new("", "");
+
+            /// <summary>
+            /// Writes the data to a file, see <see cref="ReadFromFile"/> for a description
+            /// of the file format.
+            /// </summary>
+            /// <param name="path">The path to the file to write to.</param>
+            public void WriteToFile(string path) {
+                List<string> lines = new();
+                lines.Add(GameChecksum);
+                lines.Add(FileChecksum);
+                lines.Add(SymFileChecksum ?? "");
+
+                foreach ((string metaName, string hash) in DepHashes) {
+                    lines.Add($"{metaName}:{hash}");
+                }
+                lines.Add("");
+
+                foreach ((string metaName, string hash) in OptDepHashes) {
+                    lines.Add($"{metaName}:{hash}");
+                }
+                File.WriteAllLines(path, lines);
+            }
+
+            /// <summary>
+            /// Creates an instance from a file, format is as following:
+            /// We take all the data and partition it on each new line character into strings, keeping empty strings.
+            /// Then, the first element will be the game checksum, the second one, the file checksum,
+            /// the third one, the symbol file (pdb) checksum, or empty an empty string if it doesn't exist or we are working with
+            /// archives (zips).
+            /// After the third element, each element is of the format `Name:Hash`, where Name is the meta name and
+            /// Hash is the hash for that meta, this represents a dependency. Until an empty element, which marks the
+            /// end of the dependencies list. After this element and until the end of file, the optional dependencies list follow
+            /// in the same format.
+            /// </summary>
+            /// <param name="path">Path to read from.</param>
+            /// <returns>A populated instance.</returns>
+            public static AsmChecksums ReadFromFile(string path) {
+                string[] data = File.ReadAllLines(path);
+                if (data.Length < 2) return Empty;
+                
+                string gameChecksum = data[0];
+                string fileChecksum = data[1];
+                if (data.Length <= 2) return new AsmChecksums(gameChecksum, fileChecksum);
+                string symChecksum = data[2];
+                if (data.Length <= 3) return new AsmChecksums(gameChecksum, fileChecksum, symChecksum);
+                Dictionary<string, string> depChecksums = new();
+                Dictionary<string, string> optDepChecksums = new();
+                
+                Dictionary<string, string> currentDict = depChecksums;
+                int index = 3;
+                while (index < data.Length) {
+                    if (data[index] == "") {
+                        if (currentDict == depChecksums) {
+                            currentDict = optDepChecksums;
+                            index++;
+                            continue;
+                        } else {
+                            // Malformed cache, return minimum data
+                            return new AsmChecksums(gameChecksum, fileChecksum, symChecksum);
+                        }
+                    }
+                    ReadOnlySpan<char> curr = data[index];
+                    int sepIdx = curr.LastIndexOf(':');
+                    if (sepIdx == -1) {
+                        // Malformed cache, return minimum data
+                        return new AsmChecksums(gameChecksum, fileChecksum, symChecksum);
+                    }
+                    
+                    ReadOnlySpan<char> metaName = curr[..sepIdx];
+                    ReadOnlySpan<char> metaHash = curr[(sepIdx + 1)..];
+                    currentDict[metaName.ToString()] = metaHash.ToString();
+                    
+                    index++;
+                }
+                return new AsmChecksums(gameChecksum, fileChecksum, symChecksum, depChecksums, optDepChecksums);
+            }
+
+            /// <summary>
+            /// Verifies whether the current instance is a valid in respect to the one passed in:
+            /// Game, file, and symbol checksums must always match for it to be valid, but
+            /// the requirements for dependencies and optional dependencies are different.
+            /// We consider this instance valid with respect to the one passed in, if for every dependency D present
+            /// in this instance, D is also present in <paramref name="other"/>, and it is associated with the same checksum.
+            /// The same reasoning goes with optional dependencies.
+            /// </summary>
+            /// <param name="other">The other cache to check with.</param>
+            /// <returns>Whether this is compatible with <paramref name="other"/></returns>
+            public bool IsValidWith(AsmChecksums other) {
+                if (other == null) return false;
+                if (GameChecksum != other.GameChecksum) return false;
+                if (FileChecksum != other.FileChecksum) return false;
+                if (SymFileChecksum != other.SymFileChecksum) return false;
+
+                // A null list indicates no dependencies, thus, it always satisfies the requirements
+                if (DepHashes != null) {
+                    if (other.DepHashes != null) {
+                        foreach ((string metaName, string hash) in DepHashes) {
+                            if (!other.DepHashes.TryGetValue(metaName, out string otherHash)) {
+                                return false;
+                            }
+                            if (hash != otherHash) return false;
+                        }
+                    } else if (DepHashes.Count != 0) 
+                        // Having an empty and null list should be equivalent
+                        return false;
+                }
+
+                if (OptDepHashes != null) {
+                    if (other.OptDepHashes != null) {
+                        foreach ((string metaName, string hash) in OptDepHashes) {
+                            if (!other.OptDepHashes.TryGetValue(metaName, out string otherHash)) {
+                                return false;
+                            }
+                            if (hash != otherHash) return false;
+                        }
+                    } else if (OptDepHashes.Count != 0)
+                        return false;
+                }
+
+                return true;
+            }
+        }
+
         /// <summary>
         /// Tries to load an assembly from a given path inside the mod.
         /// This path is an absolute path if the the mod was loaded from a directory, or a path into the mod ZIP otherwise.


### PR DESCRIPTION
Relinking assemblies with missing dependencies has some caveats, we may encounter that some transformations of the code are incorrect (such as the one we found where a base method `call` was replaced with a `callvirt`) due to the lack information that the missing dependencies cause.

Thus, if an assembly has been relinked with missing dependencies, this cache must be invalidated once these dependencies become available. Note that, if the dependencies were to be removed again, we can still consider the cache as valid as long as all the other dependencies remain valid, further explanation of what this means is in the code.

This wouldn't matter in the case of hard Everest dependencies, but it does affect optional everest dependencies.