### PR TITLE
Introduce events for Player.Update and Level.Update.

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Events.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Events.cs
@@ -187,6 +187,21 @@ namespace Celeste.Mod {
                 public static event CompleteHandler OnComplete;
                 internal static void Complete(_Level level)
                     => OnComplete?.Invoke(level);
+                
+                /// <summary>
+                /// Called at the very beginning of <see cref="global::Celeste.Level.Update"/>.
+                /// </summary>
+                public static event Action<_Level> OnBeforeUpdate;
+                internal static void BeforeUpdate(_Level level)
+                    => OnBeforeUpdate?.Invoke(level);
+                
+                /// <summary>
+                /// Called at the very end of <see cref="global::Celeste.Level.Update"/>.
+                /// </summary>
+                public static event Action<_Level> OnAfterUpdate;
+                
+                internal static void AfterUpdate(_Level level)
+                    => OnAfterUpdate?.Invoke(level);
             }
 
             public static class Session {
@@ -196,17 +211,41 @@ namespace Celeste.Mod {
             }
 
             public static class Player {
+                /// <summary>
+                /// Called at the end of <see cref="global::Celeste.Player.Added"/>.
+                /// </summary>
                 public static event Action<_Player> OnSpawn;
                 internal static void Spawn(_Player player)
                     => OnSpawn?.Invoke(player);
 
+                /// <summary>
+                /// Called in <see cref="global::Celeste.Player.Die"/>, only if a PlayerDeadBody will be returned from the method.
+                /// </summary>
                 public static event Action<_Player> OnDie;
                 internal static void Die(_Player player)
                     => OnDie?.Invoke(player);
 
+                /// <summary>
+                /// Called in the Player constructor during <see cref="StateMachine"/> initialisation, to be used to register custom Player states.
+                /// </summary>
                 public static event Action<_Player> OnRegisterStates;
                 internal static void RegisterStates(_Player player)
                     => OnRegisterStates?.Invoke(player);
+
+                /// <summary>
+                /// Called at the very beginning of <see cref="global::Celeste.Player.Update"/>.
+                /// </summary>
+                public static event Action<_Player> OnBeforeUpdate;
+                internal static void BeforeUpdate(_Player player)
+                    => OnBeforeUpdate?.Invoke(player);
+                
+                /// <summary>
+                /// Called at the very end of <see cref="global::Celeste.Player.Update"/>.
+                /// </summary>
+                public static event Action<_Player> OnAfterUpdate;
+                
+                internal static void AfterUpdate(_Player player)
+                    => OnAfterUpdate?.Invoke(player);
             }
 
             public static class Seeker {

--- a/Celeste.Mod.mm/Patches/Level.cs
+++ b/Celeste.Mod.mm/Patches/Level.cs
@@ -972,8 +972,14 @@ namespace MonoMod {
             MethodReference m_Everest_CoreModule_Settings = MonoModRule.Modder.Module.GetType("Celeste.Mod.Core.CoreModule").FindProperty("Settings").GetMethod;
             TypeDefinition t_Everest_CoreModuleSettings = MonoModRule.Modder.Module.GetType("Celeste.Mod.Core.CoreModuleSettings");
             MethodReference m_ButtonBinding_Pressed = MonoModRule.Modder.Module.GetType("Celeste.Mod.ButtonBinding").FindProperty("Pressed").GetMethod;
-
+            TypeDefinition t_Everest_Events_Level = MonoModRule.Modder.Module.GetType("Celeste.Mod.Everest/Events/Level");
+            MethodReference m_Everest_Events_Level_BeforeUpdate = t_Everest_Events_Level.FindMethod(nameof(Everest.Events.Level.BeforeUpdate));
+            MethodReference m_Everest_Events_Level_AfterUpdate = t_Everest_Events_Level.FindMethod(nameof(Everest.Events.Level.AfterUpdate));
+            
             ILCursor cursor = new ILCursor(context);
+            
+            // Invoke Celeste.Mod.Everest.Events.Level.OnBeforeUpdate
+            cursor.Emit(OpCodes.Ldarg_0).Emit(OpCodes.Call, m_Everest_Events_Level_BeforeUpdate);
 
             // Insert CheckForErrors() at the beginning so we can display an error screen if needed
             cursor.Emit(OpCodes.Ldarg_0).Emit(OpCodes.Call, m_CheckForErrors);
@@ -1005,6 +1011,13 @@ namespace MonoMod {
             cursor.Emit(OpCodes.Call, m_Everest_CoreModule_Settings);
             cursor.Emit(OpCodes.Call, t_Everest_CoreModuleSettings.FindProperty("DebugMap").GetMethod);
             cursor.Emit(OpCodes.Call, m_ButtonBinding_Pressed);
+            
+            // Invoke Everest.Events.Level.OnAfterUpdate before each ret.
+            cursor.Index = 0;
+            while (cursor.TryGotoNext(MoveType.AfterLabel, instr => instr.MatchRet())) {
+                cursor.Emit(OpCodes.Ldarg_0).Emit(OpCodes.Call, m_Everest_Events_Level_AfterUpdate);
+                cursor.Index++;
+            }
         }
 
         public static void PatchLevelRender(ILContext context, CustomAttribute attrib) {

--- a/Celeste.Mod.mm/Patches/Player.cs
+++ b/Celeste.Mod.mm/Patches/Player.cs
@@ -135,6 +135,7 @@ namespace Celeste {
         [PatchPlayerOrigUpdate] // Manipulate the method via MonoModRules
         public extern void orig_Update();
         public override void Update() {
+            Everest.Events.Player.BeforeUpdate(this);
             orig_Update();
 
             Level level = Scene as Level;
@@ -144,6 +145,8 @@ namespace Celeste {
                 framesAlive++;
             if (framesAlive >= 8)
                 diedInGBJ = 0;
+
+            Everest.Events.Player.AfterUpdate(this);
         }
 
         public bool _IsOverWater() {


### PR DESCRIPTION
These 2 methods are some of the most frequently On hooked methods in the game, so it makes sense to introduce an everest event for these, as:
- Hooks have higher overhead than events, as tested in one of Wartori's benchmarks.
- Stack traces become insanely long.
- Navigating tools like dotTrace becomes very annoying.

Also, should `Player.OnBeforeUpdate` allow returning a bool to cancel `Player.Update` to mimic not calling orig?