### PR TITLE
Remove Mono HTTPS workaround

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/ContentExtensions.cs
+++ b/Celeste.Mod.mm/Mod/Everest/ContentExtensions.cs
@@ -26,7 +26,8 @@ namespace Celeste.Mod {
             ?.GetMethod("FNA3D_Image_Free")
             ?.CreateDelegate<d_FNA3D_Image_Free>();
 
-        public static readonly bool TextureSetDataSupportsPtr = Everest.Flags.IsFNA;
+        [Obsolete("`TextureSetDataSupportsPtr` is always true on Everest Core")]
+        public static readonly bool TextureSetDataSupportsPtr = true;
 
         /// <summary>
         /// Determine if the MTexture depicts a region of a larger VirtualTexture.

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Flags.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Flags.cs
@@ -12,22 +12,24 @@ namespace Celeste.Mod {
             /// <summary>
             /// Is the game running on XNA - always false on .NET Core Everest.
             /// </summary>
+            [Obsolete("`IsXNA` is always false on Everest Core")]
             public static bool IsXNA => false;
 
             /// <summary>
             /// Is the game running on FNA - always true on .NET Core Everest.
             /// </summary>
+            [Obsolete("`IsFNA` is always true on Everest Core")]
             public static bool IsFNA => true;
 
             /// <summary>
             /// Is the vanilla install running on XNA?
             /// </summary>
-            public static bool VanillaIsXNA { get; private set;}
+            public static bool VanillaIsXNA { get; private set; }
 
             /// <summary>
             /// Is the vanilla install running on FNA?
             /// </summary>
-            public static bool VanillaIsFNA { get; private set;}
+            public static bool VanillaIsFNA { get; private set; }
 
             /// <summary>
             /// Is Everest running without a window?
@@ -37,6 +39,7 @@ namespace Celeste.Mod {
             /// <summary>
             /// Is the game running using Mono - always false on .NET Core Everest.
             /// </summary>
+            [Obsolete("`IsMono` is always false on Everest Core")]
             public static bool IsMono => false;
 
             /// <summary>
@@ -51,7 +54,8 @@ namespace Celeste.Mod {
             /// <summary>
             /// Does the environment (renderer, framework ,...) prefer threaded GL?
             /// </summary>
-            public static bool PreferThreadedGL { get; private set; }
+            [Obsolete("`PreferThreadedGL` is always false on Everest Core")]
+            public static bool PreferThreadedGL => false;
 
             /// <summary>
             /// Does the environment (platform, ...) support loading runtime mods?
@@ -77,9 +81,6 @@ namespace Celeste.Mod {
 
                 AvoidRenderTargets = Environment.GetEnvironmentVariable("EVEREST_NO_RT") == "1";
                 PreferLazyLoading = false;
-
-                // The way how FNA3D's D3D11 implementation handles threaded GL is hated by a few drivers.
-                PreferThreadedGL = IsXNA;
 
                 SupportRuntimeMods = true;
                 SupportUpdatingEverest = true;

--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -321,13 +321,6 @@ namespace Celeste.Mod {
             Logger.Info("core", $"SystemMemoryMB: {SystemMemoryMB:F3} MB");
             Logger.Info("core", $"RuntimeVersion: {Environment.Version}");
 
-            if (Type.GetType("Mono.Runtime") != null) {
-                // Mono hates HTTPS.
-                ServicePointManager.ServerCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) => {
-                    return true;
-                };
-            }
-
             // enable TLS 1.2 to fix connecting to everestapi.github.io
             ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
 

--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -61,8 +61,8 @@ namespace Celeste.Mod {
         /// <summary>
         /// The currently present Celeste version combined with the currently installed Everest build.
         /// </summary>
-        // we cannot use Everest.Flags.IsFNA at this point because flags aren't initialized yet when it's used for the first time in log
-        public static string VersionCelesteString => $"{Celeste.Instance.Version}-{(typeof(Game).Assembly.FullName.Contains("FNA") ? "fna" : "xna")} [Everest: {BuildString}]";
+        // assume FNA since Everest Core
+        public static string VersionCelesteString => $"{Celeste.Instance.Version}-fna [Everest: {BuildString}]";
 
         /// <summary>
         /// UTF8 text encoding without a byte order mark, to be preferred over Encoding.UTF8
@@ -447,7 +447,7 @@ namespace Celeste.Mod {
             // Note: Everest fulfills some mod dependencies by itself.
             NullModule vanilla = new NullModule(new EverestModuleMetadata {
                 Name = "Celeste",
-                VersionString = $"{Celeste.Instance.Version.ToString()}-{(Flags.IsFNA ? "fna" : "xna")}"
+                VersionString = $"{Celeste.Instance.Version.ToString()}-fna"
             });
             vanilla.Register();
             vanilla.Metadata.RegisterMod();
@@ -871,12 +871,7 @@ namespace Celeste.Mod {
             }
 
             AppDomain.CurrentDomain.SetData("EverestRestart", true);
-            scene.RunAfterRender = () => {
-                if (Flags.IsXNA && Engine.Graphics.IsFullScreen) {
-                    Engine.SetWindowed(320 * (Settings.Instance?.WindowScale ?? 1), 180 * (Settings.Instance?.WindowScale ?? 1));
-                }
-                Engine.Instance.Exit();
-            };
+            scene.RunAfterRender = Engine.Instance.Exit;
             yield break;
         }
 

--- a/Celeste.Mod.mm/Patches/Celeste.cs
+++ b/Celeste.Mod.mm/Patches/Celeste.cs
@@ -346,7 +346,7 @@ https://discord.gg/6qjaePQ");
              * -ade
              */
 
-            if (CoreModule.Settings.FastTextureLoading ?? (Environment.ProcessorCount >= 4 && !(CoreModule.Settings.ThreadedGL ?? false))) {
+            if (CoreModule.Settings.FastTextureLoading ?? (Environment.ProcessorCount >= 4 && (!CoreModule.Settings.ThreadedGL ?? true))) {
                 long limit = (long) (CoreModule.Settings.FastTextureLoadingMaxMB * 1024f * 1024f);
 
                 if (limit <= 0) {

--- a/Celeste.Mod.mm/Patches/Celeste.cs
+++ b/Celeste.Mod.mm/Patches/Celeste.cs
@@ -44,10 +44,9 @@ namespace Celeste {
                 Thread.CurrentThread.Name = "Main Thread";
             }
 
-            // we cannot use Everest.Flags.IsFNA at this point because flags aren't initialized yet.
-            bool isFNA = typeof(Game).Assembly.FullName.Contains("FNA");
-            string correctFile = $"BuildIs{(isFNA ? "FNA" : "XNA")}.txt";
-            string wrongFile = $"BuildIs{(isFNA ? "XNA" : "FNA")}.txt";
+            // we assume FNA since Everest Core.
+            string correctFile = "BuildIsFNA.txt";
+            string wrongFile = "BuildIsXNA.txt";
             if (File.Exists(wrongFile))
                 File.Delete(wrongFile);
             if (!File.Exists(correctFile))
@@ -347,7 +346,7 @@ https://discord.gg/6qjaePQ");
              * -ade
              */
 
-            if (CoreModule.Settings.FastTextureLoading ?? (Environment.ProcessorCount >= 4 && !(CoreModule.Settings.ThreadedGL ?? Everest.Flags.PreferThreadedGL))) {
+            if (CoreModule.Settings.FastTextureLoading ?? (Environment.ProcessorCount >= 4 && !(CoreModule.Settings.ThreadedGL ?? false))) {
                 long limit = (long) (CoreModule.Settings.FastTextureLoadingMaxMB * 1024f * 1024f);
 
                 if (limit <= 0) {

--- a/Celeste.Mod.mm/Patches/Level.cs
+++ b/Celeste.Mod.mm/Patches/Level.cs
@@ -562,7 +562,7 @@ namespace Celeste {
 
         private static object _GCCollectLock = Tuple.Create(new object(), "Level Transition GC.Collect");
         private static void _GCCollect() {
-            if (!(CoreModule.Settings.MultithreadedGC ?? !Everest.Flags.IsMono)) {
+            if (!(CoreModule.Settings.MultithreadedGC ?? true)) {
                 GC.Collect();
                 return;
             }

--- a/Celeste.Mod.mm/Patches/Level.cs
+++ b/Celeste.Mod.mm/Patches/Level.cs
@@ -562,7 +562,7 @@ namespace Celeste {
 
         private static object _GCCollectLock = Tuple.Create(new object(), "Level Transition GC.Collect");
         private static void _GCCollect() {
-            if (!(CoreModule.Settings.MultithreadedGC ?? true)) {
+            if (!CoreModule.Settings.MultithreadedGC ?? false) {
                 GC.Collect();
                 return;
             }

--- a/Celeste.Mod.mm/Patches/Monocle/VirtualTexture.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/VirtualTexture.cs
@@ -361,7 +361,7 @@ namespace Monocle {
             if (tex == null || tex.IsDisposed)
                 return;
 
-            if (!(CoreModule.Settings.ThreadedGL ?? false) && !MainThreadHelper.IsMainThread) {
+            if ((!CoreModule.Settings.ThreadedGL ?? true) && !MainThreadHelper.IsMainThread) {
                 MainThreadHelper.Schedule(() => tex.Dispose());
             } else {
                 tex.Dispose();

--- a/Celeste.Mod.mm/Patches/Monocle/VirtualTexture.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/VirtualTexture.cs
@@ -361,7 +361,7 @@ namespace Monocle {
             if (tex == null || tex.IsDisposed)
                 return;
 
-            if (!(CoreModule.Settings.ThreadedGL ?? Everest.Flags.PreferThreadedGL) && !MainThreadHelper.IsMainThread) {
+            if (!(CoreModule.Settings.ThreadedGL ?? false) && !MainThreadHelper.IsMainThread) {
                 MainThreadHelper.Schedule(() => tex.Dispose());
             } else {
                 tex.Dispose();
@@ -369,7 +369,7 @@ namespace Monocle {
         }
 
         internal bool LoadImmediately =>
-            !_Texture_FTLLoading && ((CoreModule.Settings.ThreadedGL ?? Everest.Flags.PreferThreadedGL) || MainThreadHelper.IsMainThread);
+            !_Texture_FTLLoading && ((CoreModule.Settings.ThreadedGL ?? false) || MainThreadHelper.IsMainThread);
         internal bool Load(bool wait, Func<Texture2D> load) {
             if (LoadImmediately) {
                 Texture_Unsafe?.Dispose();
@@ -511,39 +511,21 @@ namespace Monocle {
                             if (Metadata.TryGetMeta(out TextureMeta meta))
                                 premul = meta.Premultiplied;
 
-                            if (ContentExtensions.TextureSetDataSupportsPtr) {
-                                int w, h;
-                                IntPtr dataPtr;
-                                if (premul)
-                                    ContentExtensions.LoadTextureRaw(Celeste.Celeste.Instance.GraphicsDevice, stream, out w, out h, out dataPtr);
-                                else
-                                    ContentExtensions.LoadTextureLazyPremultiply(Celeste.Celeste.Instance.GraphicsDevice, stream, out w, out h, out dataPtr);
-                                stream.Dispose();
-                                Width = w;
-                                Height = h;
-                                Load(false, () => {
-                                    Texture2D tex = new Texture2D(Celeste.Celeste.Instance.GraphicsDevice, w, h, false, SurfaceFormat.Color);
-                                    tex.SetData(dataPtr);
-                                    ContentExtensions.UnloadTextureRaw(dataPtr);
-                                    return tex;
-                                });
-                            } else {
-                                int w, h;
-                                byte[] data;
-                                if (premul)
-                                    ContentExtensions.LoadTextureRaw(Celeste.Celeste.Instance.GraphicsDevice, stream, out w, out h, out data);
-                                else
-                                    ContentExtensions.LoadTextureLazyPremultiply(Celeste.Celeste.Instance.GraphicsDevice, stream, out w, out h, out data);
-                                stream.Dispose();
-                                Width = w;
-                                Height = h;
-                                Load(false, () => {
-                                    Texture2D tex = new Texture2D(Celeste.Celeste.Instance.GraphicsDevice, w, h, false, SurfaceFormat.Color);
-                                    tex.SetData(data);
-                                    data = null;
-                                    return tex;
-                                });
-                            }
+                            int w, h;
+                            IntPtr dataPtr; // assume Texture.SetData supports Ptr since we are using FNA
+                            if (premul)
+                                ContentExtensions.LoadTextureRaw(Celeste.Celeste.Instance.GraphicsDevice, stream, out w, out h, out dataPtr);
+                            else
+                                ContentExtensions.LoadTextureLazyPremultiply(Celeste.Celeste.Instance.GraphicsDevice, stream, out w, out h, out dataPtr);
+                            stream.Dispose();
+                            Width = w;
+                            Height = h;
+                            Load(false, () => {
+                                Texture2D tex = new Texture2D(Celeste.Celeste.Instance.GraphicsDevice, w, h, false, SurfaceFormat.Color);
+                                tex.SetData(dataPtr);
+                                ContentExtensions.UnloadTextureRaw(dataPtr);
+                                return tex;
+                            });
                         }
 
                     } else if (Fallback != null) {
@@ -564,17 +546,12 @@ namespace Monocle {
                                 if (premul) {
                                     Texture2D tex = Texture2D.FromStream(Celeste.Celeste.Instance.GraphicsDevice, stream);
                                     return tex;
-                                } else if (ContentExtensions.TextureSetDataSupportsPtr) {
+                                } else {
                                     ContentExtensions.LoadTextureLazyPremultiply(Celeste.Celeste.Instance.GraphicsDevice, stream, out int w, out int h, out IntPtr dataPtr);
                                     Texture2D tex = new Texture2D(Celeste.Celeste.Instance.GraphicsDevice, w, h, false, SurfaceFormat.Color);
+                                     // assume Texture.SetData supports Ptr since we are using FNA
                                     tex.SetData(dataPtr);
                                     ContentExtensions.UnloadTextureRaw(dataPtr);
-                                    return tex;
-                                } else {
-                                    ContentExtensions.LoadTextureLazyPremultiply(Celeste.Celeste.Instance.GraphicsDevice, stream, out int w, out int h, out byte[] data);
-                                    Texture2D tex = new Texture2D(Celeste.Celeste.Instance.GraphicsDevice, w, h, false, SurfaceFormat.Color);
-                                    tex.SetData(data);
-                                    data = null;
                                     return tex;
                                 }
 
@@ -602,7 +579,7 @@ namespace Monocle {
 
             } else {
                 int w, h;
-                bool bufferGC = !ContentExtensions.TextureSetDataSupportsPtr;
+                bool bufferGC = false;
                 byte[] buffer = null;
                 IntPtr bufferPtr = IntPtr.Zero;
                 bool bufferStolen = false;

--- a/Celeste.Mod.mm/Patches/MountainModel.cs
+++ b/Celeste.Mod.mm/Patches/MountainModel.cs
@@ -451,7 +451,7 @@ namespace Celeste {
                 }
             }
 
-            if (!(CoreModule.Settings.ThreadedGL ?? Everest.Flags.PreferThreadedGL) && !MainThreadHelper.IsMainThread && queuedLoadLock == null) {
+            if (!(CoreModule.Settings.ThreadedGL ?? false) && !MainThreadHelper.IsMainThread && queuedLoadLock == null) {
                 // Let's queue a reload onto the main thread and call it a day.
                 lock (queuedLoadLock = new object()) {
                     _Billboard_QueuedLoadLock = queuedLoadLock;

--- a/Celeste.Mod.mm/Patches/MountainModel.cs
+++ b/Celeste.Mod.mm/Patches/MountainModel.cs
@@ -451,7 +451,7 @@ namespace Celeste {
                 }
             }
 
-            if (!(CoreModule.Settings.ThreadedGL ?? false) && !MainThreadHelper.IsMainThread && queuedLoadLock == null) {
+            if ((!CoreModule.Settings.ThreadedGL ?? true) && !MainThreadHelper.IsMainThread && queuedLoadLock == null) {
                 // Let's queue a reload onto the main thread and call it a day.
                 lock (queuedLoadLock = new object()) {
                     _Billboard_QueuedLoadLock = queuedLoadLock;

--- a/Celeste.Mod.mm/Patches/ObjModel.cs
+++ b/Celeste.Mod.mm/Patches/ObjModel.cs
@@ -160,7 +160,7 @@ namespace Celeste {
                 }
             }
 
-            if (!(CoreModule.Settings.ThreadedGL ?? Everest.Flags.PreferThreadedGL) && !MainThreadHelper.IsMainThread && queuedLoadLock == null) {
+            if (!(CoreModule.Settings.ThreadedGL ?? false) && !MainThreadHelper.IsMainThread && queuedLoadLock == null) {
                 // Let's queue a reload onto the main thread and call it a day.
                 lock (queuedLoadLock = new object()) {
                     _Vertices_QueuedLoadLock = queuedLoadLock;

--- a/Celeste.Mod.mm/Patches/ObjModel.cs
+++ b/Celeste.Mod.mm/Patches/ObjModel.cs
@@ -160,7 +160,7 @@ namespace Celeste {
                 }
             }
 
-            if (!(CoreModule.Settings.ThreadedGL ?? false) && !MainThreadHelper.IsMainThread && queuedLoadLock == null) {
+            if ((!CoreModule.Settings.ThreadedGL ?? true) && !MainThreadHelper.IsMainThread && queuedLoadLock == null) {
                 // Let's queue a reload onto the main thread and call it a day.
                 lock (queuedLoadLock = new object()) {
                     _Vertices_QueuedLoadLock = queuedLoadLock;

--- a/Celeste.Mod.mm/Patches/OuiTitleScreen.cs
+++ b/Celeste.Mod.mm/Patches/OuiTitleScreen.cs
@@ -122,9 +122,6 @@ namespace Celeste {
                     Everest.RestartVanilla = true;
                     new FadeWipe(Scene, false, () => {
                         Engine.Scene = new Scene();
-                        if (Everest.Flags.IsXNA && Engine.Graphics.IsFullScreen) {
-                            Engine.SetWindowed(320 * Settings.Instance.WindowScale, 180 * Settings.Instance.WindowScale);
-                        }
                         Engine.Instance.Exit();
                     });
                 }


### PR DESCRIPTION
The `Mono` runtime is no longer relevant since Everest is now using the `.NET` runtime.

This PR removes an old `Mono`-specific HTTPS workaround.