### PR TITLE
Update CustomMemorialText.cs to position itself sensibly when level.Zoom =\= 1

### DIFF
--- a/Celeste.Mod.mm/Mod/Entities/CustomMemorialText.cs
+++ b/Celeste.Mod.mm/Mod/Entities/CustomMemorialText.cs
@@ -108,7 +108,7 @@ namespace Celeste.Mod.Entities {
             }
 
             Camera camera = level.Camera;
-            Vector2 pos = new Vector2((Memorial.X - camera.X) * 6f, (Memorial.Y - camera.Y) * 6f - 350f - ActiveFont.LineHeight * 3.3f);
+            Vector2 pos = new Vector2((Memorial.X - camera.X) * (6f * level.Zoom), (Memorial.Y - camera.Y) * (6f * level.Zoom) - 350f - ActiveFont.LineHeight * 3.3f);
             if (SaveData.Instance != null && SaveData.Instance.Assists.MirrorMode)
                 pos.X = 1920f - pos.X;
 


### PR DESCRIPTION
Like vanilla, the CustomMemorialText assumes that the UI will be at 6x scale from the world.
When Level.Zoom =\\= 1, this assumption fails, and the text is placed in a seemingly strange position.
This fix(?) makes the position more in-line with mapper expectations when the zoom factor =\\= 1.

> Note: this makes the custom memorial deviate from vanilla in behavior, which could theoretically break pre-existing maps' visuals. e.g.: If someone intentionally zoomed in for the odd text position, then this fix would break their map's visuals.
I don't think that's the case, but I think it's worth pointing out.

_I also admit this is partially because people keep bugging me about these being broken with excam. Since I can't patch Everest with a code mod, this is the only way to fix it without duplicating them on my end._