### PR TITLE
Optimise some Hitbox and Grid methods

### DIFF
--- a/Celeste.Mod.mm/MonoModRules.cs
+++ b/Celeste.Mod.mm/MonoModRules.cs
@@ -49,6 +49,18 @@ namespace MonoMod {
     /// </summary>
     [MonoModCustomMethodAttribute(nameof(MonoModRules.ForceNoInlining))]
     class ForceNoInliningAttribute : Attribute { }
+    
+    /// <summary>
+    /// Forces AggressiveInlining onto a given member. Works for methods as well as properties.
+    /// </summary>
+    [MonoModCustomAttribute(nameof(MonoModRules.ForceAggressiveInlining))]
+    class ForceAggressiveInliningAttribute : Attribute { }
+    
+    /// <summary>
+    /// Forces the given member to be sealed. Works for methods as well as properties.
+    /// </summary>=
+    [MonoModCustomAttribute(nameof(MonoModRules.ForceSealed))]
+    class ForceSealedAttribute : Attribute { }
 #endregion
 
     static partial class MonoModRules {
@@ -313,6 +325,35 @@ namespace MonoMod {
 
         public static void ForceNoInlining(MethodDefinition method, CustomAttribute attrib) {
             method.NoInlining = true;
+        }
+        
+        public static void ForceAggressiveInlining(ICustomAttributeProvider provider, CustomAttribute attrib) {
+            switch (provider) {
+                case PropertyDefinition prop:
+                    ForceAggressiveInlining(prop.GetMethod, attrib);
+                    ForceAggressiveInlining(prop.SetMethod, attrib);
+                    break;
+                case MethodDefinition method:
+                    method.NoInlining = false;
+                    method.AggressiveInlining = true;
+                    break;
+            }
+
+            provider?.CustomAttributes?.Remove(attrib);
+        }
+        
+        public static void ForceSealed(ICustomAttributeProvider provider, CustomAttribute attrib) {
+            switch (provider) {
+                case PropertyDefinition prop:
+                    ForceSealed(prop.GetMethod, attrib);
+                    ForceSealed(prop.SetMethod, attrib);
+                    break;
+                case MethodDefinition method:
+                    method.IsFinal = true;
+                    break;
+            }
+            
+            provider?.CustomAttributes?.Remove(attrib);
         }
 
         /// <summary>

--- a/Celeste.Mod.mm/Patches/Monocle/Collider.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Collider.cs
@@ -1,0 +1,72 @@
+using Microsoft.Xna.Framework;
+using MonoMod;
+
+namespace Monocle;
+
+public class patch_Collider {
+    // Force all these properties to be AggressiveInlining, as they're crucial to collision perf, and contain virtual calls,
+    // which could get inlined if the extending type seals their properties.
+    
+    [MonoModIgnore, ForceAggressiveInlining]
+    public float CenterX { get; set; }
+
+    [MonoModIgnore, ForceAggressiveInlining]
+	public float CenterY { get; set; }
+
+    [MonoModIgnore, ForceAggressiveInlining]
+	public Vector2 TopLeft { get; set; }
+
+    [MonoModIgnore, ForceAggressiveInlining]
+	public Vector2 TopCenter { get; set; }
+
+    [MonoModIgnore, ForceAggressiveInlining]
+	public Vector2 TopRight { get; set; }
+
+    [MonoModIgnore, ForceAggressiveInlining]
+	public Vector2 CenterLeft { get; set; }
+
+    [MonoModIgnore, ForceAggressiveInlining]
+	public Vector2 Center { get; set; }
+
+    [MonoModIgnore, ForceAggressiveInlining]
+    public Vector2 Size { get; }
+
+    [MonoModIgnore, ForceAggressiveInlining]
+	public Vector2 HalfSize { get; }
+
+    [MonoModIgnore, ForceAggressiveInlining]
+	public Vector2 CenterRight { get; set; }
+
+    [MonoModIgnore, ForceAggressiveInlining]
+	public Vector2 BottomLeft { get; set; }
+
+    [MonoModIgnore, ForceAggressiveInlining]
+	public Vector2 BottomCenter { get; set; }
+
+    [MonoModIgnore, ForceAggressiveInlining]
+	public Vector2 BottomRight { get; set; }
+
+    [MonoModIgnore, ForceAggressiveInlining]
+	public Vector2 AbsolutePosition { get; set; }
+
+    [MonoModIgnore, ForceAggressiveInlining]
+	public float AbsoluteX { get; set; }
+
+    [MonoModIgnore, ForceAggressiveInlining]
+	public float AbsoluteY { get; set; }
+
+    [MonoModIgnore, ForceAggressiveInlining]
+	public float AbsoluteTop { get; set; }
+
+    [MonoModIgnore, ForceAggressiveInlining]
+	public float AbsoluteBottom { get; set; }
+
+    [MonoModIgnore, ForceAggressiveInlining]
+	public float AbsoluteLeft { get; set; }
+
+    [MonoModIgnore, ForceAggressiveInlining]
+	public float AbsoluteRight { get; set; }
+
+    [MonoModIgnore, ForceAggressiveInlining]
+	public Rectangle Bounds { get; set; }
+}

--- a/Celeste.Mod.mm/Patches/Monocle/Grid.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Grid.cs
@@ -1,0 +1,19 @@
+#pragma warning disable CS0108 // Member is never used
+
+using Microsoft.Xna.Framework;
+using MonoMod;
+
+namespace Monocle {
+    public class patch_Grid : Grid {
+        public patch_Grid(int cellsX, int cellsY, float cellWidth, float cellHeight) : base(cellsX, cellsY, cellWidth, cellHeight)
+        {
+            // no-op, ignored by MonoMod
+        }
+        
+        [MonoModReplace] // Avoid virtual calls and redundant bounds checks - Everest adds bounds checks to VirtualMap already.
+        public override bool Collide(Vector2 point) {
+            var pos = point - AbsolutePosition;
+            return Data[(int)(pos.X / CellWidth), (int)(pos.Y / CellHeight)];
+        }
+    } 
+}

--- a/Celeste.Mod.mm/Patches/Monocle/Hitbox.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Hitbox.cs
@@ -16,6 +16,27 @@ namespace Monocle {
             // no-op, ignored by MonoMod
         }
         
+        // Seal and add AggressiveInlining onto the properties for better performance in various collision checks.
+        // No mods override these properties (nor should there be a reason to do so) as of now, so this is safe to do.
+        
+        [MonoModIgnore, ForceSealed, ForceAggressiveInlining]
+        public override float Width { get; set; }
+        
+        [MonoModIgnore, ForceSealed, ForceAggressiveInlining]
+        public override float Height { get; set; }
+
+        [MonoModIgnore, ForceSealed, ForceAggressiveInlining]
+        public override float Left { get; set; }
+
+        [MonoModIgnore, ForceSealed, ForceAggressiveInlining]
+        public override float Top { get; set; }
+
+        [MonoModIgnore, ForceSealed, ForceAggressiveInlining]
+        public override float Right { get; set; }
+
+        [MonoModIgnore, ForceSealed, ForceAggressiveInlining]
+        public override float Bottom { get; set; }
+        
         // Optimise most frequent collision methods to avoid virtual calls:
         
         [MonoModReplace]

--- a/Celeste.Mod.mm/Patches/Monocle/Hitbox.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Hitbox.cs
@@ -1,0 +1,54 @@
+#pragma warning disable CS0108 // Member hides inherited member; missing new keyword
+#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
+
+using Microsoft.Xna.Framework;
+using MonoMod;
+
+namespace Monocle {
+    class patch_Hitbox : Hitbox {
+        [MonoModIgnore]
+        private float width;
+        [MonoModIgnore]
+        private float height;
+        
+        public patch_Hitbox(float width, float height, float x = 0, float y = 0) : base(width, height, x, y)
+        {
+            // no-op, ignored by MonoMod
+        }
+        
+        // Optimise most frequent collision methods to avoid virtual calls:
+        
+        [MonoModReplace]
+        public override bool Collide(Rectangle rect) {
+            var pos = AbsolutePosition;
+            
+            return pos.X + width > rect.Left
+                && pos.Y + height > rect.Top
+                && pos.X < rect.Right
+                && pos.Y < rect.Bottom;
+        }
+        
+        [MonoModReplace]
+        public bool Intersects(patch_Hitbox hitbox)
+        {
+            var pos = AbsolutePosition;
+            var otherPos = hitbox.AbsolutePosition;
+            
+            return pos.X + width > otherPos.X
+                && pos.Y + height > otherPos.Y
+                && pos.X < otherPos.X + hitbox.width
+                && pos.Y < otherPos.Y + hitbox.height;
+        }
+        
+        [MonoModReplace]
+        public bool Intersects(float x, float y, float width, float height)
+        {
+            var pos = AbsolutePosition;
+            
+            return pos.X + this.width > x
+                && pos.Y + this.height > y
+                && pos.X < x + width
+                && pos.Y < y + height;
+        }
+    }
+}


### PR DESCRIPTION
`Hitbox`'s most important collision methods cause a lot of virtual calls and redundant null checks inside said virtual methods, this PR manually inlines through all those abstractions for the best perf.
`Grid.Collide(Vector2 point)` does a redundant bound check, as Everest patches VirtualMap to do bounds checks anyway.