### PR TITLE
Ensure no dead players get loaded as part of a `Level.LoadOverride`

### DIFF
--- a/Celeste.Mod.mm/Patches/Level.cs
+++ b/Celeste.Mod.mm/Patches/Level.cs
@@ -367,8 +367,8 @@ namespace Celeste {
 
         // Called from LoadLevel, patched via MonoModRules.PatchLevelLoader
         private static Player LoadNewPlayerForLevel(Vector2 position, PlayerSpriteMode spriteMode, Level lvl) {
-            // Check if there is a player override
-            if (LoadOverrides.TryGetValue(lvl, out LoadOverride ovr) && ovr.NextLoadedPlayer != null) {
+            // Check if there is a player override (that isn't dead!)
+            if (LoadOverrides.TryGetValue(lvl, out LoadOverride ovr) && ovr.NextLoadedPlayer is { Dead: false }) {
                 Player player = ovr.NextLoadedPlayer;
 
                 // Oh wait, you think we can just return the player override now?


### PR DESCRIPTION
This PR ensures that `Level.LoadOverride`s will not get used if their `NextLoadedPlayer` is dead. This can happen due to deaths caused by the state change in `AssetReloadHelper.ReloadLevel`: https://github.com/EverestAPI/Everest/blob/ecad4be5e89defe614118b8451b47f89cd43d800/Celeste.Mod.mm/Mod/Helpers/AssetReloadHelper.cs#L234 (for example, a death caused by `Player.StarFlyReturnToNormalHitbox` when reloading in feather state), which undesirably softlocks the player into having to reload the level again.