### PR TITLE
Fix crash when TalkComponent Handler has no Collider

### DIFF
--- a/Celeste.Mod.mm/Patches/TalkComponent.cs
+++ b/Celeste.Mod.mm/Patches/TalkComponent.cs
@@ -34,7 +34,7 @@ namespace Celeste {
                 if (Handler.Entity?.Collider != null) {
                     // use Collider if available instead of Position, as Position behaves wrongly
                     // (see https://github.com/EverestAPI/Everest/issues/759)
-                    if (Handler.Entity == null || Scene.CollideCheck<FakeWall>(Handler.Entity.Collider.Bounds)) {
+                    if (Scene.CollideCheck<FakeWall>(Handler.Entity.Collider.Bounds)) {
                         alpha = 0f;
                     }
                 } else {
@@ -59,7 +59,7 @@ namespace Celeste {
                 if (Handler.Entity?.Collider != null) {
                     // use Collider if available instead of Position, as Position behaves wrongly
                     // (see https://github.com/EverestAPI/Everest/issues/759)
-                    if (alpha < 1f && Handler.Entity != null && !Scene.CollideCheck<FakeWall>(Handler.Entity.Collider.Bounds)) {
+                    if (alpha < 1f && !Scene.CollideCheck<FakeWall>(Handler.Entity.Collider.Bounds)) {
                         alpha = Calc.Approach(alpha, 1f, 2f * Engine.DeltaTime);
                     }
                 } else {

--- a/Celeste.Mod.mm/Patches/TalkComponent.cs
+++ b/Celeste.Mod.mm/Patches/TalkComponent.cs
@@ -31,10 +31,17 @@ namespace Celeste {
             [MonoModReplace]
             public override void Awake(Scene scene) {
                 base_Awake(scene);
-                // use Collider instead of Position, as Position behaves wrongly
-                // (see https://github.com/EverestAPI/Everest/issues/759)
-                if (Handler.Entity == null || Scene.CollideCheck<FakeWall>(Handler.Entity.Collider.Bounds)) {
-                    alpha = 0f;
+                if (Handler.Entity.Collider != null) {
+                    // use Collider if available instead of Position, as Position behaves wrongly
+                    // (see https://github.com/EverestAPI/Everest/issues/759)
+                    if (Handler.Entity == null || Scene.CollideCheck<FakeWall>(Handler.Entity.Collider.Bounds)) {
+                        alpha = 0f;
+                    }
+                } else {
+                    // Entity has no Collider, fallback to Position
+                    if (Handler.Entity == null || Scene.CollideCheck<FakeWall>(Handler.Entity.Position)) {
+                        alpha = 0f;
+                    }
                 }
                 // force alpha if the player can interact
                 if (Highlighted) {
@@ -49,10 +56,17 @@ namespace Celeste {
             public override void Update() {
                 timer += Engine.DeltaTime;
                 slide = Calc.Approach(slide, Display ? 1 : 0, Engine.DeltaTime * 4f);
-                // use Collider instead of Position, as Position behaves wrongly
-                // (see https://github.com/EverestAPI/Everest/issues/759)
-                if (alpha < 1f && Handler.Entity != null && !Scene.CollideCheck<FakeWall>(Handler.Entity.Collider.Bounds)) {
-                    alpha = Calc.Approach(alpha, 1f, 2f * Engine.DeltaTime);
+                if (Handler.Entity.Collider != null) {
+                    // use Collider if available instead of Position, as Position behaves wrongly
+                    // (see https://github.com/EverestAPI/Everest/issues/759)
+                    if (alpha < 1f && Handler.Entity != null && !Scene.CollideCheck<FakeWall>(Handler.Entity.Collider.Bounds)) {
+                        alpha = Calc.Approach(alpha, 1f, 2f * Engine.DeltaTime);
+                    }
+                } else {
+                    // Entity has no Collider, fallback to Position
+                    if (alpha < 1f && Handler.Entity != null && !Scene.CollideCheck<FakeWall>(Handler.Entity.Position)) {
+                        alpha = 0f;
+                    }
                 }
                 // force alpha if the player can interact
                 if (Highlighted) {

--- a/Celeste.Mod.mm/Patches/TalkComponent.cs
+++ b/Celeste.Mod.mm/Patches/TalkComponent.cs
@@ -31,7 +31,7 @@ namespace Celeste {
             [MonoModReplace]
             public override void Awake(Scene scene) {
                 base_Awake(scene);
-                if (Handler.Entity.Collider != null) {
+                if (Handler.Entity?.Collider != null) {
                     // use Collider if available instead of Position, as Position behaves wrongly
                     // (see https://github.com/EverestAPI/Everest/issues/759)
                     if (Handler.Entity == null || Scene.CollideCheck<FakeWall>(Handler.Entity.Collider.Bounds)) {
@@ -56,7 +56,7 @@ namespace Celeste {
             public override void Update() {
                 timer += Engine.DeltaTime;
                 slide = Calc.Approach(slide, Display ? 1 : 0, Engine.DeltaTime * 4f);
-                if (Handler.Entity.Collider != null) {
+                if (Handler.Entity?.Collider != null) {
                     // use Collider if available instead of Position, as Position behaves wrongly
                     // (see https://github.com/EverestAPI/Everest/issues/759)
                     if (alpha < 1f && Handler.Entity != null && !Scene.CollideCheck<FakeWall>(Handler.Entity.Collider.Bounds)) {


### PR DESCRIPTION
Fix a `NullReferenceException` when the `TalkComponent` `Handler` entity has no `Collider` (such as the `OshiroLobbyBell` in "Celestial Resort").

Fallback to vanilla behavior in this case.

Crash introduced in https://github.com/EverestAPI/Everest/pull/906.