### PR TITLE
Add default values for MapMetaMountain (#935)

### DIFF
--- a/Celeste.Mod.mm/Patches/AreaData.cs
+++ b/Celeste.Mod.mm/Patches/AreaData.cs
@@ -256,7 +256,20 @@ namespace Celeste {
 
                     // Custom values can be set via the MapMeta.
                     MapMeta meta = new MapMeta();
+                    // default values for mountain camera and cursor
+                    meta.Mountain = new MapMetaMountain();
+                    meta.Mountain.Idle = new MapMetaMountainCamera();
+                    meta.Mountain.Idle.Position = new float[] { 10, 16, 10 };
+                    meta.Mountain.Idle.Target = new float[] { 1, 10, 1 };
+                    meta.Mountain.Select = new MapMetaMountainCamera();
+                    meta.Mountain.Select.Position = new float[] { 8, 13, 8 };
+                    meta.Mountain.Select.Target = new float[] { 1, 8, 1 };
+                    meta.Mountain.Zoom = new MapMetaMountainCamera();
+                    meta.Mountain.Zoom.Position = new float[] { 6, 10, 6 };
+                    meta.Mountain.Zoom.Target = new float[] { 1, 6, 1 };
+                    meta.Mountain.Cursor = new float[] { 3, 10, 3 };
                     meta.ApplyTo(area);
+
                     MapMeta metaLoaded = asset.GetMeta<MapMeta>();
                     if (metaLoaded != null) {
                         area.Meta = null;


### PR DESCRIPTION
This PR adds a default value for the `MapMetaMountain` data so that we can actually see the Overworld even when no mountain metadata is bundled with a map.

<img width="942" height="720" alt="image" src="https://github.com/user-attachments/assets/9f0d5e38-1132-4dee-8eea-288849a8c2b5" />

Closes #935.