### PR TITLE
Bump TAS check dependencies

### DIFF
--- a/.github/tas-check/2-1-install.sh
+++ b/.github/tas-check/2-1-install.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 # Installs Everest from the branch to test, CelesteTAS and the mod that is going to be TASed.
-# Parameters: ID of the mod to be TASed, URL of the TAS files
+# Parameters: URL of the TAS files, URL of the mod bundle
 
 set -xeo pipefail
 
 docker build \
 	--build-arg "MAIN_BUILD_URL=`cat /tmp/everest-pr-tas-check/download-link.txt`" \
-	--build-arg "TAS_FILES_URL=$2" \
-	--build-arg "TAS_TO_RUN=$1" \
+	--build-arg "TAS_FILES_URL=$1" \
+	--build-arg "BUNDLE_DOWNLOAD_URL=$2" \
 	-t celeste .

--- a/.github/tas-check/2-2-install-inner.sh
+++ b/.github/tas-check/2-2-install-inner.sh
@@ -31,7 +31,8 @@ curl --fail -Lo CelesteTAS.zip "https://github.com/EverestAPI/CelesteTAS-Everest
 
 # install the mod that is going to be TASed, downloaded as a bundle zip containing the mod zip
 # and all of its dependencies (https://maddie480.ovh/celeste/bundle-download?id=${TAS_TO_RUN})
-# for simplicity's sake, Celeste-Bundle.zip exists but is an empty zip
-curl --fail -Lo t.zip "https://celestemodupdater.0x0a.de/pinned-mods/${TAS_TO_RUN}-Bundle.zip"
-unzip t.zip
-rm -v t.zip
+if ! [ "${BUNDLE_DOWNLOAD_URL}" == "" ]; then
+    curl --fail -Lo t.zip "${BUNDLE_DOWNLOAD_URL}"
+    unzip t.zip
+    rm -v t.zip
+fi

--- a/.github/tas-check/Dockerfile
+++ b/.github/tas-check/Dockerfile
@@ -1,5 +1,5 @@
 FROM max480/everest:vanilla
 
-ARG MAIN_BUILD_URL TAS_FILES_URL TAS_TO_RUN
+ARG MAIN_BUILD_URL TAS_FILES_URL BUNDLE_DOWNLOAD_URL
 COPY 2-2-install-inner.sh /tmp
 RUN /tmp/2-2-install-inner.sh && rm /tmp/2-2-install-inner.sh

--- a/.github/tas-check/run-locally.sh
+++ b/.github/tas-check/run-locally.sh
@@ -16,8 +16,9 @@ case "$1" in
         ;;
 
     "StrawberryJam2021")
-        TAS_URL="https://github.com/VampireFlower/StrawberryJamTAS/archive/fc7397c26f4d15468d4a8a3e58e7cc3d62d21223.zip"
-        TAS_PATH="StrawberryJamTAS-fc7397c26f4d15468d4a8a3e58e7cc3d62d21223/0-SJ All Levels.tas"
+        TAS_URL="https://github.com/VampireFlower/StrawberryJamTAS/archive/c9c589a8ef225def5aca869cc1ed3eedf588ec14.zip"
+        TAS_PATH="StrawberryJamTAS-c9c589a8ef225def5aca869cc1ed3eedf588ec14/0-SJ All Levels.tas"
+        BUNDLE_DOWNLOAD="https://celestemodupdater.0x0a.de/pinned-mods/StrawberryJam2021-Bundle-134df0f4.zip"
         ;;
 
     *)
@@ -27,5 +28,5 @@ esac
 
 cd "`dirname "$0"`"
 ./1-get-build-url.sh "$2"
-./2-1-install.sh "$1" "${TAS_URL}"
+./2-1-install.sh "${TAS_URL}" "${BUNDLE_DOWNLOAD}"
 ./3-run.sh "${TAS_PATH}"

--- a/.github/workflows/tas-sync-check.yml
+++ b/.github/workflows/tas-sync-check.yml
@@ -10,14 +10,13 @@ jobs:
       matrix:
         tas:
           - name: Celeste 100%
-            mod: Celeste
             url: "https://github.com/VampireFlower/CelesteTAS/archive/60b1680e61e43ec4681d7c9053d249491e0fe905.zip"
             path: "CelesteTAS-60b1680e61e43ec4681d7c9053d249491e0fe905/0 - 100%.tas"
 
           - name: Strawberry Jam All Levels
-            mod: StrawberryJam2021
-            url: "https://github.com/VampireFlower/StrawberryJamTAS/archive/fc7397c26f4d15468d4a8a3e58e7cc3d62d21223.zip"
-            path: "StrawberryJamTAS-fc7397c26f4d15468d4a8a3e58e7cc3d62d21223/0-SJ All Levels.tas"
+            url: "https://github.com/VampireFlower/StrawberryJamTAS/archive/c9c589a8ef225def5aca869cc1ed3eedf588ec14.zip"
+            path: "StrawberryJamTAS-c9c589a8ef225def5aca869cc1ed3eedf588ec14/0-SJ All Levels.tas"
+            bundle: "https://celestemodupdater.0x0a.de/pinned-mods/StrawberryJam2021-Bundle-134df0f4.zip"
 
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -32,8 +31,8 @@ jobs:
     - name: Wait for Azure build on commit ${{ github.sha }}
       run: cd .github/tas-check && ./1-get-build-url.sh "${{ github.sha }}"
 
-    - name: Install Everest and ${{ matrix.tas.mod }}
-      run: cd .github/tas-check && ./2-1-install.sh "${{ matrix.tas.mod }}" "${{ matrix.tas.url }}"
+    - name: Install Everest and required mods
+      run: cd .github/tas-check && ./2-1-install.sh "${{ matrix.tas.url }}" "${{ matrix.tas.bundle }}"
 
     - name: Run TAS at ${{ matrix.tas.path }}
       run: cd .github/tas-check && ./3-run.sh "${{ matrix.tas.path }}"


### PR DESCRIPTION
New post-release routine just dropped, not expecting reviews here, just opening a PR to check if bumping breaks anything.

- CelesteTAS: up-to-date :white_check_mark: @ [v3.45.1](https://github.com/EverestAPI/CelesteTAS-EverestInterop/releases/tag/v3.45.1)
- Celeste TAS files: up-to-date :white_check_mark: @ https://github.com/VampireFlower/CelesteTAS/commit/60b1680e61e43ec4681d7c9053d249491e0fe905
- Strawberry Jam TAS files: updated :arrow_up: @ https://github.com/VampireFlower/StrawberryJamTAS/commit/c9c589a8ef225def5aca869cc1ed3eedf588ec14
- Strawberry Jam bundle: updated :arrow_up: @ [134df0f4](https://celestemodupdater.0x0a.de/pinned-mods/StrawberryJam2021-Bundle-134df0f4.zip) (crc32 of the zip)