### PR TITLE
Avoid string interpolation in the Logger if the message won't get logged anyway

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Logger.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Logger.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
 using Celeste.Mod.Core;
+using Celeste.Mod.Helpers;
 using System.Globalization;
 
 namespace Celeste.Mod {
@@ -105,6 +106,15 @@ namespace Celeste.Mod {
         /// <param name="str">The string / message to log.</param>
         public static void Verbose(string tag, string str)
             => Log(LogLevel.Verbose, tag, str);
+        
+        /// <inheritdoc cref="Verbose(string,string)"/>
+        public static void Verbose(string tag, 
+            [InterpolatedStringHandlerArgument(nameof(tag))] LogInterpolatedStringHandler<LogLevelConstTypes.Verbose> str)
+        {
+            if (str.ShouldLog)
+                LogUnchecked(LogLevel.Verbose, tag, str.ToStringAndClear());
+        }
+        
         /// <summary>
         /// Log a string to the console and to log.txt, using <see cref="LogLevel.Debug"/>
         /// </summary>
@@ -112,6 +122,15 @@ namespace Celeste.Mod {
         /// <param name="str">The string / message to log.</param>
         public static void Debug(string tag, string str)
             => Log(LogLevel.Debug, tag, str);
+        
+        /// <inheritdoc cref="Debug(string,string)"/>
+        public static void Debug(string tag, 
+            [InterpolatedStringHandlerArgument(nameof(tag))] LogInterpolatedStringHandler<LogLevelConstTypes.Debug> str)
+        {
+            if (str.ShouldLog)
+                LogUnchecked(LogLevel.Debug, tag, str.ToStringAndClear());
+        }
+        
         /// <summary>
         /// Log a string to the console and to log.txt, using <see cref="LogLevel.Info"/>
         /// </summary>
@@ -119,6 +138,15 @@ namespace Celeste.Mod {
         /// <param name="str">The string / message to log.</param>
         public static void Info(string tag, string str)
             => Log(LogLevel.Info, tag, str);
+        
+        /// <inheritdoc cref="Info(string,string)"/>
+        public static void Info(string tag, 
+            [InterpolatedStringHandlerArgument(nameof(tag))] LogInterpolatedStringHandler<LogLevelConstTypes.Info> str)
+        {
+            if (str.ShouldLog)
+                LogUnchecked(LogLevel.Info, tag, str.ToStringAndClear());
+        }
+        
         /// <summary>
         /// Log a string to the console and to log.txt, using <see cref="LogLevel.Warn"/>
         /// </summary>
@@ -126,6 +154,15 @@ namespace Celeste.Mod {
         /// <param name="str">The string / message to log.</param>
         public static void Warn(string tag, string str)
             => Log(LogLevel.Warn, tag, str);
+        
+        /// <inheritdoc cref="Warn(string,string)"/>
+        public static void Warn(string tag, 
+            [InterpolatedStringHandlerArgument(nameof(tag))] LogInterpolatedStringHandler<LogLevelConstTypes.Warn> str)
+        {
+            if (str.ShouldLog)
+                LogUnchecked(LogLevel.Warn, tag, str.ToStringAndClear());
+        }
+        
         /// <summary>
         /// Log a string to the console and to log.txt, using <see cref="LogLevel.Error"/>
         /// </summary>
@@ -133,6 +170,14 @@ namespace Celeste.Mod {
         /// <param name="str">The string / message to log.</param>
         public static void Error(string tag, string str)
             => Log(LogLevel.Error, tag, str);
+        
+        /// <inheritdoc cref="Error(string,string)"/>
+        public static void Error(string tag, 
+            [InterpolatedStringHandlerArgument(nameof(tag))] LogInterpolatedStringHandler<LogLevelConstTypes.Error> str)
+        {
+            if (str.ShouldLog)
+                LogUnchecked(LogLevel.Error, tag, str.ToStringAndClear());
+        }
 
         /// <summary>
         /// Log a string to the console and to log.txt
@@ -141,6 +186,14 @@ namespace Celeste.Mod {
         /// <param name="str">The string / message to log.</param>
         public static void Log(string tag, string str)
             => Verbose(tag, str);
+        
+        /// <inheritdoc cref="Log(string,string)"/>
+        public static void Log(string tag, 
+            [InterpolatedStringHandlerArgument(nameof(tag))] LogInterpolatedStringHandler<LogLevelConstTypes.Verbose> str)
+        {
+            if (str.ShouldLog)
+                LogUnchecked(LogLevel.Verbose, tag, str.ToStringAndClear());
+        }
 
         /// <summary>
         /// Log a string to the console and to log.txt
@@ -150,24 +203,40 @@ namespace Celeste.Mod {
         /// <param name="str">The string / message to log.</param>
         public static void Log(LogLevel level, string tag, string str) {
             if (shouldLog(tag, level)) {
-                lock (locker) {
-                    string now = DateTime.Now.ToString(CultureInfo.InvariantCulture);
-                    string logLevel = level.FastToString();
+                LogUnchecked(level, tag, str);
+            }
+        }
+        
+        /// <inheritdoc cref="Log(LogLevel,string,string)"/>
+        public static void Log(LogLevel level, string tag, 
+            [InterpolatedStringHandlerArgument(nameof(level), nameof(tag))] LogInterpolatedStringHandler str)
+        {
+            if (str.ShouldLog)
+                LogUnchecked(level, tag, str.ToStringAndClear());
+        }
 
-                    if (!ColorizedLogging) {
-                        Console.WriteLine($"({now}) [Everest] [{logLevel}] [{tag}] {str}");
-                        return;
-                    }
+        /// <summary>
+        /// Logs a string to the console and to log.txt, without checking whether the LogLevel should be logged,
+        /// only for internal use.
+        /// </summary>
+        private static void LogUnchecked(LogLevel level, string tag, string str) {
+            lock (locker) {
+                string now = DateTime.Now.ToString(CultureInfo.InvariantCulture);
+                string logLevel = level.FastToString();
 
-                    const string colorReset = "\x1b[0m";
-                    const string colorFaint = "\x1b[2m";
-                    string colorLevel = level.GetAnsiEscapeCodeForLevel();
-                    string colorText = level.GetAnsiEscapeCodeForText();
-
-                    outWriter.WriteLine($"{colorFaint}({now}) [Everest] {colorReset}{colorLevel}[{logLevel}] [{tag}] {colorText}{str}{colorReset}");
-                    logWriter.WriteLine($"({now}) [Everest] [{logLevel}] [{tag}] {str}");
-                    logWriter.Flush();
+                if (!ColorizedLogging) {
+                    Console.WriteLine($"({now}) [Everest] [{logLevel}] [{tag}] {str}");
+                    return;
                 }
+
+                const string colorReset = "\x1b[0m";
+                const string colorFaint = "\x1b[2m";
+                string colorLevel = level.GetAnsiEscapeCodeForLevel();
+                string colorText = level.GetAnsiEscapeCodeForText();
+
+                outWriter.WriteLine($"{colorFaint}({now}) [Everest] {colorReset}{colorLevel}[{logLevel}] [{tag}] {colorText}{str}{colorReset}");
+                logWriter.WriteLine($"({now}) [Everest] [{logLevel}] [{tag}] {str}");
+                logWriter.Flush();
             }
         }
 
@@ -277,6 +346,87 @@ namespace Celeste.Mod {
             }
             return false;
         }
+        
+        /// <summary>
+        /// Interpolated String Handler used by the logger to avoid interpolating the string if the message won't get logged anyway.
+        /// </summary>
+        [InterpolatedStringHandler]
+        public ref struct LogInterpolatedStringHandler
+        {
+            DefaultInterpolatedStringHandler _handler;
+            
+            public bool ShouldLog { get; }
+            
+            public LogInterpolatedStringHandler(int literalLength, int formattedCount, LogLevel level, string tag, out bool shouldLog)
+            {
+                ShouldLog = shouldLog = Logger.shouldLog(tag, level);
+
+                if (shouldLog)
+                    _handler = new DefaultInterpolatedStringHandler(literalLength, formattedCount);
+            }
+
+            internal string ToStringAndClear() => _handler.ToStringAndClear();
+
+            public void AppendLiteral(string txt) => _handler.AppendLiteral(txt);
+
+            public void AppendFormatted<T>(T value) => _handler.AppendFormatted(value);
+            
+            public void AppendFormatted<T>(T value, string format) => _handler.AppendFormatted(value);
+            
+            public void AppendFormatted<T>(T value, int alignment) => _handler.AppendFormatted(value, alignment);
+            
+            public void AppendFormatted<T>(T value, int alignment, string format) => _handler.AppendFormatted(value, alignment);
+            
+            public void AppendFormatted(scoped ReadOnlySpan<char> value) => _handler.AppendFormatted(value);
+            
+            public void AppendFormatted(scoped ReadOnlySpan<char> value, int alignment, string format = null) =>
+                _handler.AppendFormatted(value, alignment, format);
+            
+            public void AppendFormatted(string value) => _handler.AppendFormatted(value);
+            
+            public void AppendFormatted(string value, int alignment, string format = null) => _handler.AppendFormatted(value, alignment, format);
+        }
+        
+        // Unfortunately, it is impossible to pass constants as a parameter to InterpolatedStringHandlers afaik,
+        // so we need a different way to pass the log level - const generics seem like the only way unfortunately.
+        /// <inheritdoc cref="LogInterpolatedStringHandler"/>
+        [InterpolatedStringHandler]
+        public ref struct LogInterpolatedStringHandler<TLevel> where TLevel : struct, IConst<LogLevel>
+        {
+            DefaultInterpolatedStringHandler _handler;
+            
+            public bool ShouldLog { get; }
+            
+            public LogInterpolatedStringHandler(int literalLength, int formattedCount, string tag, out bool shouldLog)
+            {
+                shouldLog = Logger.shouldLog(tag, TLevel.Value);
+                ShouldLog = shouldLog;
+
+                if (shouldLog)
+                    _handler = new DefaultInterpolatedStringHandler(literalLength, formattedCount);
+            }
+            
+            internal string ToStringAndClear() => _handler.ToStringAndClear();
+
+            public void AppendLiteral(string txt) => _handler.AppendLiteral(txt);
+
+            public void AppendFormatted<T>(T value) => _handler.AppendFormatted(value);
+            
+            public void AppendFormatted<T>(T value, string format) => _handler.AppendFormatted(value);
+            
+            public void AppendFormatted<T>(T value, int alignment) => _handler.AppendFormatted(value, alignment);
+            
+            public void AppendFormatted<T>(T value, int alignment, string format) => _handler.AppendFormatted(value, alignment);
+            
+            public void AppendFormatted(scoped ReadOnlySpan<char> value) => _handler.AppendFormatted(value);
+            
+            public void AppendFormatted(scoped ReadOnlySpan<char> value, int alignment, string format = null) =>
+                _handler.AppendFormatted(value, alignment, format);
+            
+            public void AppendFormatted(string value) => _handler.AppendFormatted(value);
+            
+            public void AppendFormatted(string value, int alignment, string format = null) => _handler.AppendFormatted(value, alignment, format);
+        }
     }
     public enum LogLevel {
         Verbose,
@@ -320,6 +470,33 @@ namespace Celeste.Mod {
                 LogLevel.Error => "\x1b[31m",
                 _ => ""
             };
+        }
+    }
+
+    public static class LogLevelConstTypes {
+        public struct Verbose : IConst<LogLevel>
+        {
+            public static LogLevel Value => LogLevel.Verbose;
+        }
+        
+        public struct Debug : IConst<LogLevel>
+        {
+            public static LogLevel Value => LogLevel.Debug;
+        }
+        
+        public struct Info : IConst<LogLevel>
+        {
+            public static LogLevel Value => LogLevel.Info;
+        }
+        
+        public struct Warn : IConst<LogLevel>
+        {
+            public static LogLevel Value => LogLevel.Warn;
+        }
+        
+        public struct Error : IConst<LogLevel>
+        {
+            public static LogLevel Value => LogLevel.Error;
         }
     }
 }

--- a/Celeste.Mod.mm/Mod/Helpers/IConst.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/IConst.cs
@@ -1,0 +1,12 @@
+namespace Celeste.Mod.Helpers;
+
+/// <summary>
+/// Represents a constant value, to be used for generic methods by structs implementing this interface.
+/// </summary>
+public interface IConst<out T>
+{
+    /// <summary>
+    /// The value of this constant.
+    /// </summary>
+    public static abstract T Value { get; }
+}


### PR DESCRIPTION
Currently, there are tons of places using string interpolation to create a message for the logger, which does unnecessary string interpolation if it turns out the message won't get logged due to log level anyway.
This PR uses a custom InterpolatedStringHandler to avoid said interpolation.