### PR TITLE
Warn and crash on hooks with insecure inlining policies

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -386,6 +386,7 @@ namespace Celeste.Mod {
             }
 
             DetourManager.DetourApplied += info => {
+                HookUtils.EnsureLegalHook(info);
                 if (GetHookOwner(out bool isMMHook) is not Assembly owner)
                     return;
 
@@ -399,6 +400,7 @@ namespace Celeste.Mod {
             DetourManager.DetourUndone += UnregisterModDetour;
 
             DetourManager.ILHookApplied += info => {
+                HookUtils.EnsureLegalHook(info);
                 if (GetHookOwner(out bool isMMHook) is not Assembly owner)
                     return;
 

--- a/Celeste.Mod.mm/Mod/Helpers/HookUtils.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/HookUtils.cs
@@ -1,0 +1,57 @@
+using Celeste.Mod.Helpers.LegacyMonoMod;
+using MonoMod.Core.Platforms;
+using MonoMod.RuntimeDetour;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Celeste.Mod.Helpers;
+
+public static class HookUtils {
+    // This field is used to skip warnings on method which have had inlining disabled at runtime, since
+    // reflection does not update the inlining status of a method.
+    private static readonly HashSet<MethodBase> InliningDisabledMethods = new();
+    
+    /// <summary>
+    /// Attempts to disable inlining on a method.
+    /// </summary>
+    /// <param name="targetMethod">The method to disable inlining on.</param>
+    /// <returns>Whether it was successful.</returns>
+    public static bool TryDisableInlining(MethodBase targetMethod) {
+        if (InliningDisabledMethods.Contains(targetMethod)) return true;
+
+        if (PlatformTriple.Current.TryDisableInlining(targetMethod)) {
+            InliningDisabledMethods.Add(targetMethod);
+            return true;
+        }
+
+        return false;
+    }
+    
+    // Entirely disallow any sort of (managed) hooks on methods flagged as AggressiveInlining
+    // Also warn on any late hooks on methods which are for inlining
+    internal static void EnsureLegalHook(DetourBase info) {
+        MethodBase target = info.Method.Method;
+        if (target.MethodImplementationFlags.HasFlag(MethodImplAttributes.NoInlining)) return;
+            
+        MethodBase hookingMethod = info switch {
+            DetourInfo di => di.Entry,
+            ILHookInfo hi => hi.ManipulatorMethod,
+            _ => throw new NotSupportedException(),
+        };
+        // Hooks on AggressiveInlining tagged methods are considered significantly performance impactful and are never allowed
+        if (target.MethodImplementationFlags.HasFlag(MethodImplAttributes.AggressiveInlining)) {
+            MonoModPolice.ReportMonoModCrime($"{GetFullMethodName(hookingMethod)} is hooking method {GetFullMethodName(target)} which has aggressive inlining enabled!", hookingMethod);
+        }
+            
+        // We consider a hook to be "late" if the EverestModule `Initialize` call has occured already for all the loaded mods.
+        // But leave the message for early hooks on verbose level too
+        if (!InliningDisabledMethods.Contains(target))
+            Logger.Log(Everest._Initialized ? LogLevel.Warn : LogLevel.Verbose, "Everest", $"{GetFullMethodName(hookingMethod)} is hooking method {GetFullMethodName(target)} which does not have inlining disabled!");
+        return;
+
+        string GetFullMethodName(MethodBase m) {
+            return $"{m.DeclaringType?.FullName ?? "(Unknown Declaring Type}"}.{m.Name}";
+        }
+    }
+}


### PR DESCRIPTION
Crash (with a Monomod crime) on hooks to methods with `AggressiveInlining` and warn on methods that arent marked with `NoInlining` if such hooks happen "late" (see changes for a definition).
No public facing in Everest currently contain the `AggressiveInlining` attribute (before #957), so this change should be non-breaking.
`EnsureLegalHook` should be expanded with an `Unhookable` attribute should be added once we need to disable hooking on some method without wanting to alter its inlining policy.

Also adds a new API to disable inlining on methods in a way where warnings will be avoided afterwards.