### PR TITLE
Run Celeste TASes on pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/tas-check/1-get-build-url.sh
+++ b/.github/tas-check/1-get-build-url.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Waits for Azure to be finished building, and writes the download link to /tmp/everest-pr-tas-check/download-link.txt.
+# Parameter: commit SHA
+
+set -xeo pipefail
+
+get_build_id() {
+	curl 'https://dev.azure.com/EverestAPI/Everest/_apis/build/builds?definitions=3&statusFilter=completed' \
+		| jq -r ".value | map(select(.sourceVersion == \"${1}\")) | .[].id"
+}
+
+BUILD_ID=`get_build_id "$1"`
+while [ "${BUILD_ID}" == "" ]; do
+	sleep 60
+	BUILD_ID=`get_build_id "$1"`
+done
+
+mkdir /tmp/everest-pr-tas-check
+echo -n "https://dev.azure.com/EverestAPI/Everest/_apis/build/builds/${BUILD_ID}/artifacts?artifactName=main&api-version=5.0&%24format=zip" > /tmp/everest-pr-tas-check/download-link.txt

--- a/.github/tas-check/1-get-build-url.sh
+++ b/.github/tas-check/1-get-build-url.sh
@@ -15,5 +15,5 @@ while [ "${BUILD_ID}" == "" ]; do
 	BUILD_ID=`get_build_id "$1"`
 done
 
-mkdir /tmp/everest-pr-tas-check
+mkdir -p /tmp/everest-pr-tas-check
 echo -n "https://dev.azure.com/EverestAPI/Everest/_apis/build/builds/${BUILD_ID}/artifacts?artifactName=main&api-version=5.0&%24format=zip" > /tmp/everest-pr-tas-check/download-link.txt

--- a/.github/tas-check/2-1-install.sh
+++ b/.github/tas-check/2-1-install.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Installs Everest from the branch to test, CelesteTAS and the mod that is going to be TASed.
+# Parameter: mod ID of the mod to be TASed
+
+set -xeo pipefail
+
+docker build \
+	--build-arg "MAIN_BUILD_URL=`cat /tmp/everest-pr-tas-check/download-link.txt`" \
+	--build-arg "TAS_TO_RUN=$1" \
+	-t celeste .

--- a/.github/tas-check/2-1-install.sh
+++ b/.github/tas-check/2-1-install.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 # Installs Everest from the branch to test, CelesteTAS and the mod that is going to be TASed.
-# Parameter: mod ID of the mod to be TASed
+# Parameters: ID of the mod to be TASed, URL of the TAS files
 
 set -xeo pipefail
 
 docker build \
 	--build-arg "MAIN_BUILD_URL=`cat /tmp/everest-pr-tas-check/download-link.txt`" \
+	--build-arg "TAS_FILES_URL=$2" \
 	--build-arg "TAS_TO_RUN=$1" \
 	-t celeste .

--- a/.github/tas-check/2-2-install-inner.sh
+++ b/.github/tas-check/2-2-install-inner.sh
@@ -21,13 +21,13 @@ chmod -v u+x MiniInstaller-linux
 
 # download TAS files
 cd ..
-curl --fail -Lo t.zip "https://celestemodupdater.0x0a.de/pinned-mods/TAS-Files-${TAS_TO_RUN}.zip"
+curl --fail -Lo t.zip "${TAS_FILES_URL}"
 unzip t.zip
 rm -v t.zip
 
-# install CelesteTAS (https://maddie480.ovh/celeste/dl?id=CelesteTAS&mirror=1)
+# install CelesteTAS
 cd celeste/Mods
-curl --fail -Lo CelesteTAS.zip "https://celestemodupdater.0x0a.de/pinned-mods/CelesteTAS.zip"
+curl --fail -Lo CelesteTAS.zip "https://github.com/EverestAPI/CelesteTAS-EverestInterop/releases/download/v3.45.1/CelesteTAS.zip"
 
 # install the mod that is going to be TASed, downloaded as a bundle zip containing the mod zip
 # and all of its dependencies (https://maddie480.ovh/celeste/bundle-download?id=${TAS_TO_RUN})

