### PR TITLE
Add clearer errors on access failures

### DIFF
--- a/MiniInstaller/InGameUpdaterHelper.cs
+++ b/MiniInstaller/InGameUpdaterHelper.cs
@@ -59,10 +59,12 @@ public static class InGameUpdaterHelper {
         // let's wait for 1 minute
         const int WaitTimeSeconds = 60;
         const int MaxRetryCount = 12;
+
+        Exception error;
         for (int i = 0; i < MaxRetryCount; i++) {
             Thread.Sleep(WaitTimeSeconds * 1000 / MaxRetryCount);
 
-            if (CanReadWrite(Globals.PathCelesteExe, out Exception error) && CanReadWrite(Globals.PathEverestDLL, out error))
+            if (CanReadWrite(Globals.PathCelesteExe, out error) && CanReadWrite(Globals.PathEverestDLL, out error))
                 return;
         }
 

--- a/MiniInstaller/InGameUpdaterHelper.cs
+++ b/MiniInstaller/InGameUpdaterHelper.cs
@@ -64,13 +64,12 @@ public static class InGameUpdaterHelper {
 
             if (CanReadWrite(Globals.PathCelesteExe, out Exception error) && CanReadWrite(Globals.PathEverestDLL, out error))
                 return;
-
-            if (i == MaxRetryCount - 1)
-                throw new InvalidOperationException(
-                    "Celeste is not read-writeable. "
-                    + "Please ensure the game is not running, its files are not in use and that you have write permissions.",
-                    error);
         }
+
+        throw new InvalidOperationException(
+            "Celeste is not read-writeable. "
+            + "Please ensure the game is not running, its files are not in use and that you have write permissions.",
+            error);
     }
 
     // AFAIK there's no "clean" way to check for any file locks in C#.

