### PR TITLE
Delete all modded save data when deleting a file

### DIFF
--- a/Celeste.Mod.mm/Patches/SaveData.cs
+++ b/Celeste.Mod.mm/Patches/SaveData.cs
@@ -327,6 +327,22 @@ namespace Celeste {
                 }
             }
 
+            // clean modsave and modsession files which are not deleted if their module is not loaded
+            string saveFilePath = patch_UserIO.GetSaveFilePath();
+            if (Directory.Exists(saveFilePath)) {
+                foreach (string modSaveFile in Directory.GetFiles(saveFilePath, $"{slot}-modsave-*.celeste")) {
+                    string file = Path.GetFileNameWithoutExtension(modSaveFile);
+                    Logger.Info("SaveData", $"Save slot {slot} has modsave {file} which was not cleaned, deleting file");
+                    UserIO.Delete(file);
+                }
+
+                foreach (string modSessionFile in Directory.GetFiles(saveFilePath, $"{slot}-modsession-*.celeste")) {
+                    string file = Path.GetFileNameWithoutExtension(modSessionFile);
+                    Logger.Info("SaveData", $"Save slot {slot} has modsession {file} which was not cleaned, deleting file");
+                    UserIO.Delete(file);
+                }
+            }
+
             LoadedModSaveDataIndex = int.MinValue;
 
             // delete the modsavedata file if it exists.


### PR DESCRIPTION
The method deleting modded save data did not consider disabled mods, so when deleting a save file slot with data associated to a disabled mod, the related files would not be deleted, and the slot would be left in a state preventing its deletion.

This PR adds a step to the `TryDeleteModSaveData` method to forcibly delete `modsave` and `modsession` files related to the deleted slot, clearing files related to the slot even if related mods are disabled.

Related to #899.

_(originally reported by @WEGFan on Discord)_