### PR TITLE
Bump MonoMod

### DIFF
--- a/.azure-pipelines/build.yml
+++ b/.azure-pipelines/build.yml
@@ -26,7 +26,7 @@ steps:
 - task: UseDotNet@2
   displayName: 'Set up .NET'
   inputs: # packageType defaults to sdk
-    version: 9.0.102 # net9.0 required by MonoMod
+    version: 9.0.304 # net9.0 required by MonoMod
 
 - task: DotNetCoreCLI@2
   displayName: 'Restore NuGet packages'

--- a/Celeste.Mod.mm/Celeste.Mod.mm.csproj
+++ b/Celeste.Mod.mm/Celeste.Mod.mm.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Cecil" Version="0.11.5" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.6" />
     <ProjectReference Include="..\external\MonoMod\src\MonoMod.Patcher\MonoMod.Patcher.csproj" />
     <ProjectReference Include="..\external\MonoMod\src\MonoMod.Utils\MonoMod.Utils.csproj" />
     <ProjectReference Include="..\external\MonoMod\src\MonoMod.RuntimeDetour\MonoMod.RuntimeDetour.csproj" />

--- a/NETCoreifier/NETCoreifier.csproj
+++ b/NETCoreifier/NETCoreifier.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Cecil" Version="0.11.5" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.6" />
     <ProjectReference Include="..\external\MonoMod\src\MonoMod.Patcher\MonoMod.Patcher.csproj" />
     <ProjectReference Include="..\external\MonoMod\src\MonoMod.Utils\MonoMod.Utils.csproj" />
   </ItemGroup>


### PR DESCRIPTION
This bump mainly introduces ARM support on MonoMod's end. This can be useful for anyone interested in porting modded into arm devices.

The Cecil bump is required by MonoMod.