### PR TITLE
Fix `Portraits.xml` reloading in unintended scenarios

### DIFF
--- a/Celeste.Mod.mm/Patches/Level.cs
+++ b/Celeste.Mod.mm/Patches/Level.cs
@@ -585,11 +585,19 @@ namespace Celeste {
 
             Scene nextScene = patch_Engine.NextScene;
 
+            // reload the vanilla Portraits.xml when exiting; if a map overrides the Portraits.xml
+            // and doesn't have portrait_madeline defined, the game would crash when trying to load a save file
+            // (since it shows madeline's portrait)
+            //
+            // however we need to pay attention to the new scene, else we'll reload vanilla portraits too soon
+            // and make custom portraits stop working. therefore, we ignore these scenes as they don't actually
+            // exit the map:
+            // - MapEditor - debug map
+            // - AssetReloadHelper - f5 bind
+            // - LevelLoader - vanilla f1-f3 binds + everest softlock prevention
+            // - LevelExit (if Mode is Restart or GoldenBerryRestart) - restarts the level, duh
             if (nextScene is not (Editor.MapEditor or AssetReloadHelper or LevelLoader
                 or patch_LevelExit { Mode: LevelExit.Mode.Restart or LevelExit.Mode.GoldenBerryRestart })) {
-                // reload the vanilla Portraits.xml when exiting
-                // else, if a map overrides the Portraits.xml and doesn't have portrait_madeline defined,
-                // the game will crash when trying to load a save file (since it shows madeline's portrait)
                 GFX.PortraitsSpriteBank = new SpriteBank(GFX.Portraits, Path.Combine("Graphics", "Portraits.xml"));
             }
 

--- a/Celeste.Mod.mm/Patches/Level.cs
+++ b/Celeste.Mod.mm/Patches/Level.cs
@@ -583,13 +583,18 @@ namespace Celeste {
         public override void End() {
             orig_End();
 
-            // reload the vanilla Portraits.xml in case it was overridden by a map
-            // else, if the Portraits.xml doesn't have portrait_madeline defined,
-            // the game will crash when trying to load a save file (since it shows madeline's portrait)
-            GFX.PortraitsSpriteBank = new SpriteBank(GFX.Portraits, Path.Combine("Graphics", "Portraits.xml"));
+            Scene nextScene = patch_Engine.NextScene;
+
+            if (nextScene is not (LevelLoader or patch_LevelExit { Mode: LevelExit.Mode.Restart or LevelExit.Mode.GoldenBerryRestart }
+                or Editor.MapEditor or AssetReloadHelper)) {
+                // reload the vanilla Portraits.xml when exiting
+                // else, if a map overrides the Portraits.xml and doesn't have portrait_madeline defined,
+                // the game will crash when trying to load a save file (since it shows madeline's portrait)
+                GFX.PortraitsSpriteBank = new SpriteBank(GFX.Portraits, Path.Combine("Graphics", "Portraits.xml"));
+            }
 
             // if we are not entering PICO-8 or the Reflection Fall cutscene...
-            if (patch_Engine.NextScene is not (Pico8.Emulator or OverworldReflectionsFall)) {
+            if (nextScene is not (Pico8.Emulator or OverworldReflectionsFall)) {
                 // break all links between this level and its entities.
                 foreach (Entity entity in Entities) {
                     ((patch_Entity) entity).DissociateFromScene();

--- a/Celeste.Mod.mm/Patches/Level.cs
+++ b/Celeste.Mod.mm/Patches/Level.cs
@@ -585,8 +585,8 @@ namespace Celeste {
 
             Scene nextScene = patch_Engine.NextScene;
 
-            if (nextScene is not (LevelLoader or patch_LevelExit { Mode: LevelExit.Mode.Restart or LevelExit.Mode.GoldenBerryRestart }
-                or Editor.MapEditor or AssetReloadHelper)) {
+            if (nextScene is not (Editor.MapEditor or AssetReloadHelper or LevelLoader
+                or patch_LevelExit { Mode: LevelExit.Mode.Restart or LevelExit.Mode.GoldenBerryRestart })) {
                 // reload the vanilla Portraits.xml when exiting
                 // else, if a map overrides the Portraits.xml and doesn't have portrait_madeline defined,
                 // the game will crash when trying to load a save file (since it shows madeline's portrait)

--- a/Celeste.Mod.mm/Patches/Level.cs
+++ b/Celeste.Mod.mm/Patches/Level.cs
@@ -598,13 +598,8 @@ namespace Celeste {
             //
             // however we need to pay attention to the new scene, else we'll reload vanilla portraits too soon
             // and make custom portraits stop working. therefore, we ignore these scenes as they don't actually
-            // exit the map:
-            // - MapEditor - debug map
-            // - AssetReloadHelper - f5 bind
-            // - LevelLoader - vanilla f1-f3 binds + everest softlock prevention
-            // - LevelExit (if Mode is Restart or GoldenBerryRestart) - restarts the level, duh
-            if (nextScene is not (Editor.MapEditor or AssetReloadHelper or LevelLoader
-                or patch_LevelExit { Mode: LevelExit.Mode.Restart or LevelExit.Mode.GoldenBerryRestart })) {
+            // exit the map
+            if (nextScene is not (LevelLoader or Pico8.Emulator or OverworldReflectionsFall)) {
                 GFX.PortraitsSpriteBank = new SpriteBank(GFX.Portraits, Path.Combine("Graphics", "Portraits.xml"));
             }
 

--- a/Celeste.Mod.mm/Patches/LevelExit.cs
+++ b/Celeste.Mod.mm/Patches/LevelExit.cs
@@ -19,12 +19,18 @@ namespace Celeste {
     class patch_LevelExit : LevelExit {
 
         // We're effectively in LevelExit, but still need to "expose" private fields to our mod.
+        private Mode mode;
         private Session session;
         private XmlElement completeXml;
         private Atlas completeAtlas;
         private bool completeLoaded;
 
         private MapMetaCompleteScreen completeMeta;
+
+        // the mode field is private, but everest needs to access it
+        // however, making it public will break mods which use reflection to access the field...
+        // so we have no other option but to make a public property, oh well
+        public Mode Mode => mode;
 
         public patch_LevelExit(Mode mode, Session session, HiresSnow snow = null)
             : base(mode, session, snow) {

--- a/Celeste.Mod.mm/Patches/LevelExit.cs
+++ b/Celeste.Mod.mm/Patches/LevelExit.cs
@@ -19,18 +19,12 @@ namespace Celeste {
     class patch_LevelExit : LevelExit {
 
         // We're effectively in LevelExit, but still need to "expose" private fields to our mod.
-        private Mode mode;
         private Session session;
         private XmlElement completeXml;
         private Atlas completeAtlas;
         private bool completeLoaded;
 
         private MapMetaCompleteScreen completeMeta;
-
-        // the mode field is private, but everest needs to access it
-        // however, making it public will break mods which use reflection to access the field...
-        // so we have no other option but to make a public property, oh well
-        public Mode Mode => mode;
 
         public patch_LevelExit(Mode mode, Session session, HiresSnow snow = null)
             : base(mode, session, snow) {


### PR DESCRIPTION
Introduced by #890, portraits are reloaded on any scene change. This causes the portraits to reload in unintended scenarios, like reloading the map via <kbd>F5</kbd>, opening the Debug Map, or hitting any of the hardcoded <kbd>F1</kbd>-<kbd>F3</kbd> binds.

This PR fixes this unintended behavior. Tested locally and it works.