### PR TITLE
Fix hardlock when leaving OuiMapSearch

### DIFF
--- a/Celeste.Mod.mm/Mod/UI/OuiMapSearch.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiMapSearch.cs
@@ -463,6 +463,7 @@ namespace Celeste.Mod.UI {
             FromChapterSelect = false;
 
             MInput.Disabled = false;
+            Searching = false;
 
             menu.Focused = false;
 
@@ -480,7 +481,6 @@ namespace Celeste.Mod.UI {
             }
 
             menu.Visible = Visible = false;
-            Searching = false;
             menu.RemoveSelf();
             menu = null;
         }


### PR DESCRIPTION
The game still processes inputs in the `OnTextInput` handler when leaving the `OuiMapSearch`.

This can cause a "hardlock" (game not processing any input), because the handler can disable the input engine.

The "hardlock" can be reproduced by entering some input when transitioning from the `OuiMapSearch` to the `OuiChapterSelect`.

This PR prevents the "hardlock" by removing the handler (which is done by setting `Searching` to `false`) right at the start of the `Leave` method, instead of waiting for the transition to end.

_(originally reported by `tobyaaa` on Discord)_