### PR TITLE
Log `FileSystemWatcher` errors

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Content.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Content.cs
@@ -177,6 +177,7 @@ namespace Celeste.Mod {
                 watcher.Created += FileUpdated;
                 watcher.Deleted += FileUpdated;
                 watcher.Renamed += FileRenamed;
+                watcher.Error += WatcherError;
 
                 watcher.EnableRaisingEvents = true;
             } catch (Exception e) {
@@ -289,6 +290,11 @@ namespace Celeste.Mod {
         private void FileRenamed(object source, RenamedEventArgs e) {
             Logger.Verbose("content", $"File renamed: {e.OldFullPath} - {e.FullPath}");
             QueuedTaskHelper.Do(Tuple.Create(e.OldFullPath, e.FullPath), () => Update(e.OldFullPath, e.FullPath));
+        }
+
+        private void WatcherError(object source, ErrorEventArgs e) {
+            Logger.Error("content", $"Error while watching \"{Path}\" for changes. Updates will no longer be detected.");
+            Logger.LogDetailed(e.GetException());
         }
 
         private void Update(string pathPrev, string pathNext) {

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
@@ -218,6 +218,7 @@ namespace Celeste.Mod {
                     };
 
                     Watcher.Created += LoadAutoUpdated;
+                    Watcher.Error += WatcherError;
 
                     Watcher.EnableRaisingEvents = true;
                     AutoLoadNewMods = true;
@@ -241,6 +242,11 @@ namespace Celeste.Mod {
                         LoadZip(e.FullPath);
                     ((patch_OuiMainMenu) (AssetReloadHelper.ReturnToScene as Overworld)?.GetUI<OuiMainMenu>())?.NeedsRebuild();
                 })));
+            }
+
+            private static void WatcherError(object source, ErrorEventArgs e) {
+                Logger.Error("loader", $"Error while watching \"{PathMods}\" for changes. Updates will no longer be detected.");
+                Logger.LogDetailed(e.GetException());
             }
 
             /// <summary>

--- a/Celeste.Mod.mm/Mod/Module/EverestModuleAssemblyContext.cs
+++ b/Celeste.Mod.mm/Mod/Module/EverestModuleAssemblyContext.cs
@@ -473,6 +473,11 @@ namespace Celeste.Mod {
                     Logger.Info("modasmctx", $"Reloading mod assembly context because of changed assembly: {e.FullPath}");
                     Everest.Loader.ReloadMod(ModuleMeta);
                 };
+                watcher.Error += (s, e) => {
+                    Logger.Error("modasmctx", $"Error while watching \"{asmDir}\" for changes. Updates will no longer be detected.");
+                    Logger.LogDetailed(e.GetException());
+                };
+
                 watcher.EnableRaisingEvents = true;
 
                 _AssemblyReloadWatchers.Add(asmDir, watcher);


### PR DESCRIPTION
If a `FileSystemWatcher` encounters an error, it will silently stop listening for events. This PR makes watcher errors no longer silent.

This should hopefully help in figuring out asset reload issues.