### PR TITLE
Consider missing vanilla savefile corrupted (#649)

### DIFF
--- a/Celeste.Mod.mm/Content/Dialog/English.txt
+++ b/Celeste.Mod.mm/Content/Dialog/English.txt
@@ -187,6 +187,8 @@
 	LEVELSET_CELESTE= 		Celeste
 	LEVELSET_= 				Uncategorized
 
+	MISSING_VANILLA_DATA= Missing Vanilla data :(
+
 # Updater
 	UPDATER_TITLE= 					UPDATER
 	UPDATER_LEGACYREF_TITLE=		LEGACYREF SETUP

--- a/Celeste.Mod.mm/Patches/OuiFileSelect.cs
+++ b/Celeste.Mod.mm/Patches/OuiFileSelect.cs
@@ -8,11 +8,29 @@ using System.Linq;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using MonoMod.Cil;
+using Celeste.Mod;
 
 namespace Celeste {
     class patch_OuiFileSelect : OuiFileSelect {
 
         internal bool startingNewFile;
+
+        public extern void orig_LoadThread();
+        public new void LoadThread() {
+            orig_LoadThread();
+
+            string saveFilePath = patch_UserIO.GetSaveFilePath();
+            if (!Directory.Exists(saveFilePath))
+                return;
+
+            for (int i = 0; i < Slots.Count() - 1; i++) { // - 1, last slot is always empty
+                if (!Slots[i].Exists && Directory.GetFiles(saveFilePath, $"{i}-mod*.celeste").Length > 0) {
+                    Logger.Warn("save", $"Save slot {i} have modded data but no save file, flagging as corrupted");
+                    Slots[i].Corrupted = true;
+                    Slots[i].Exists = true; // both `Corrupted` and `Exists` flags must be set
+                }
+            }
+        }
 
         [PatchOuiFileSelectSubmenuChecks] // we want to manipulate the orig method with MonoModRules
         public extern IEnumerator orig_Enter(Oui from);
@@ -28,11 +46,15 @@ namespace Celeste {
                     maxSaveFile = 1; // we're adding 2 later, so there will be at least 3 slots.
                     string saveFilePath = patch_UserIO.GetSaveFilePath();
                     if (Directory.Exists(saveFilePath)) {
-                        foreach (string filePath in Directory.GetFiles(saveFilePath)) {
+                        foreach (string filePath in Directory.GetFiles(saveFilePath, "*.celeste")) {
                             string fileName = Path.GetFileName(filePath);
                             // is the file named [number].celeste?
-                            if (fileName.EndsWith(".celeste") && int.TryParse(fileName.Substring(0, fileName.Length - 8), out int fileIndex)) {
+                            if (int.TryParse(fileName.Substring(0, fileName.Length - 8), out int fileIndex)) {
                                 maxSaveFile = Math.Max(maxSaveFile, fileIndex);
+                            }
+                            // or is the file mod data named [number]-mod[save|session]-[modname].celeste?
+                            if (fileName.Contains("-mod") && int.TryParse(fileName.Substring(0, fileName.IndexOf('-')), out int modFileIndex)) {
+                                maxSaveFile = Math.Max(maxSaveFile, modFileIndex);
                             }
                         }
                     }

--- a/Celeste.Mod.mm/Patches/OuiFileSelect.cs
+++ b/Celeste.Mod.mm/Patches/OuiFileSelect.cs
@@ -26,6 +26,7 @@ namespace Celeste {
             for (int i = 0; i < Slots.Count() - 1; i++) { // - 1, last slot is always empty
                 if (!Slots[i].Exists && Directory.GetFiles(saveFilePath, $"{i}-mod*.celeste").Length > 0) {
                     Logger.Warn("save", $"Save slot {i} have modded data but no save file, flagging as corrupted");
+                    ((patch_OuiFileSelectSlot) Slots[i]).MissingVanillaData = true;
                     Slots[i].Corrupted = true;
                     Slots[i].Exists = true; // both `Corrupted` and `Exists` flags must be set
                 }

--- a/Celeste.Mod.mm/Patches/OuiFileSelect.cs
+++ b/Celeste.Mod.mm/Patches/OuiFileSelect.cs
@@ -25,7 +25,7 @@ namespace Celeste {
 
             for (int i = 0; i < Slots.Count() - 1; i++) { // - 1, last slot is always empty
                 if (!Slots[i].Exists && Directory.GetFiles(saveFilePath, $"{i}-mod*.celeste").Length > 0) {
-                    Logger.Warn("save", $"Save slot {i} have modded data but no save file, flagging as corrupted");
+                    Logger.Warn("OuiFileSelect", $"Save slot {i} has modded data but no vanilla save data, flagging as corrupted");
                     ((patch_OuiFileSelectSlot) Slots[i]).MissingVanillaData = true;
                     Slots[i].Corrupted = true;
                     Slots[i].Exists = true; // both `Corrupted` and `Exists` flags must be set

--- a/Celeste.Mod.mm/Patches/OuiFileSelectSlot.cs
+++ b/Celeste.Mod.mm/Patches/OuiFileSelectSlot.cs
@@ -204,8 +204,6 @@ namespace Celeste {
 
         public extern void orig_OnNewGameSelected();
         public void OnNewGameSelected() {
-            patch_SaveData.TryDeleteModSaveData(FileSlot);
-
             orig_OnNewGameSelected();
 
             string newGameLevelSet = newGameLevelSetPicker?.NewGameLevelSet;

--- a/Celeste.Mod.mm/Patches/OuiFileSelectSlot.cs
+++ b/Celeste.Mod.mm/Patches/OuiFileSelectSlot.cs
@@ -44,6 +44,8 @@ namespace Celeste {
 
         private OuiFileSelectSlotLevelSetPicker newGameLevelSetPicker;
 
+        public bool MissingVanillaData;
+
         // computed maximums for stamp rendering
         private int maxStrawberryCount;
         private int maxGoldenStrawberryCount;
@@ -289,6 +291,7 @@ namespace Celeste {
             public float Scale = 1f;
         }
 
+        [PatchFileSelectSlotRenderMissingVanillaDataDialog]
         [PatchFileSelectSlotRender] // manually manipulate the method via MonoModRules
         public extern void orig_Render();
         public override void Render() {
@@ -352,6 +355,12 @@ namespace MonoMod {
     [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchOuiFileSelectSlotOnContinueSelected))]
     class PatchOuiFileSelectSlotOnContinueSelectedAttribute : Attribute { }
 
+    /// <summary>
+    /// Patches the method to differentiate between Corrupted and MissingVanillaData.
+    /// </summary>
+    [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchFileSelectSlotRenderMissingVanillaDataDialog))]
+    class PatchFileSelectSlotRenderMissingVanillaDataDialog : Attribute { }
+
     static partial class MonoModRules {
 
         public static void PatchOuiFileSelectSlotUpdate(ILContext context, CustomAttribute attrib) {
@@ -366,6 +375,48 @@ namespace MonoMod {
             cursor.EmitCall(m_CoreModule_get_Settings);
             cursor.EmitCallvirt(m_get_AllowScreenFlash);
             cursor.Next.OpCode = OpCodes.Brfalse;
+        }
+
+        public static void PatchFileSelectSlotRenderMissingVanillaDataDialog(ILContext context, CustomAttribute attrib) {
+            TypeDefinition declaringType = context.Method.DeclaringType;
+            FieldDefinition f_MissingVanillaData = declaringType.FindField("MissingVanillaData");
+
+            ILCursor cursor = new ILCursor(context);
+
+            // C# change:
+            // [...]
+            // else if (Corrupted)
+            // {
+            // -    ActiveFont.Draw(Dialog.Clean("file_corrupted"), slide2, new Vector2(0.5f, 0.5f), Vector2.One, Color.Black * 0.8f);
+            // +    ActiveFont.Draw(Dialog.Clean((!MissingVanillaData) ? "file_corrupted" : "MISSING_VANILLA_DATA"), vector3, new Vector2(0.5f, 0.5f), Vector2.One, Color.Black * 0.8f);
+            // }
+            // [...]
+
+            // IL change:
+            // [...]
+            //          ldfld System.Boolean Celeste.OuiFileSelectSlot::Corrupted
+            //          brfalse.s (...)
+            // +        ldarg.0
+            // +        ldfld bool Celeste.OuiFileSelectSlot::MissingVanillaData
+            // +        brfalse.s ldstr
+            // +        ldstr "MISSING_VANILLA_DATA"
+            // +        br.s ldnull
+            // ldstr  : ldstr "file_corrupted"
+            // ldnull : ldnull
+            //          call string Celeste.Dialog::Clean(string, class Celeste.Language)
+            // [...]
+
+            cursor.GotoNext(MoveType.Before, instr => instr.MatchLdstr("file_corrupted"));
+            ILLabel ldstr = cursor.MarkLabel();
+            cursor.GotoNext();
+            ILLabel ldnull = cursor.MarkLabel();
+
+            cursor.GotoLabel(ldstr, MoveType.Before);
+            cursor.EmitLdarg0();
+            cursor.EmitLdfld(f_MissingVanillaData);
+            cursor.EmitBrfalse(ldstr);
+            cursor.EmitLdstr("MISSING_VANILLA_DATA");
+            cursor.EmitBr(ldnull);
         }
 
         public static void PatchFileSelectSlotRender(ILContext context, CustomAttribute attrib) {

--- a/Celeste.Mod.mm/Patches/SaveData.cs
+++ b/Celeste.Mod.mm/Patches/SaveData.cs
@@ -6,6 +6,7 @@ using Monocle;
 using MonoMod;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Xml;
@@ -297,8 +298,17 @@ namespace Celeste {
 
         public static extern bool orig_TryDelete(int slot);
         public static new bool TryDelete(int slot) {
-            if (!orig_TryDelete(slot))
-                return false;
+            bool vanillaExists = false;
+            string saveFilePath = patch_UserIO.GetSaveFilePath();
+            if (Directory.Exists(saveFilePath))
+                vanillaExists = File.Exists(Path.Combine(saveFilePath, $"{slot}.celeste"));
+
+            if (vanillaExists)
+                if (!orig_TryDelete(slot))
+                    return false;
+            else
+                Logger.Warn("save", $"Deleting save data for slot {slot} which have no vanilla data");
+
             return TryDeleteModSaveData(slot);
         }
 

--- a/Celeste.Mod.mm/Patches/SaveData.cs
+++ b/Celeste.Mod.mm/Patches/SaveData.cs
@@ -303,11 +303,13 @@ namespace Celeste {
             if (Directory.Exists(saveFilePath))
                 vanillaExists = File.Exists(Path.Combine(saveFilePath, $"{slot}.celeste"));
 
-            if (vanillaExists)
-                if (!orig_TryDelete(slot))
+            if (vanillaExists) {
+                if (!orig_TryDelete(slot)) {
                     return false;
+                }
+            }
             else
-                Logger.Warn("save", $"Deleting save data for slot {slot} which have no vanilla data");
+                Logger.Warn("SaveData", $"Deleting save data for slot {slot} which has no vanilla data");
 
             return TryDeleteModSaveData(slot);
         }


### PR DESCRIPTION
Commit https://github.com/EverestAPI/Everest/commit/fa9b476b16ef7d82c5c6ab8d3b50b79683f87922 always delete modded save data when starting a new game.

This PR changes this behavior:
- Modded save data is no longer deleted when starting a new save file.
- Instead, save slots without vanilla save data and with modded save data are considered corrupted, making the slot unusable until all save data (vanilla and modded) is deleted.

This allows the `Everest.Events.FileSelectSlot.OnCreateButtons` event to work properly on new save files, as modded save data is no longer deleted after being created.

Fixes #649.