### PR TITLE
Bump TAS Check dependencies

### DIFF
--- a/.github/tas-check/2-2-install-inner.sh
+++ b/.github/tas-check/2-2-install-inner.sh
@@ -27,7 +27,7 @@ rm -v t.zip
 
 # install CelesteTAS
 cd celeste/Mods
-curl --fail -Lo CelesteTAS.zip "https://github.com/EverestAPI/CelesteTAS-EverestInterop/releases/download/v3.45.1/CelesteTAS.zip"
+curl --fail -Lo CelesteTAS.zip "https://github.com/EverestAPI/CelesteTAS-EverestInterop/releases/download/v3.45.2/CelesteTAS.zip"
 
 # install the mod that is going to be TASed, downloaded as a bundle zip containing the mod zip
 # and all of its dependencies (https://maddie480.ovh/celeste/bundle-download?id=${TAS_TO_RUN})

--- a/.github/tas-check/run-locally.sh
+++ b/.github/tas-check/run-locally.sh
@@ -11,14 +11,14 @@ set -xeo pipefail
 
 case "$1" in
     "Celeste")
-        TAS_URL="https://github.com/VampireFlower/CelesteTAS/archive/9332a874faac2fd0949180f7447222c91b202b51.zip"
-        TAS_PATH="CelesteTAS-9332a874faac2fd0949180f7447222c91b202b51/0 - 100%.tas"
+        TAS_URL="https://github.com/VampireFlower/CelesteTAS/archive/57aa973164cb5924ba9114923869c7c3b0291549.zip"
+        TAS_PATH="CelesteTAS-57aa973164cb5924ba9114923869c7c3b0291549/0 - 100%.tas"
         ;;
 
     "StrawberryJam2021")
-        TAS_URL="https://github.com/VampireFlower/StrawberryJamTAS/archive/2f6ffde25cfeafda7b38523b50034d9c4313053f.zip"
-        TAS_PATH="StrawberryJamTAS-2f6ffde25cfeafda7b38523b50034d9c4313053f/0-SJ All Levels.tas"
-        BUNDLE_DOWNLOAD="https://celestemodupdater.0x0a.de/pinned-mods/StrawberryJam2021-Bundle-8cc2878e.zip"
+        TAS_URL="https://github.com/VampireFlower/StrawberryJamTAS/archive/5c3e1a904af8bb0e37fe88e084a0fbf7241eee0b.zip"
+        TAS_PATH="StrawberryJamTAS-5c3e1a904af8bb0e37fe88e084a0fbf7241eee0b.zip/0-SJ All Levels.tas"
+        BUNDLE_DOWNLOAD="https://celestemodupdater.0x0a.de/pinned-mods/StrawberryJam2021-Bundle-36e2909e.zip"
         ;;
 
     *)

--- a/.github/workflows/tas-sync-check.yml
+++ b/.github/workflows/tas-sync-check.yml
@@ -16,7 +16,7 @@ jobs:
           - name: Strawberry Jam All Levels
             url: "https://github.com/VampireFlower/StrawberryJamTAS/archive/5c3e1a904af8bb0e37fe88e084a0fbf7241eee0b.zip"
             path: "StrawberryJamTAS-5c3e1a904af8bb0e37fe88e084a0fbf7241eee0b/0-SJ All Levels.tas"
-            bundle: "https://celestemodupdater.0x0a.de/pinned-mods/StrawberryJam2021-Bundle-8cc2878e.zip"
+            bundle: "https://celestemodupdater.0x0a.de/pinned-mods/StrawberryJam2021-Bundle-36e2909e.zip"
 
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/tas-sync-check.yml
+++ b/.github/workflows/tas-sync-check.yml
@@ -10,12 +10,12 @@ jobs:
       matrix:
         tas:
           - name: Celeste 100%
-            url: "https://github.com/VampireFlower/CelesteTAS/archive/9332a874faac2fd0949180f7447222c91b202b51.zip"
-            path: "CelesteTAS-9332a874faac2fd0949180f7447222c91b202b51/0 - 100%.tas"
+            url: "https://github.com/VampireFlower/CelesteTAS/archive/57aa973164cb5924ba9114923869c7c3b0291549.zip"
+            path: "CelesteTAS-57aa973164cb5924ba9114923869c7c3b0291549/0 - 100%.tas"
 
           - name: Strawberry Jam All Levels
-            url: "https://github.com/VampireFlower/StrawberryJamTAS/archive/2f6ffde25cfeafda7b38523b50034d9c4313053f.zip"
-            path: "StrawberryJamTAS-2f6ffde25cfeafda7b38523b50034d9c4313053f/0-SJ All Levels.tas"
+            url: "https://github.com/VampireFlower/StrawberryJamTAS/archive/5c3e1a904af8bb0e37fe88e084a0fbf7241eee0b.zip"
+            path: "StrawberryJamTAS-5c3e1a904af8bb0e37fe88e084a0fbf7241eee0b/0-SJ All Levels.tas"
             bundle: "https://celestemodupdater.0x0a.de/pinned-mods/StrawberryJam2021-Bundle-8cc2878e.zip"
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
- CelesteTAS: updated :arrow_up: @ [v3.45.2](https://github.com/EverestAPI/CelesteTAS-EverestInterop/releases/tag/v3.45.2)
- Celeste TAS files: updated :arrow_up: @ https://github.com/VampireFlower/CelesteTAS/commit/57aa973164cb5924ba9114923869c7c3b0291549
- Strawberry Jam TAS files: updated :arrow_up: @ https://github.com/VampireFlower/StrawberryJamTAS/commit/5c3e1a904af8bb0e37fe88e084a0fbf7241eee0b
- Strawberry Jam bundle: updated :arrow_up: @ [36e2909e](https://celestemodupdater.0x0a.de/pinned-mods/StrawberryJam2021-Bundle-36e2909e.zip) (crc32 of the zip)