### PR TITLE
Make OnEndOfFrame thread safe

### DIFF
--- a/Celeste.Mod.mm/Patches/Monocle/Scene.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Scene.cs
@@ -3,6 +3,8 @@ using MonoMod;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
 
 namespace Monocle {
     class patch_Scene : Scene {
@@ -41,5 +43,10 @@ namespace Monocle {
         
         internal void ClearOnEndOfFrame() => OnEndOfFrame = null;
 
+        [MonoModReplace]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public new virtual void AfterUpdate() {
+            Interlocked.Exchange(ref OnEndOfFrame, null)?.Invoke();
+        }
     }
 }


### PR DESCRIPTION
Previously: Any `OnEndOfFrame` added during `OnEndOfFrame` invocation will be discarded.

Changes: They will be invoked in next frame.

Note: `OnEndOfFrame` can add new `OnEndOfFrame`s. Nobody should be doing this (otherwise they will notice it), but if it happens, this pr causes desync.