### PR TITLE
Handle 32-bit Unicode characters in dialog files

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Emoji.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Emoji.cs
@@ -1,8 +1,7 @@
-﻿using Monocle;
-using System.Collections;
+﻿using Celeste.Mod.Helpers;
+using Monocle;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Linq;
 using System.Text;
 using System.Xml;
 
@@ -16,6 +15,7 @@ namespace Celeste.Mod {
         /// A list of all registered emoji names, in order of their IDs.
         /// </summary>
         public static ReadOnlyCollection<string> Registered => new ReadOnlyCollection<string>(_Registered);
+
         public static char Last => (char) ('\uE000' + _Registered.Count - 1);
 
         private static List<string> _Registered = new List<string>();
@@ -23,9 +23,12 @@ namespace Celeste.Mod {
         private static List<bool> _IsMonochrome = new List<bool>();
         private static List<PixelFontCharacter> _Chars = new List<PixelFontCharacter>();
 
+        private static readonly CachedApply cachedApplies = new CachedApply();
+
         private static bool Initialized = false;
         private static Queue<KeyValuePair<string, MTexture>> Queue = new Queue<KeyValuePair<string, MTexture>>();
         private static XmlElement _FakeXML;
+
         public static XmlElement FakeXML {
             get {
                 if (_FakeXML != null)
@@ -129,6 +132,7 @@ namespace Celeste.Mod {
             }
 
             _Chars.Add(new PixelFontCharacter(Start + id, emoji, xml));
+            cachedApplies.Clear();
         }
 
         /// <summary>
@@ -174,68 +178,76 @@ namespace Celeste.Mod {
         public static bool IsMonochrome(char c)
             => _IsMonochrome[c - Start];
 
+        private class CachedApply : CacheHelper<string, string> {
+            public CachedApply() : base(name: "Emoji.Apply", maxSize: 1000) { }
+
+            protected override string compute(string text) {
+                if (text == null)
+                    return text;
+
+                // TODO: This trashes the GC and doesn't allow escaping!
+                lock (_IDs) {
+                    StringBuilder resultBuilder = new StringBuilder();
+                    int appendStartIndex = 0;
+                    int head = -1, tail = 0;
+                    // suppose text is "aaaa:1111:2222:bbbb", and only ":2222:" is emoji name
+                    // H = head, T = tail, S = appendStartIndex
+                    while (tail < text.Length) {
+                        if (text[tail] == ':') {
+                            if (head >= 0 && text[head] == ':') {
+                                /*
+                                        aaaa:1111:2222:bbbb
+                                    (2) ^S  ^H   ^T   ^
+                                    (4) ^S       ^H   ^T
+                                    now head and tail are pointing to colons so we need to check if the text inside colons is an emoji name
+                                */
+                                string name = text.Substring(head + 1, (tail - 1) - (head + 1) + 1);
+                                if (_IDs.TryGetValue(name, out int value)) {
+                                    // if it is, we need to first append the text before emoji
+                                    resultBuilder.Append(text, appendStartIndex, (head - 1) - appendStartIndex + 1);
+                                    // then append the emoji itself
+                                    resultBuilder.Append((char) (Start + value));
+                                    // the emoji name has been replaced, we need to advance tail pointer once
+                                    // because the colon is used and can't belong to next emoji
+                                    tail++;
+                                    appendStartIndex = tail;
+                                    /*
+                                            aaaa:1111:2222:bbbb
+                                        (5)          ^H   S^T
+                                    */
+                                }
+                            }
+                            head = tail;
+                            /*
+                                    aaaa:1111:2222:bbbb
+                                (1) ^S H^T   ^
+                                (3) ^S      H^T
+                                when tail is pointing to a colon, we need to let head also points to it
+                                so when tail moves to next colon, text[head..tail] can be an emoji name and we can check then replace it
+                            */
+                        }
+                        tail++;
+                    }
+                    /*
+                            aaaa:1111:2222:bbbb
+                        (6)               H^S  ^T
+                        there are still text left since last append, so we need to append them
+                    */
+                    if (appendStartIndex < text.Length) {
+                        resultBuilder.Append(text, appendStartIndex, (text.Length - 1) - appendStartIndex + 1);
+                    }
+                    return resultBuilder.ToString();
+                }
+            }
+        }
+
         /// <summary>
         /// Transforms all instances of :emojiname: to \uSTART+ID
         /// </summary>
         /// <param name="text"></param>
         /// <returns></returns>
         public static string Apply(string text) {
-            if (text == null)
-                return text;
-            // TODO: This trashes the GC and doesn't allow escaping!
-            lock (_IDs) {
-                StringBuilder resultBuilder = new StringBuilder();
-                int appendStartIndex = 0;
-                int head = -1, tail = 0;
-                // suppose text is "aaaa:1111:2222:bbbb", and only ":2222:" is emoji name
-                // H = head, T = tail, S = appendStartIndex
-                while (tail < text.Length) {
-                    if (text[tail] == ':') {
-                        if (head >= 0 && text[head] == ':') {
-                            /*
-                                    aaaa:1111:2222:bbbb
-                                (2) ^S  ^H   ^T   ^
-                                (4) ^S       ^H   ^T
-                                now head and tail are pointing to colons so we need to check if the text inside colons is an emoji name
-                            */
-                            string name = text.Substring(head + 1, (tail - 1) - (head + 1) + 1);
-                            if (_IDs.TryGetValue(name, out int value)) {
-                                // if it is, we need to first append the text before emoji
-                                resultBuilder.Append(text, appendStartIndex, (head - 1) - appendStartIndex + 1);
-                                // then append the emoji itself
-                                resultBuilder.Append((char) (Start + value));
-                                // the emoji name has been replaced, we need to advance tail pointer once
-                                // because the colon is used and can't belong to next emoji
-                                tail++;
-                                appendStartIndex = tail;
-                                /*
-                                        aaaa:1111:2222:bbbb
-                                    (5)          ^H   S^T
-                                */
-                            }
-                        }
-                        head = tail;
-                        /*
-                                aaaa:1111:2222:bbbb
-                            (1) ^S H^T   ^
-                            (3) ^S      H^T
-                            when tail is pointing to a colon, we need to let head also points to it
-                            so when tail moves to next colon, text[head..tail] can be an emoji name and we can check then replace it
-                        */
-                    }
-                    tail++;
-                }
-                /*
-                        aaaa:1111:2222:bbbb
-                    (6)               H^S  ^T
-                    there are still text left since last append, so we need to append them
-                */
-                if (appendStartIndex < text.Length) {
-                    resultBuilder.Append(text, appendStartIndex, (text.Length - 1) - appendStartIndex + 1);
-                }
-                return resultBuilder.ToString();
-            }
+            return cachedApplies.GetCached(text);
         }
-
     }
 }

--- a/Celeste.Mod.mm/Mod/Everest/Emoji.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Emoji.cs
@@ -181,7 +181,7 @@ namespace Celeste.Mod {
         private class CachedApply : CacheHelper<string, string> {
             public CachedApply() : base(name: "Emoji.Apply", maxSize: 1000) { }
 
-            protected override string compute(string text) {
+            protected override string Compute(string text) {
                 if (text == null)
                     return text;
 

--- a/Celeste.Mod.mm/Mod/Helpers/CacheHelper.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/CacheHelper.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+
+namespace Celeste.Mod.Helpers {
+    /**
+     * A helper class that wraps a <code>compute</code> function, in order to keep the
+     * latest computed values in memory (holding up to <code>maxSize</code> values),
+     * to help with performance or with repeated memory allocations.
+     */
+    public abstract class CacheHelper<Key, Value> {
+        private readonly string name;
+        private readonly int maxSize;
+        private readonly Dictionary<Key, Value> cache = new Dictionary<Key, Value>();
+        private readonly LinkedList<Key> cacheOldestToNewest = new LinkedList<Key>();
+
+        public CacheHelper(string name, int maxSize) {
+            this.name = name;
+            this.maxSize = maxSize;
+        }
+
+        public Value GetCached(Key key) {
+            lock (cache) {
+                if (cache.TryGetValue(key, out Value value)) {
+                    LinkedListNode<Key> node = cacheOldestToNewest.Find(key);
+                    cacheOldestToNewest.Remove(node);
+                    cacheOldestToNewest.AddLast(node);
+                    return value;
+                }
+
+                value = compute(key);
+                while (cache.Count >= maxSize) {
+                    Key keyToEvict = cacheOldestToNewest.First.Value;
+                    cache.Remove(keyToEvict);
+                    cacheOldestToNewest.RemoveFirst();
+                }
+
+                cache.Add(key, value);
+                cacheOldestToNewest.AddLast(key);
+                Logger.Verbose("CacheHelper", $"[{name}] Cached value for \"{key}\" => \"{value}\", cache size: {cache.Count}");
+                return value;
+            }
+        }
+
+        protected abstract Value compute(Key key);
+
+        public void Clear() {
+            lock (cache) {
+                cache.Clear();
+                cacheOldestToNewest.Clear();
+            }
+        }
+    }
+}

--- a/Celeste.Mod.mm/Mod/Helpers/CacheHelper.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/CacheHelper.cs
@@ -7,9 +7,14 @@ namespace Celeste.Mod.Helpers {
      * to help with performance or with repeated memory allocations.
      */
     public abstract class CacheHelper<Key, Value> {
+        private readonly struct ValueNode {
+            public LinkedListNode<Key> Node { get; init; }
+            public Value Value { get; init; }
+        }
+
         private readonly string name;
         private readonly int maxSize;
-        private readonly Dictionary<Key, Value> cache = new Dictionary<Key, Value>();
+        private readonly Dictionary<Key, ValueNode> cache = new Dictionary<Key, ValueNode>();
         private readonly LinkedList<Key> cacheOldestToNewest = new LinkedList<Key>();
 
         public CacheHelper(string name, int maxSize) {
@@ -19,28 +24,27 @@ namespace Celeste.Mod.Helpers {
 
         public Value GetCached(Key key) {
             lock (cache) {
-                if (cache.TryGetValue(key, out Value value)) {
-                    LinkedListNode<Key> node = cacheOldestToNewest.Find(key);
-                    cacheOldestToNewest.Remove(node);
-                    cacheOldestToNewest.AddLast(node);
-                    return value;
+                if (cache.TryGetValue(key, out ValueNode valueNode)) {
+                    cacheOldestToNewest.Remove(valueNode.Node);
+                    cacheOldestToNewest.AddLast(valueNode.Node);
+                    return valueNode.Value;
                 }
 
-                value = compute(key);
+                Value value = Compute(key);
                 while (cache.Count >= maxSize) {
                     Key keyToEvict = cacheOldestToNewest.First.Value;
                     cache.Remove(keyToEvict);
                     cacheOldestToNewest.RemoveFirst();
                 }
 
-                cache.Add(key, value);
-                cacheOldestToNewest.AddLast(key);
+                LinkedListNode<Key> node = cacheOldestToNewest.AddLast(key);
+                cache.Add(key, new ValueNode { Node = node, Value = value });
                 Logger.Verbose("CacheHelper", $"[{name}] Cached value for \"{key}\" => \"{value}\", cache size: {cache.Count}");
                 return value;
             }
         }
 
-        protected abstract Value compute(Key key);
+        protected abstract Value Compute(Key key);
 
         public void Clear() {
             lock (cache) {

--- a/Celeste.Mod.mm/Mod/Helpers/UnicodeStringHelper.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/UnicodeStringHelper.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using YamlDotNet.Core.Tokens;
 
 namespace Celeste.Mod.Helpers {
     public static class UnicodeStringHelper {
@@ -10,33 +11,20 @@ namespace Celeste.Mod.Helpers {
             public int this[int index] => Elements[index];
         }
 
-        private const int CACHE_MAX_SIZE = 1000;
-        private static readonly Dictionary<string, ListInt> cache = new Dictionary<string, ListInt>();
-        private static readonly LinkedList<string> cacheOldestToNewest = new LinkedList<string>();
+        private class Cacher : CacheHelper<string, ListInt> {
+            public Cacher() : base(name: "UnicodeStringHelper.ToCodePointList", maxSize: 1000) { }
 
-        public static ListInt ToCodePointList(string text) {
-            lock (cache) {
-                if (cache.TryGetValue(text, out ListInt list)) {
-                    LinkedListNode<string> node = cacheOldestToNewest.Find(text);
-                    cacheOldestToNewest.Remove(node);
-                    cacheOldestToNewest.AddLast(node);
-                    return list;
-                }
-
-                list = new ListInt {
+            protected override ListInt compute(string text) {
+                return new ListInt {
                     Elements = text.EnumerateRunes().Select(r => r.Value).ToArray()
                 };
-                while (cache.Count >= CACHE_MAX_SIZE) {
-                    string textToEvict = cacheOldestToNewest.First.Value;
-                    cache.Remove(textToEvict);
-                    cacheOldestToNewest.RemoveFirst();
-                }
-
-                cache.Add(text, list);
-                cacheOldestToNewest.AddLast(text);
-                Logger.Verbose("UnicodeStringHelper", $"Cached unicode code point list for \"{text}\", cache size: {cache.Count}");
-                return list;
             }
+        }
+
+        private static readonly Cacher cacher = new Cacher();
+
+        public static ListInt ToCodePointList(string text) {
+            return cacher.GetCached(text);
         }
     }
 }

--- a/Celeste.Mod.mm/Mod/Helpers/UnicodeStringHelper.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/UnicodeStringHelper.cs
@@ -14,7 +14,7 @@ namespace Celeste.Mod.Helpers {
         private class Cacher : CacheHelper<string, ListInt> {
             public Cacher() : base(name: "UnicodeStringHelper.ToCodePointList", maxSize: 1000) { }
 
-            protected override ListInt compute(string text) {
+            protected override ListInt Compute(string text) {
                 return new ListInt {
                     Elements = text.EnumerateRunes().Select(r => r.Value).ToArray()
                 };

--- a/Celeste.Mod.mm/Mod/Helpers/UnicodeStringHelper.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/UnicodeStringHelper.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Celeste.Mod.Helpers {
+    public static class UnicodeStringHelper {
+        // helper class because manipulating generic types in IL is annoying
+        public class ListInt {
+            public required int[] Elements;
+            public int Count => Elements.Length;
+            public int this[int index] => Elements[index];
+        }
+
+        private const int CACHE_MAX_SIZE = 1000;
+        private static readonly Dictionary<string, ListInt> cache = new Dictionary<string, ListInt>();
+        private static readonly LinkedList<string> cacheOldestToNewest = new LinkedList<string>();
+
+        public static ListInt ToCodePointList(string text) {
+            lock (cache) {
+                if (cache.TryGetValue(text, out ListInt list)) {
+                    LinkedListNode<string> node = cacheOldestToNewest.Find(text);
+                    cacheOldestToNewest.Remove(node);
+                    cacheOldestToNewest.AddLast(node);
+                    return list;
+                }
+
+                list = new ListInt {
+                    Elements = text.EnumerateRunes().Select(r => r.Value).ToArray()
+                };
+                while (cache.Count >= CACHE_MAX_SIZE) {
+                    string textToEvict = cacheOldestToNewest.First.Value;
+                    cache.Remove(textToEvict);
+                    cacheOldestToNewest.RemoveFirst();
+                }
+
+                cache.Add(text, list);
+                cacheOldestToNewest.AddLast(text);
+                Logger.Verbose("UnicodeStringHelper", $"Cached unicode code point list for \"{text}\", cache size: {cache.Count}");
+                return list;
+            }
+        }
+    }
+}

--- a/Celeste.Mod.mm/Patches/FancyText.cs
+++ b/Celeste.Mod.mm/Patches/FancyText.cs
@@ -3,11 +3,13 @@
 using Celeste.Mod;
 using Microsoft.Xna.Framework;
 using Monocle;
+using MonoMod;
 
 namespace Celeste {
     // The FancyText ctor is private.
     class patch_FancyText {
 
+        [PatchTextIteration]
         private extern void orig_AddWord(string word);
         private void AddWord(string word) {
             word = Emoji.Apply(word);

--- a/Celeste.Mod.mm/Patches/Monocle/PixelFontSize.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/PixelFontSize.cs
@@ -1,16 +1,29 @@
 ﻿#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
 
 using Celeste.Mod;
+using Celeste.Mod.Helpers;
 using Microsoft.Xna.Framework;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using MonoMod;
+using MonoMod.Cil;
+using MonoMod.InlineRT;
+using MonoMod.Utils;
+using System;
 
 namespace Monocle {
     class patch_PixelFontSize : PixelFontSize {
 
+        [PatchTextIteration]
         public extern Vector2 orig_Measure(string text);
         public new Vector2 Measure(string text) {
             text = Emoji.Apply(text);
             return orig_Measure(text);
         }
+
+        [MonoModIgnore]
+        [PatchTextIteration]
+        public extern new float WidthToNextLine(string text, int start);
 
         public extern void orig_Draw(char character, Vector2 position, Vector2 justify, Vector2 scale, Color color);
         public new void Draw(char character, Vector2 position, Vector2 justify, Vector2 scale, Color color) {
@@ -22,7 +35,7 @@ namespace Monocle {
             orig_Draw(character, position, justify, scale, color);
         }
 
-        public extern void orig_Draw(string text, Vector2 position, Vector2 justify, Vector2 scale, Color color, float edgeDepth, Color edgeColor, float stroke, Color strokeColor);
+        [MonoModReplace]
         public new void Draw(string text, Vector2 position, Vector2 justify, Vector2 scale, Color color, float edgeDepth, Color edgeColor, float stroke, Color strokeColor) {
             text = Emoji.Apply(text);
 
@@ -35,8 +48,9 @@ namespace Monocle {
                 HeightOf(text) * justify.Y
             );
 
-            for (int i = 0; i < text.Length; i++) {
-                if (text[i] == '\n') {
+            UnicodeStringHelper.ListInt codePoints = UnicodeStringHelper.ToCodePointList(text);
+            for (int i = 0; i < codePoints.Count; i++) {
+                if (codePoints[i] == '\n') {
                     offset.X = 0f;
                     offset.Y += LineHeight;
                     if (justify.X != 0f)
@@ -45,7 +59,7 @@ namespace Monocle {
                 }
 
                 PixelFontCharacter c = null;
-                if (!Characters.TryGetValue(text[i], out c))
+                if (!Characters.TryGetValue(codePoints[i], out c))
                     continue;
 
                 Vector2 pos = position + (offset + new Vector2(c.XOffset, c.YOffset) - justifyOffs) * scale;
@@ -84,11 +98,70 @@ namespace Monocle {
 
                 offset.X += c.XAdvance;
 
-                if (i < text.Length - 1 && c.Kerning.TryGetValue(text[i + 1], out int kerning)) {
+                if (i < codePoints.Count - 1 && c.Kerning.TryGetValue(codePoints[i + 1], out int kerning)) {
                     offset.X += kerning;
                 }
             }
         }
 
+    }
+}
+
+namespace MonoMod {
+    /// <summary>
+    /// Replace the char-by-char text iteration with a codepoint-per-codepoint one.
+    /// </summary>
+    [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchTextIteration))]
+    class PatchTextIterationAttribute : Attribute {
+    }
+
+    static partial class MonoModRules {
+        public static void PatchTextIteration(ILContext context, CustomAttribute attrib) {
+            TypeReference t_List_int = MonoModRule.Modder.FindType("Celeste.Mod.Helpers.UnicodeStringHelper").Resolve().NestedTypes[0];
+            VariableDefinition v_listOfCodePoints = new VariableDefinition(t_List_int);
+            context.Body.Variables.Add(v_listOfCodePoints);
+
+            ILCursor cursor = new ILCursor(context);
+            if (context.Method.Name == "orig_AddWord") {
+                // start after the PixelFontSize.Measure call because it needs to get the original text, not the code point thingy
+                cursor.GotoNext(MoveType.After, instr => instr.OpCode == OpCodes.Callvirt && (instr.Operand as MethodReference)?.Name == "Measure");
+            }
+
+            // List<int> listOfCodePoints = UnicodeStringHelper.ToCodePointList(text);
+            cursor.Emit(OpCodes.Ldarg_1);
+            cursor.Emit(OpCodes.Call, MonoModRule.Modder.FindType("Celeste.Mod.Helpers.UnicodeStringHelper").Resolve().FindMethod("ToCodePointList"));
+            cursor.Emit(OpCodes.Stloc, v_listOfCodePoints);
+
+            // string.IsNullOrEmpty => isEmpty
+            int index = cursor.Index;
+            while (cursor.TryGotoNext(instr => instr.MatchCall<string>("IsNullOrEmpty"))) {
+                cursor.Next.OpCode = OpCodes.Call;
+                cursor.Next.Operand = t_List_int.Resolve().FindMethod("get_Count");
+                cursor.Index++;
+                cursor.Emit(OpCodes.Ldc_I4_0);
+                cursor.Emit(OpCodes.Ceq);
+            }
+
+            // text => listOfCodePoints
+            cursor.Index = index;
+            while (cursor.TryGotoNext(instr => instr.MatchLdarg1())) {
+                cursor.Next.OpCode = OpCodes.Ldloc;
+                cursor.Next.Operand = v_listOfCodePoints;
+            }
+
+            // text.Length => listOfCodePoints.Count
+            cursor.Index = index;
+            while (cursor.TryGotoNext(instr => instr.MatchCallvirt<string>("get_Length"))) {
+                cursor.Next.OpCode = OpCodes.Call;
+                cursor.Next.Operand = t_List_int.Resolve().FindMethod("get_Count");
+            }
+
+            // text[i] => listOfCodePoints[i]
+            cursor.Index = index;
+            while (cursor.TryGotoNext(instr => instr.MatchCallvirt<string>("get_Chars"))) {
+                cursor.Next.OpCode = OpCodes.Call;
+                cursor.Next.Operand = t_List_int.Resolve().FindMethod("get_Item");
+            }
+        }
     }
 }


### PR DESCRIPTION
C# strings are encoded in UTF-16, and when encountering characters above U+FFFF, you get 2 chars ("surrogate pair") if you just iterate on the string. This PR adds a utility method to turn a string into an array of ints (with a small cache to avoid instantiating them on each frame) and patches a few methods with an IL hook that pretty much replaces `text` with `codePointArray`.