--- a/MiniInstaller/InGameUpdaterHelper.cs
+++ b/MiniInstaller/InGameUpdaterHelper.cs
@@ -60,7 +60,7 @@ public static class InGameUpdaterHelper {
         const int WaitTimeSeconds = 60;
         const int MaxRetryCount = 12;
 
-        Exception error;
+        Exception error = null;
         for (int i = 0; i < MaxRetryCount; i++) {
             Thread.Sleep(WaitTimeSeconds * 1000 / MaxRetryCount);
 

--- a/MiniInstaller/InGameUpdaterHelper.cs
+++ b/MiniInstaller/InGameUpdaterHelper.cs
@@ -67,7 +67,8 @@ public static class InGameUpdaterHelper {
 
             if (i == MaxRetryCount - 1)
                 throw new InvalidOperationException(
-                    "Celeste is not read-writeable. Please ensure the game is not running and its files are not in use.",
+                    "Celeste is not read-writeable. "
+                    + "Please ensure the game is not running, its files are not in use and that you have write permissions.",
                     error);
         }
     }

--- a/MiniInstaller/InGameUpdaterHelper.cs
+++ b/MiniInstaller/InGameUpdaterHelper.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading;
 
@@ -35,30 +36,53 @@ public static class InGameUpdaterHelper {
     }
     
     public static void WaitForGameExit() {
-        if (int.TryParse(Environment.GetEnvironmentVariable("EVEREST_UPDATE_CELESTE_PID"), out int celestePid)) {
-            try {
-                Process celesteProc = Process.GetProcessById(celestePid);
-                celesteProc.Kill(false);
-                celesteProc.WaitForExit();
-            } catch {}
-        }
+        if (!int.TryParse(Environment.GetEnvironmentVariable("EVEREST_UPDATE_CELESTE_PID"), out int celestePid))
+            return;
 
-        if (
-            (File.Exists(Globals.PathCelesteExe) && !CanReadWrite(Globals.PathCelesteExe)) ||
-            (File.Exists(Globals.PathEverestDLL) && !CanReadWrite(Globals.PathEverestDLL))
-         ) {
-            Logger.LogErr("Celeste not read-writeable - waiting");
-            while (!CanReadWrite(Globals.PathCelesteExe))
-                Thread.Sleep(5000);
+        try {
+            Process celesteProc = Process.GetProcessById(celestePid);
+            celesteProc.Kill(false);
+            celesteProc.WaitForExit();
+        } catch {}
+    }
+
+    public static void EnsureGameIsWriteable() {
+        MiscUtil.EnsureFileIsWriteable(Globals.PathCelesteExe);
+        MiscUtil.EnsureFileIsWriteable(Globals.PathEverestDLL);
+
+        if ((!File.Exists(Globals.PathCelesteExe) || CanReadWrite(Globals.PathCelesteExe)) &&
+            (!File.Exists(Globals.PathEverestDLL) || CanReadWrite(Globals.PathEverestDLL)))
+            return;
+
+        Logger.LogErr("Celeste is not read-writeable - waiting");
+
+        // let's wait for 1 minute
+        const int WaitTimeSeconds = 60;
+        const int MaxRetryCount = 12;
+        for (int i = 0; i < MaxRetryCount; i++) {
+            Thread.Sleep(WaitTimeSeconds * 1000 / MaxRetryCount);
+
+            if (CanReadWrite(Globals.PathCelesteExe, out Exception error) && CanReadWrite(Globals.PathEverestDLL, out error))
+                return;
+
+            if (i == MaxRetryCount - 1)
+                throw new InvalidOperationException(
+                    "Celeste is not read-writeable. Please ensure the game is not running and its files are not in use.",
+                    error);
         }
     }
-    
+
     // AFAIK there's no "clean" way to check for any file locks in C#.
-    private static bool CanReadWrite(string path) {
+    private static bool CanReadWrite(string path)
+        => CanReadWrite(path, out _);
+
+    private static bool CanReadWrite(string path, [NotNullWhen(false)] out Exception error) {
         try {
             new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite | FileShare.Delete).Dispose();
+            error = null;
             return true;
-        } catch {
+        } catch (Exception e) {
+            error = e;
             return false;
         }
     }

--- a/MiniInstaller/MiscUtil.cs
+++ b/MiniInstaller/MiscUtil.cs
@@ -4,6 +4,8 @@ using System.IO;
 using System.Linq;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
+using System.Runtime.InteropServices;
+using System.Text;
 using System.Xml;
 
 namespace MiniInstaller;
@@ -81,5 +83,24 @@ public static class MiscUtil {
                 File.Move(Path.ChangeExtension(srcPath, ".mdb"), Path.ChangeExtension(dstPath, ".mdb"));
             }
         }
+    }
+
+    public static void EnsureFileIsWriteable(string path) {
+        if (!File.Exists(path))
+            return;
+
+        if ((File.GetAttributes(path) & FileAttributes.ReadOnly) == 0)
+            return;
+
+        StringBuilder errorMessage = new StringBuilder()
+            .Append(Path.GetFileName(path))
+            .Append(" is marked as read-only. ");
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            errorMessage.Append("Please remove the read-only attribute from the game folder and its files.");
+        else
+            errorMessage.Append("Please ensure the user has write permissions to the file.");
+
+        throw new InvalidOperationException(errorMessage.ToString());
     }
 }

--- a/MiniInstaller/Program.cs
+++ b/MiniInstaller/Program.cs
@@ -62,6 +62,7 @@ namespace MiniInstaller {
             using Logger.DisposableTuple _ = Logger.SetupLogger();
             try {
                 InGameUpdaterHelper.WaitForGameExit();
+                InGameUpdaterHelper.EnsureGameIsWriteable();
 
                 BackUp.Backup();
 


### PR DESCRIPTION
Throws an error if the `Celeste.exe` or `Celeste.dll` have are marked as read-only and throws an error if so with instructions to remove the read-only attribute (Windows-only) or ensure the user has write permissions to the file.

The "Celeste not read-writeable - waiting" message now has a timeout of 1 minute instead of waiting indefinitely, throwing an exception if `Celeste.exe` or `Celeste.dll` are not accessible (including the source exception).