### PR TITLE
Rework `SwapImmediately` handling

### DIFF
--- a/Celeste.Mod.mm/Mod/Helpers/SwapImmediatelyExtension.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/SwapImmediatelyExtension.cs
@@ -32,24 +32,46 @@ namespace Celeste.Mod {
         ///   }
         /// </code>
         /// </example>
-        public static IEnumerator SafeEnumerate(this IEnumerator self) {
-            Stack<IEnumerator> enums = new();
-            enums.Push(self);
+        public static Flattened SafeEnumerate(this IEnumerator self) {
+            if(self is Flattened f) {
+                return f;
+            }
+            return new(self);
+        }
 
-            while (enums.Count > 0) {
-                IEnumerator cur = enums.Peek();
+        public struct Flattened : IEnumerator {
+            private readonly Stack<IEnumerator> enums = new();
+            private object current = null;
 
-                if (cur.MoveNext()) {
-                    object obj = cur.Current;
+            public readonly object Current => current;
 
-                    if (obj is SwapImmediately swap) {
-                        enums.Push(swap.Inner);
+            public Flattened(IEnumerator from) {
+                enums.Push(from);
+            }
+
+            public bool MoveNext() {
+                while (enums.Count > 0) {
+                    IEnumerator cur = enums.Peek();
+
+                    if (cur.MoveNext()) {
+                        object obj = cur.Current;
+
+                        if (obj is SwapImmediately swap) {
+                            enums.Push(swap.Inner);
+                        } else {
+                            current = obj;
+                            return true;
+                        }
                     } else {
-                        yield return obj;
+                        enums.Pop();
                     }
-                } else {
-                    enums.Pop();
                 }
+                current = null;
+                return false;
+            }
+
+            public void Reset() {
+                throw new NotSupportedException();
             }
         }
     }

--- a/Celeste.Mod.mm/Mod/Helpers/SwapImmediatelyExtension.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/SwapImmediatelyExtension.cs
@@ -9,14 +9,29 @@ using System.Collections.Generic;
 namespace Celeste.Mod {
     public static class SwapImmediatelyExtension {
         /// <summary>
-        ///   when you want to enumerate a coroutine ienumerator,
-        ///   always keep in mind that the original sequence may have been wrapped into <see cref="SwapImmediately"/>.
-        ///   this method helps you to handle it correctly like <see cref="Coroutine"/>.<br/>
-        ///   also known as, flattening the given sequence.
+        ///   Flattens all <see cref="SwapImmediately"/> returned by the source IEnumerator.
+        ///   When writing hooks on Coroutine-style methods, 
+        ///   this method is needed if you want to access values returned from the orig Coroutine,
+        ///   for instance, if it were to return the following sequence `{1, 2, SwapImmediately({1, 2}), 3}`
+        ///   a simple enumeration of it would not pass properly the values inside the <see cref="SwapImmediately" />.
+        ///   This method makes it so the returned values become the sequence `{1, 2, 1, 2, 3}`.
+        ///   (Behaviour mimicks <see cref="Coroutine"/>'s handling of <see cref="SwapImmediately"/>.)
         /// </summary>
         /// <returns>
-        ///   A new enumerator, but all <see cref="SwapImmediately"/> is safely handled.
+        ///   A new enumerator which flattens the sequence once <see cref="SwapImmediately" />s are received.
         /// </returns>
+        /// <example>
+        /// The most common use would be hooking a Coroutine method:
+        /// <code>
+        ///   private static IEnumerator DashCoroutine(On.Celeste.Player.orig_DashCoroutine orig, Player self) {
+        ///     IEnumerator origEnum = orig(self).SafeEnumerate();
+        ///     while (origEnum.MoveNext()) {
+        ///       yield return origEnum.Current;
+        ///       // Do anything here
+        ///     }
+        ///   }
+        /// </code>
+        /// </example>
         public static IEnumerator SafeEnumerate(this IEnumerator self) {
             Stack<IEnumerator> enums = new();
             enums.Push(self);

--- a/Celeste.Mod.mm/Mod/Helpers/SwapImmediatelyExtension.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/SwapImmediatelyExtension.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Monocle;
+using System;
 using System.Collections;
 using System.Linq;
 using System.Text;
@@ -7,6 +8,15 @@ using System.Collections.Generic;
 
 namespace Celeste.Mod {
     public static class SwapImmediatelyExtension {
+        /// <summary>
+        ///   when you want to enumerate a coroutine ienumerator,
+        ///   always keep in mind that the original sequence may have been wrapped into <see cref="SwapImmediately"/>.
+        ///   this method helps you to handle it correctly like <see cref="Coroutine"/>.<br/>
+        ///   also known as, flattening the given sequence.
+        /// </summary>
+        /// <returns>
+        ///   A new enumerator, but all <see cref="SwapImmediately"/> is safely handled.
+        /// </returns>
         public static IEnumerator SafeEnumerate(this IEnumerator self) {
             Stack<IEnumerator> enums = new();
             enums.Push(self);

--- a/Celeste.Mod.mm/Mod/Helpers/SwapImmediatelyExtension.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/SwapImmediatelyExtension.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+
+namespace Celeste.Mod {
+    public static class SwapImmediatelyExtension {
+        public static IEnumerator SafeEnumerate(this IEnumerator self) {
+            Stack<IEnumerator> enums = new();
+            enums.Push(self);
+
+            while (enums.Count > 0) {
+                IEnumerator cur = enums.Peek();
+
+                if (cur.MoveNext()) {
+                    object obj = cur.Current;
+
+                    if (obj is SwapImmediately swap) {
+                        enums.Push(swap.Inner);
+                    } else {
+                        yield return obj;
+                    }
+                } else {
+                    enums.Pop();
+                }
+            }
+        }
+    }
+}

--- a/Celeste.Mod.mm/Patches/Monocle/Coroutine.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Coroutine.cs
@@ -30,24 +30,16 @@ namespace Monocle {
         public extern void orig_Update();
         public override void Update() {
             do {
+                if (Current is { } cur && cur is not SwapImmediatelyExtension.Flattened) {
+                    enumerators.Pop();
+                    enumerators.Push(cur.SafeEnumerate());
+                }
+
                 orig_Update();
 
                 // if the coroutine last returned an Action<Coroutine>, run it passing the coroutine.
                 if (Current?.Current is Action<patch_Coroutine> cb) {
                     cb(this);
-                    continue;
-                }
-
-                // if the top of the stack is a SwapImmediately... swap it immediately.
-                if (Current is SwapImmediately swap) {
-                    enumerators.Pop();
-                    enumerators.Push(swap.Inner);
-                    continue;
-                }
-
-                // if the coroutine last returned a SwapImmediately, this means we returned from a coroutine that swaps immediately...
-                // so, swap immediately.
-                if (Current?.Current is SwapImmediately) {
                     continue;
                 }
 


### PR DESCRIPTION
Although #953 looks to be good, but i still noticed somethong:

What if code modders don't use it correctly?

According to https://github.com/EverestAPI/Resources/wiki/Making-Code-Mods#on-hooks, when hooking a coroutine with `SwapImmediately`, sometimes the method suffix will not run. However, #953 will ALWAYS run them. While nobody should be doing this, this could cause problems in the future:

- B flattens the sequence, just because they can.
- A adds a method suffix.
  - the suffix should not run, but...
- A runs before B.
  - their sequence will be flattened by B. so it runs.
- A is released with the bug.
- Some users don't enable B. For no reason.
- A can't work.

Actually there's no solution for this. so
This pr changes `Coroutine` to always run suffixes.

still not tested, but looks good to me.