--- a/.github/tas-check/2-2-install-inner.sh
+++ b/.github/tas-check/2-2-install-inner.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Installs Everest from the branch to test, CelesteTAS and the mod that is going to be TASed.
+# Run from within the Docker image, where Celeste is installed at /home/ubuntu/celeste.
+
+set -xeo pipefail
+
+# download Everest
+cd /home/ubuntu
+curl --fail -Lo everest.zip "${MAIN_BUILD_URL}"
+unzip everest.zip
+rm -v everest.zip
+
+# copy Everest files to Celeste install
+mv -fv main/* celeste/
+rm -rfv main
+
+# install Everest in headless mode
+cd celeste
+chmod -v u+x MiniInstaller-linux
+./MiniInstaller-linux headless
+
+# download TAS files
+cd ..
+curl --fail -Lo t.zip "https://celestemodupdater.0x0a.de/pinned-mods/TAS-Files-${TAS_TO_RUN}.zip"
+unzip t.zip
+rm -v t.zip
+
+# install CelesteTAS (https://maddie480.ovh/celeste/dl?id=CelesteTAS&mirror=1)
+cd celeste/Mods
+curl --fail -Lo CelesteTAS.zip "https://celestemodupdater.0x0a.de/pinned-mods/CelesteTAS.zip"
+
+# install the mod that is going to be TASed, downloaded as a bundle zip containing the mod zip
+# and all of its dependencies (https://maddie480.ovh/celeste/bundle-download?id=${TAS_TO_RUN})
+# for simplicity's sake, Celeste-Bundle.zip exists but is an empty zip
+curl --fail -Lo t.zip "https://celestemodupdater.0x0a.de/pinned-mods/${TAS_TO_RUN}-Bundle.zip"
+unzip t.zip
+rm -v t.zip

--- a/.github/tas-check/3-run.sh
+++ b/.github/tas-check/3-run.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Runs the requested TAS and checks the result.
+# Parameter: path of the TAS to run
+
+set -xeo pipefail
+
+docker run \
+	--volume "/tmp/everest-pr-tas-check:/home/ubuntu/tas" \
+	--rm \
+	--name celeste celeste \
+	--sync-check-file "/home/ubuntu/$1" \
+	--sync-check-result /home/ubuntu/tas/result.json
+
+[ "`jq -r '.entries.[].status' /tmp/everest-pr-tas-check/result.json`" == "success" ]

--- a/.github/tas-check/3-run.sh
+++ b/.github/tas-check/3-run.sh
@@ -11,4 +11,4 @@ docker run \
 	--sync-check-file "/home/ubuntu/$1" \
 	--sync-check-result /home/ubuntu/tas/result.json
 
-[ "`jq -r '.entries.[].status' /tmp/everest-pr-tas-check/result.json`" == "success" ]
+[ "`jq -r '.entries[].status' /tmp/everest-pr-tas-check/result.json`" == "success" ]

--- a/.github/tas-check/Dockerfile
+++ b/.github/tas-check/Dockerfile
@@ -1,0 +1,5 @@
+FROM max480/everest:vanilla
+
+ARG MAIN_BUILD_URL TAS_TO_RUN
+COPY 2-2-install-inner.sh /tmp
+RUN /tmp/2-2-install-inner.sh && rm /tmp/2-2-install-inner.sh

--- a/.github/tas-check/Dockerfile
+++ b/.github/tas-check/Dockerfile
@@ -1,5 +1,5 @@
 FROM max480/everest:vanilla
 
-ARG MAIN_BUILD_URL TAS_TO_RUN
+ARG MAIN_BUILD_URL TAS_FILES_URL TAS_TO_RUN
 COPY 2-2-install-inner.sh /tmp
 RUN /tmp/2-2-install-inner.sh && rm /tmp/2-2-install-inner.sh

--- a/.github/tas-check/run-locally.sh
+++ b/.github/tas-check/run-locally.sh
@@ -16,8 +16,8 @@ case "$1" in
         ;;
 
     "StrawberryJam2021")
-        TAS_URL="https://github.com/VampireFlower/StrawberryJamTAS/archive/0f0c6ee2112a2189b8d574704028db2fd37ee05e.zip"
-        TAS_PATH="StrawberryJamTAS-0f0c6ee2112a2189b8d574704028db2fd37ee05e/0-SJ All Levels.tas"
+        TAS_URL="https://github.com/VampireFlower/StrawberryJamTAS/archive/fc7397c26f4d15468d4a8a3e58e7cc3d62d21223.zip"
+        TAS_PATH="StrawberryJamTAS-fc7397c26f4d15468d4a8a3e58e7cc3d62d21223/0-SJ All Levels.tas"
         ;;
 
     *)

--- a/.github/tas-check/run-locally.sh
+++ b/.github/tas-check/run-locally.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Builds and runs the TAS locally, calling the same scripts as the pipeline in order to test them.
+# Requires Docker and jq.
+
+if [ "$1" == "" ] || [ "$2" == "" ]; then
+    echo "Usage: ./run-locally.sh [Celeste|StrawberryJam2021] [commit SHA]"
+    exit 1
+fi
+
+set -xeo pipefail
+
+case "$1" in
+    "Celeste")
+        TAS_URL="https://github.com/VampireFlower/CelesteTAS/archive/60b1680e61e43ec4681d7c9053d249491e0fe905.zip"
+        TAS_PATH="CelesteTAS-60b1680e61e43ec4681d7c9053d249491e0fe905/0 - 100%.tas"
+        ;;
+
+    "StrawberryJam2021")
+        TAS_URL="https://github.com/VampireFlower/StrawberryJamTAS/archive/0f0c6ee2112a2189b8d574704028db2fd37ee05e.zip"
+        TAS_PATH="StrawberryJamTAS-0f0c6ee2112a2189b8d574704028db2fd37ee05e/0-SJ All Levels.tas"
+        ;;
+
+    *)
+        echo "Unknown TAS: $1"
+        exit 1
+esac
+
+cd "`dirname "$0"`"
+./1-get-build-url.sh "$2"
+./2-1-install.sh "$1" "${TAS_URL}"
+./3-run.sh "${TAS_PATH}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+name: TAS Sync Check
+
+on:
+  pull_request:
+    branches: [dev]
+
+jobs:
+  check:
+    strategy:
+      matrix:
+        tas:
+          - name: Celeste 100%
+            mod: Celeste
+            path: "CelesteTAS-master/0 - 100%.tas"
+
+          - name: Strawberry Jam All Levels
+            mod: StrawberryJam2021
+            path: "StrawberryJamTAS-main/0-SJ All Levels.tas"
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    name: ${{ matrix.tas.name }}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Wait for Azure build on commit ${{ github.sha }}
+      run: cd .github/tas-check && ./1-get-build-url.sh "${{ github.sha }}"
+
+    - name: Install Everest and ${{ matrix.tas.mod }}
+      run: cd .github/tas-check && ./2-1-install.sh "${{ matrix.tas.mod }}"
+
+    - name: Run TAS at ${{ matrix.tas.path }}
+      run: cd .github/tas-check && ./3-run.sh "${{ matrix.tas.path }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,11 +11,13 @@ jobs:
         tas:
           - name: Celeste 100%
             mod: Celeste
-            path: "CelesteTAS-master/0 - 100%.tas"
+            url: "https://github.com/VampireFlower/CelesteTAS/archive/60b1680e61e43ec4681d7c9053d249491e0fe905.zip"
+            path: "CelesteTAS-60b1680e61e43ec4681d7c9053d249491e0fe905/0 - 100%.tas"
 
           - name: Strawberry Jam All Levels
             mod: StrawberryJam2021
-            path: "StrawberryJamTAS-main/0-SJ All Levels.tas"
+            url: "https://github.com/VampireFlower/StrawberryJamTAS/archive/0f0c6ee2112a2189b8d574704028db2fd37ee05e.zip"
+            path: "StrawberryJamTAS-0f0c6ee2112a2189b8d574704028db2fd37ee05e/0-SJ All Levels.tas"
 
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -31,7 +33,7 @@ jobs:
       run: cd .github/tas-check && ./1-get-build-url.sh "${{ github.sha }}"
 
     - name: Install Everest and ${{ matrix.tas.mod }}
-      run: cd .github/tas-check && ./2-1-install.sh "${{ matrix.tas.mod }}"
+      run: cd .github/tas-check && ./2-1-install.sh "${{ matrix.tas.mod }}" "${{ matrix.tas.url }}"
 
     - name: Run TAS at ${{ matrix.tas.path }}
       run: cd .github/tas-check && ./3-run.sh "${{ matrix.tas.path }}"

--- a/.github/workflows/tas-sync-check.yml
+++ b/.github/workflows/tas-sync-check.yml
@@ -16,8 +16,8 @@ jobs:
 
           - name: Strawberry Jam All Levels
             mod: StrawberryJam2021
-            url: "https://github.com/VampireFlower/StrawberryJamTAS/archive/0f0c6ee2112a2189b8d574704028db2fd37ee05e.zip"
-            path: "StrawberryJamTAS-0f0c6ee2112a2189b8d574704028db2fd37ee05e/0-SJ All Levels.tas"
+            url: "https://github.com/VampireFlower/StrawberryJamTAS/archive/fc7397c26f4d15468d4a8a3e58e7cc3d62d21223.zip"
+            path: "StrawberryJamTAS-fc7397c26f4d15468d4a8a3e58e7cc3d62d21223/0-SJ All Levels.tas"
 
     runs-on: ubuntu-latest
     timeout-minutes: 60


### PR DESCRIPTION
Tested on this PR: https://github.com/EverestAPI/Everest/pull/915 because it needed to _target_ a branch that actually had the GitHub Actions yaml in order to run it.

The action:
- Waits for the build to be completed on Azure, polling every minute, filtering on the commit SHA
- Pulls the everest:vanilla Docker image, which is just Ubuntu with a bare-bones Celeste in it, and no Everest (despite the name). We can't pull an encrypted Celeste and decode it with a secret, because pull request pipelines _don't have access to secrets_, so here we go
- Downloads the build artifact from Azure and installs Everest from it
- Downloads CelesteTAS, the TAS files and the Strawberry Jam bundle :tm: from Banana Mirror (they're static, so a mod update breaking TASes won't break the build)
- Runs Celeste with special command line parameters that tell CelesteTAS to run the TAS, write the report and close the game
- Checks if the report says "success"