### PR TITLE
Fix: /tp and /reloadmap endpoints in debugrc not url decoding

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.DebugRC.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.DebugRC.cs
@@ -374,7 +374,7 @@ header {
                     Handle = c => {
                         NameValueCollection data = ParseQueryString(c.Request.RawUrl);
 
-                        string sid = data["area"];
+                        string sid =  WebUtility.UrlDecode(data["area"]);
                         if (string.IsNullOrEmpty(sid))
                             sid = (Engine.Scene as Level)?.Session.Area.GetSID();
                         if (string.IsNullOrEmpty(sid)) {
@@ -475,7 +475,7 @@ header {
                             return;
                         }
 
-                        string sid = data["area"];
+                        string sid =  WebUtility.UrlDecode(data["area"]);
                         if (string.IsNullOrEmpty(sid))
                             sid = session.Area.GetSID();
                         if (string.IsNullOrEmpty(sid)) {

--- a/Celeste.Mod.mm/Mod/Everest/Everest.DebugRC.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.DebugRC.cs
@@ -374,7 +374,7 @@ header {
                     Handle = c => {
                         NameValueCollection data = ParseQueryString(c.Request.RawUrl);
 
-                        string sid =  WebUtility.UrlDecode(data["area"]);
+                        string sid = WebUtility.UrlDecode(data["area"]);
                         if (string.IsNullOrEmpty(sid))
                             sid = (Engine.Scene as Level)?.Session.Area.GetSID();
                         if (string.IsNullOrEmpty(sid)) {
@@ -475,7 +475,7 @@ header {
                             return;
                         }
 
-                        string sid =  WebUtility.UrlDecode(data["area"]);
+                        string sid = WebUtility.UrlDecode(data["area"]);
                         if (string.IsNullOrEmpty(sid))
                             sid = session.Area.GetSID();
                         if (string.IsNullOrEmpty(sid)) {


### PR DESCRIPTION
This changes `/tp` and `/reloadmap` in debugrc to url decode the SID
Previously, if an SID contained a space, you could not use the endpoint for a given map.

Recreation: Download any map with an SID that has a space ([example](https://gamebanana.com/mods/602839)) and try to teleport or reload the map with the SID. It will return %20 instead of a proper space, leading it to fail.
(for the given example map it would be http://localhost:32270/tp?tp=Mochi/Puppygirl%20Adventures/Puppygirl%20Adventures&side=A&level=a-1&x=27&y=440)