### PR TITLE
Patch Debris to play a custom impact sound if defined

### DIFF
--- a/Celeste.Mod.mm/Patches/Autotiler.cs
+++ b/Celeste.Mod.mm/Patches/Autotiler.cs
@@ -85,6 +85,9 @@ namespace Celeste {
             if (xml.HasAttr("debris"))
                 data.Debris = xml.Attr("debris");
 
+            if (xml.HasAttr("debrisImpactSfx"))
+                data.DebrisImpactSfx = xml.Attr("debrisImpactSfx");
+
             if (xml.HasAttr("ignoreExceptions")) {
                 string[] array = xml.Attr("ignoreExceptions").Split(',');
 
@@ -399,6 +402,10 @@ namespace Celeste {
             return !string.IsNullOrEmpty(path = lookup.TryGetValue(tiletype, out patch_TerrainType t) ? t.Debris : "");
         }
 
+        public bool TryGetCustomDebrisImpactSfx(out string sfxEvent, char tiletype) {
+            return !string.IsNullOrEmpty(sfxEvent = lookup.TryGetValue(tiletype, out patch_TerrainType t) ? t.DebrisImpactSfx : "");
+        }
+
         // Required because TerrainType is private.
         private class patch_TerrainType {
             public char ID;
@@ -411,6 +418,7 @@ namespace Celeste {
             public patch_Tiles Padded;
 
             public string Debris;
+            public string DebrisImpactSfx;
 
             public int ScanWidth;
             public int ScanHeight;

--- a/Celeste.Mod.mm/Patches/Debris.cs
+++ b/Celeste.Mod.mm/Patches/Debris.cs
@@ -2,7 +2,13 @@
 #pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
 
 using Microsoft.Xna.Framework;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
 using Monocle;
+using MonoMod;
+using MonoMod.Cil;
+using MonoMod.Utils;
+using System;
 using System.Collections.Generic;
 
 namespace Celeste {
@@ -24,6 +30,60 @@ namespace Celeste {
             }
 
             return debris;
+        }
+
+        [MonoModIgnore]
+        [PatchDebrisImpactSfx]
+        private extern void ImpactSfx(float spd);
+
+    }
+}
+
+namespace MonoMod {
+    /// <summary>
+    /// Patches Celeste.Debris.ImpactSfx(System.Single) to play a custom sound event if defined.
+    /// </summary>
+    [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchDebrisImpactSfx))]
+    class PatchDebrisImpactSfxAttribute : Attribute { }
+
+    static partial class MonoModRules {
+
+        public static void PatchDebrisImpactSfx(ILContext context, CustomAttribute attrib) {
+            ILCursor cursor = new ILCursor(context);
+
+            FieldDefinition f_tileset = context.Method.DeclaringType.FindField("tileset");
+
+            FieldDefinition f_GFX_FGAutotiler = context.Module.GetType("Celeste.GFX").FindField("FGAutotiler");
+            MethodDefinition m_Autotiler_TryGetCustomDebrisImpactSfx = context.Module.GetType("Celeste.Autotiler").FindMethod("TryGetCustomDebrisImpactSfx");
+
+            /*
+             Change:
+             
+             string path = "event:/game/general/debris_dirt";
+             [...] // tileset checks
+             Audio.Play(path, [...]);
+             
+             to:
+             
+             if (!GFX.FGAutotiler.TryGetCustomDebrisImpactSfx(out string path, tileset)) {
+                 path = "event:/game/general/debris_dirt";
+                 [...] // tileset checks
+             }
+             Audio.Play(path, [...]);
+             */
+
+            cursor.GotoNext(MoveType.AfterLabel, instr => instr.MatchLdstr("event:/game/general/debris_dirt"));
+
+            cursor.Emit(OpCodes.Ldsfld, f_GFX_FGAutotiler);
+            cursor.Emit(OpCodes.Ldloca_S, (byte) 0);
+            cursor.Emit(OpCodes.Ldarg_0);
+            cursor.Emit(OpCodes.Ldfld, f_tileset);
+            cursor.Emit(OpCodes.Callvirt, m_Autotiler_TryGetCustomDebrisImpactSfx);
+
+            ILLabel playAudioLabel = null;
+            cursor.Clone().GotoNext(instr => instr.MatchBr(out playAudioLabel));
+
+            cursor.Emit(OpCodes.Brtrue_S, playAudioLabel);
         }
 
     }


### PR DESCRIPTION
This PR implements a new attribute to tileset elements in the tileset XMLs.

**`debrisImpactSfx`** accepts the event name of the sound effect the debris spawned from this tiletype should play when it hits the ground.
By default, it plays `"event:/game/general/debris_dirt"` for every tiletype, except `4` *(girder)*, `5` *(tower)*, `6` *(stone)*, `7` *(cement)*, `a` *(woodStoneEdges)*, `c` *(poolEdges)*, `d` *(templeA)*, `e` *(templeB)*, `f` *(cliffsideAlt)*, and `g` *(reflection)* which make it play `"event:/game/general/debris_stone"`, and `9` *(wood)* which makes it play `"event:/game/general/debris_wood"`.

Resolves issue #964 