### PR TITLE
Bump TAS Check dependencies

### DIFF
--- a/.github/tas-check/run-locally.sh
+++ b/.github/tas-check/run-locally.sh
@@ -11,14 +11,14 @@ set -xeo pipefail
 
 case "$1" in
     "Celeste")
-        TAS_URL="https://github.com/VampireFlower/CelesteTAS/archive/60b1680e61e43ec4681d7c9053d249491e0fe905.zip"
-        TAS_PATH="CelesteTAS-60b1680e61e43ec4681d7c9053d249491e0fe905/0 - 100%.tas"
+        TAS_URL="https://github.com/VampireFlower/CelesteTAS/archive/9332a874faac2fd0949180f7447222c91b202b51.zip"
+        TAS_PATH="CelesteTAS-9332a874faac2fd0949180f7447222c91b202b51/0 - 100%.tas"
         ;;
 
     "StrawberryJam2021")
-        TAS_URL="https://github.com/VampireFlower/StrawberryJamTAS/archive/c9c589a8ef225def5aca869cc1ed3eedf588ec14.zip"
-        TAS_PATH="StrawberryJamTAS-c9c589a8ef225def5aca869cc1ed3eedf588ec14/0-SJ All Levels.tas"
-        BUNDLE_DOWNLOAD="https://celestemodupdater.0x0a.de/pinned-mods/StrawberryJam2021-Bundle-134df0f4.zip"
+        TAS_URL="https://github.com/VampireFlower/StrawberryJamTAS/archive/2f6ffde25cfeafda7b38523b50034d9c4313053f.zip"
+        TAS_PATH="StrawberryJamTAS-2f6ffde25cfeafda7b38523b50034d9c4313053f/0-SJ All Levels.tas"
+        BUNDLE_DOWNLOAD="https://celestemodupdater.0x0a.de/pinned-mods/StrawberryJam2021-Bundle-8cc2878e.zip"
         ;;
 
     *)

--- a/.github/workflows/tas-sync-check.yml
+++ b/.github/workflows/tas-sync-check.yml
@@ -10,13 +10,13 @@ jobs:
       matrix:
         tas:
           - name: Celeste 100%
-            url: "https://github.com/VampireFlower/CelesteTAS/archive/60b1680e61e43ec4681d7c9053d249491e0fe905.zip"
-            path: "CelesteTAS-60b1680e61e43ec4681d7c9053d249491e0fe905/0 - 100%.tas"
+            url: "https://github.com/VampireFlower/CelesteTAS/archive/9332a874faac2fd0949180f7447222c91b202b51.zip"
+            path: "CelesteTAS-9332a874faac2fd0949180f7447222c91b202b51/0 - 100%.tas"
 
           - name: Strawberry Jam All Levels
-            url: "https://github.com/VampireFlower/StrawberryJamTAS/archive/c9c589a8ef225def5aca869cc1ed3eedf588ec14.zip"
-            path: "StrawberryJamTAS-c9c589a8ef225def5aca869cc1ed3eedf588ec14/0-SJ All Levels.tas"
-            bundle: "https://celestemodupdater.0x0a.de/pinned-mods/StrawberryJam2021-Bundle-134df0f4.zip"
+            url: "https://github.com/VampireFlower/StrawberryJamTAS/archive/2f6ffde25cfeafda7b38523b50034d9c4313053f.zip"
+            path: "StrawberryJamTAS-2f6ffde25cfeafda7b38523b50034d9c4313053f/0-SJ All Levels.tas"
+            bundle: "https://celestemodupdater.0x0a.de/pinned-mods/StrawberryJam2021-Bundle-8cc2878e.zip"
 
     runs-on: ubuntu-latest
     timeout-minutes: 60


### PR DESCRIPTION
- CelesteTAS: up-to-date :white_check_mark: @ [v3.45.1](https://github.com/EverestAPI/CelesteTAS-EverestInterop/releases/tag/v3.45.1)
- Celeste TAS files: updated :arrow_up: @ https://github.com/VampireFlower/CelesteTAS/commit/9332a874faac2fd0949180f7447222c91b202b51
- Strawberry Jam TAS files: updated :arrow_up: @ https://github.com/VampireFlower/StrawberryJamTAS/commit/2f6ffde25cfeafda7b38523b50034d9c4313053f
- Strawberry Jam bundle: updated :arrow_up: @ [8cc2878e](https://celestemodupdater.0x0a.de/pinned-mods/StrawberryJam2021-Bundle-8cc2878e.zip) (crc32 of the zip)