### PR TITLE
Fix copy/paste error when entity has no Collider

### DIFF
--- a/Celeste.Mod.mm/Patches/TalkComponent.cs
+++ b/Celeste.Mod.mm/Patches/TalkComponent.cs
@@ -65,7 +65,7 @@ namespace Celeste {
                 } else {
                     // Entity has no Collider, fallback to Position
                     if (alpha < 1f && Handler.Entity != null && !Scene.CollideCheck<FakeWall>(Handler.Entity.Position)) {
-                        alpha = 0f;
+                        alpha = Calc.Approach(alpha, 1f, 2f * Engine.DeltaTime);
                     }
                 }
                 // force alpha if the player can interact


### PR DESCRIPTION
Fix a copy/paste mistake to properly fallback to vanilla behavior, instead of setting `alpha` to `0f`.

Introduced in https://github.com/EverestAPI/Everest/pull/913.

_(orignally reported by @Wartori54 on Discord)_