### PR TITLE
BOOT: When restarting the game, do not pass executable as command line argument

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/BOOT.cs
+++ b/Celeste.Mod.mm/Mod/Everest/BOOT.cs
@@ -252,7 +252,7 @@ namespace Celeste.Mod {
             }
 
             Regex escapeArg = new Regex(@"(\\+)$");
-            game.StartInfo.Arguments = string.Join(" ", Environment.GetCommandLineArgs().Select(s => "\"" + escapeArg.Replace(s, @"$1$1") + "\""));
+            game.StartInfo.Arguments = string.Join(" ", Environment.GetCommandLineArgs().Skip(1).Select(s => "\"" + escapeArg.Replace(s, @"$1$1") + "\""));
 
             game.Start();
             return game;


### PR DESCRIPTION
The doc says:

![image](https://github.com/user-attachments/assets/61760504-285d-42c5-a9d0-2d5618cf98af)

and now people's Steams are screaming about an unknown "Celeste.dll" argument being passed :destareline: