### PR TITLE
Rewrite `QueuedTaskHelper`

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Content.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Content.cs
@@ -284,12 +284,12 @@ namespace Celeste.Mod {
                 return;
 
             Logger.Verbose("content", $"File updated: {e.FullPath} - {e.ChangeType}");
-            QueuedTaskHelper.Do(e.FullPath, () => Update(e.FullPath, e.FullPath));
+            QueuedTaskHelperV2.Do(e.FullPath, () => Update(e.FullPath, e.FullPath));
         }
 
         private void FileRenamed(object source, RenamedEventArgs e) {
             Logger.Verbose("content", $"File renamed: {e.OldFullPath} - {e.FullPath}");
-            QueuedTaskHelper.Do(Tuple.Create(e.OldFullPath, e.FullPath), () => Update(e.OldFullPath, e.FullPath));
+            QueuedTaskHelperV2.Do(Tuple.Create(e.OldFullPath, e.FullPath), () => Update(e.OldFullPath, e.FullPath));
         }
 
         private void WatcherError(object source, ErrorEventArgs e) {

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
@@ -235,7 +235,7 @@ namespace Celeste.Mod {
                     return;
 
                 Logger.Info("loader", $"Possible new mod container: {e.FullPath}");
-                QueuedTaskHelper.Do("LoadAutoUpdated:" + e.FullPath, () => AssetReloadHelper.Do($"{Dialog.Clean("ASSETRELOADHELPER_LOADINGNEWMOD")} {Path.GetFileName(e.FullPath)}", () => MainThreadHelper.Schedule(() => {
+                QueuedTaskHelperV2.Do("LoadAutoUpdated:" + e.FullPath, () => AssetReloadHelper.Do($"{Dialog.Clean("ASSETRELOADHELPER_LOADINGNEWMOD")} {Path.GetFileName(e.FullPath)}", () => MainThreadHelper.Schedule(() => {
                     if (Directory.Exists(e.FullPath))
                         LoadDir(e.FullPath);
                     else if (e.FullPath.EndsWith(".zip"))
@@ -843,7 +843,7 @@ namespace Celeste.Mod {
                 if (!Flags.SupportRuntimeMods || meta.AssemblyContext == null)
                     return;
 
-                QueuedTaskHelper.Do($"ReloadModAssembly: {meta.Name}", () => {
+                QueuedTaskHelperV2.Do($"ReloadModAssembly: {meta.Name}", () => {
                     Logger.Info("loader", $"Reloading mod assemblies: {meta.Name}");
 
                     AssetReloadHelper.Do($"{Dialog.Clean("ASSETRELOADHELPER_RELOADINGMODASSEMBLY")} {meta.Name}", () => {

--- a/Celeste.Mod.mm/Mod/Helpers/QueuedTaskHelper.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/QueuedTaskHelper.cs
@@ -1,10 +1,13 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
 
+// the class has been part of the public API for years, so we can't just change the namespace
+// ReSharper disable CheckNamespace
 namespace Celeste.Mod {
+    [Obsolete("Use QueuedTaskHelperV2 instead.")]
     public static class QueuedTaskHelper {
 
         // Make sure to lock Timers and update both of those at the same time before unlocking!
@@ -13,6 +16,7 @@ namespace Celeste.Mod {
 
         public static readonly double DefaultDelay = 0.5D;
 
+        [Obsolete($"Queued tasks now support {nameof(CancellationToken)}s. Pass the token when creating the task and cancel it when necessary.")]
         public static void Cancel(object key) {
             lock (Timers) {
                 if (Timers.Remove(key, out Stopwatch timer)) {
@@ -23,8 +27,11 @@ namespace Celeste.Mod {
             }
         }
 
+        [Obsolete("Use QueuedTaskHelperV2.Do instead.")]
         public static Task Do(object key, Action a)
             => Do(key, DefaultDelay, a);
+
+        [Obsolete("Use QueuedTaskHelperV2.Do instead.")]
         public static Task Do(object key, double delay, Action a) {
             lock (Timers) {
                 if (!Timers.TryGetValue(key, out Stopwatch timer)) {
@@ -56,8 +63,11 @@ namespace Celeste.Mod {
             }
         }
 
+        [Obsolete("Use QueuedTaskHelperV2.Get instead.")]
         public static Task<T> Get<T>(object key, Func<T> f)
             => Get(key, DefaultDelay, f);
+
+        [Obsolete("Use QueuedTaskHelperV2.Get instead.")]
         public static Task<T> Get<T>(object key, double delay, Func<T> f) {
             lock (Timers) {
                 if (!Timers.TryGetValue(key, out Stopwatch timer)) {
@@ -85,6 +95,307 @@ namespace Celeste.Mod {
                 return (Task<T>) queued;
             }
         }
+    }
 
+    /// <summary>
+    ///   A class containing methods that allow for asynchronously executing a delegate after a specified delay.
+    /// </summary>
+    public static class QueuedTaskHelperV2 {
+        internal static readonly Dictionary<object, QueuedTaskBase> RunningTasks = new();
+        public static readonly TimeSpan DefaultDelay = TimeSpan.FromSeconds(0.5);
+
+        /// <summary>
+        ///   Schedules the given <paramref name="delegate"/> to execute asynchronously after the <see cref="DefaultDelay"/>.
+        /// </summary>
+        /// <remarks>
+        ///   If a task with the same key is scheduled twice, the delay time spans will be overlaid.
+        ///   That is, when the first execution delays for <c>10</c> seconds, and a second execution that delays for <c>5</c> seconds
+        ///   is scheduled <c>7.5</c> seconds after the first one, the actual delay time becomes <c>12.5</c> seconds.
+        /// </remarks>
+        /// <param name="key">
+        ///   The identifier of the task.
+        /// </param>
+        /// <param name="delegate">
+        ///   The delegate to execute after waiting for <see cref="DefaultDelay"/>.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="QueuedTask"/> representing the scheduled execution of <paramref name="delegate"/>.
+        /// </returns>
+        /// <throws cref="InvalidOperationException">
+        ///   A task with the same key that is not a <see cref="QueuedTask"/> is already running.
+        /// </throws>
+        public static QueuedTask Do(object key, Action @delegate)
+            => Do(key, DefaultDelay, @delegate, CancellationToken.None);
+
+        /// <summary>
+        ///   Schedules the given <paramref name="delegate"/> to execute asynchronously after a given <paramref name="delay"/>.
+        /// </summary>
+        /// <remarks>
+        ///   If a task with the same key is scheduled twice, the delay time spans will be overlaid.
+        ///   That is, when the first execution delays for <c>10</c> seconds, and a second execution that delays for <c>5</c> seconds
+        ///   is scheduled <c>7.5</c> seconds after the first one, the actual delay time becomes <c>12.5</c> seconds.
+        /// </remarks>
+        /// <param name="key">
+        ///   The identifier of the task.
+        /// </param>
+        /// <param name="delay">
+        ///   The delay time before executing the delegate.
+        /// </param>
+        /// <param name="delegate">
+        ///   The delegate to execute after waiting for <paramref name="delay"/>.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="QueuedTask"/> representing the delayed execution of the specified action.
+        /// </returns>
+        /// <throws cref="InvalidOperationException">
+        ///   A task with the same key that is not a <see cref="QueuedTask"/> is already running.
+        /// </throws>
+        public static QueuedTask Do(object key, TimeSpan delay, Action @delegate)
+            => Do(key, delay, @delegate, CancellationToken.None);
+
+        /// <summary>
+        ///   Schedules the given <paramref name="delegate"/> to execute asynchronously after a given <paramref name="delay"/>.
+        /// </summary>
+        /// <remarks>
+        ///   If a task with the same key is scheduled twice, the delay time spans will be overlaid.
+        ///   That is, when the first execution delays for <c>10</c> seconds, and a second execution that delays for <c>5</c> seconds
+        ///   is scheduled <c>7.5</c> seconds after the first one, the actual delay time becomes <c>12.5</c> seconds.
+        /// </remarks>
+        /// <param name="key">
+        ///   The identifier of the task.
+        /// </param>
+        /// <param name="delay">
+        ///   The delay time before executing the delegate.
+        /// </param>
+        /// <param name="delegate">
+        ///   The delegate to execute after waiting for <paramref name="delay"/>.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///   A cancellation token to observe while waiting for the delay.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="QueuedTask"/> representing the delayed execution of the specified action.
+        /// </returns>
+        /// <throws cref="InvalidOperationException">
+        ///   A task with the same key that is not a <see cref="QueuedTask"/> is already running.
+        /// </throws>
+        public static QueuedTask Do(object key, TimeSpan delay, Action @delegate, CancellationToken cancellationToken) {
+            lock (RunningTasks) {
+                if (RunningTasks.TryGetValue(key, out QueuedTaskBase baseTask)) {
+                    if (baseTask is not QueuedTask existingTask)
+                        throw new InvalidOperationException("A queued task with an incompatible type is already running.");
+
+                    existingTask.OverlayDelay(delay);
+                    return existingTask;
+                }
+
+                QueuedTask task = new(key, @delegate, delay, cancellationToken);
+                RunningTasks[key] = task;
+                return task;
+            }
+        }
+
+        /// <summary>
+        ///   Schedules the given <paramref name="delegate"/> to execute asynchronously after the <see cref="DefaultDelay"/>.
+        /// </summary>
+        /// <remarks>
+        ///   If a task with the same key is scheduled twice, the delay time spans will be overlaid.
+        ///   That is, when the first execution delays for <c>10</c> seconds, and a second execution that delays for <c>5</c> seconds
+        ///   is scheduled <c>7.5</c> seconds after the first one, the actual delay time becomes <c>12.5</c> seconds.
+        /// </remarks>
+        /// <typeparam name="T">
+        ///   The return type of <paramref name="delegate"/>.
+        /// </typeparam>
+        /// <param name="key">
+        ///   The identifier of the task.
+        /// </param>
+        /// <param name="delegate">
+        ///   The delegate to execute after waiting for <see cref="DefaultDelay"/>.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="QueuedTask{T}"/> representing the scheduled execution of <paramref name="delegate"/>.
+        /// </returns>
+        /// <throws cref="InvalidOperationException">
+        ///   A task with the same key that is not a <see cref="QueuedTask{T}"/> is already running.
+        /// </throws>
+        public static QueuedTask<T> Get<T>(object key, Func<T> @delegate)
+            => Get(key, @delegate, DefaultDelay, CancellationToken.None);
+
+        /// <summary>
+        ///   Schedules the given <paramref name="delegate"/> to execute asynchronously after a given <paramref name="delay"/>.
+        /// </summary>
+        /// <remarks>
+        ///   If a task with the same key is scheduled twice, the delay time spans will be overlaid.
+        ///   That is, when the first execution delays for <c>10</c> seconds, and a second execution that delays for <c>5</c> seconds
+        ///   is scheduled <c>7.5</c> seconds after the first one, the actual delay time becomes <c>12.5</c> seconds.
+        /// </remarks>
+        /// <typeparam name="T">
+        ///   The return type of <paramref name="delegate"/>.
+        /// </typeparam>
+        /// <param name="key">
+        ///   The identifier of the task.
+        /// </param>
+        /// <param name="delay">
+        ///   The delay time before executing the delegate.
+        /// </param>
+        /// <param name="delegate">
+        ///   The delegate to execute after waiting for <paramref name="delay"/>.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="QueuedTask{T}"/> representing the delayed execution of the specified action.
+        /// </returns>
+        /// <throws cref="InvalidOperationException">
+        ///   A task with the same key that is not a <see cref="QueuedTask{T}"/> is already running.
+        /// </throws>
+        public static QueuedTask<T> Get<T>(object key, Func<T> @delegate, TimeSpan delay)
+            => Get(key, @delegate, delay, CancellationToken.None);
+
+        /// <summary>
+        ///   Schedules the given <paramref name="delegate"/> to execute asynchronously after a given <paramref name="delay"/>.
+        /// </summary>
+        /// <remarks>
+        ///   If a task with the same key is scheduled twice, the delay time spans will be overlaid.
+        ///   That is, when the first execution delays for <c>10</c> seconds, and a second execution that delays for <c>5</c> seconds
+        ///   is scheduled <c>7.5</c> seconds after the first one, the actual delay time becomes <c>12.5</c> seconds.
+        /// </remarks>
+        /// <typeparam name="T">
+        ///   The return type of <paramref name="delegate"/>.
+        /// </typeparam>
+        /// <param name="key">
+        ///   The identifier of the task.
+        /// </param>
+        /// <param name="delay">
+        ///   The delay time before executing the delegate.
+        /// </param>
+        /// <param name="delegate">
+        ///   The delegate to execute after waiting for <paramref name="delay"/>.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///   A cancellation token to observe while waiting for the delay.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="QueuedTask{T}"/> representing the delayed execution of the specified action.
+        /// </returns>
+        /// <throws cref="InvalidOperationException">
+        ///   A task with the same key that is not a <see cref="QueuedTask{T}"/> is already running.
+        /// </throws>
+        public static QueuedTask<T> Get<T>(object key, Func<T> @delegate, TimeSpan delay, CancellationToken cancellationToken) {
+            lock (RunningTasks) {
+                if (RunningTasks.TryGetValue(key, out QueuedTaskBase baseTask)) {
+                    if (baseTask is not QueuedTask<T> existingTask)
+                        throw new InvalidOperationException("A queued task with an incompatible type is already running.");
+
+                    existingTask.OverlayDelay(delay);
+                    return existingTask;
+                }
+
+                QueuedTask<T> task = new(key, @delegate, delay, cancellationToken);
+                RunningTasks[key] = task;
+                return task;
+            }
+        }
+    }
+
+    /// <summary>
+    ///   The base class of all queued tasks.
+    /// </summary>
+    public abstract class QueuedTaskBase {
+        /// <summary>
+        ///   The key associated with the task.
+        /// </summary>
+        public object Key { get; set; }
+
+        /// <summary>
+        ///   The <see cref="System.Threading.CancellationToken"/> that can cancel the task.
+        /// </summary>
+        public CancellationToken CancellationToken { get; init; }
+
+        /// <summary>
+        ///   A task that will complete after the given delay.
+        /// </summary>
+        /// <seealso cref="OverlayDelay"/>
+        protected Task DelayTask { get; private set; }
+
+        /// <summary>
+        ///   The queued <see cref="Task"/>.
+        /// </summary>
+        public Task Queued { get; init; }
+
+        protected QueuedTaskBase(object key, TimeSpan delay, CancellationToken cancellationToken) {
+            Key = key;
+            CancellationToken = cancellationToken;
+            OverlayDelay(delay);
+        }
+
+        /// <summary>
+        ///   Overlays a new delay on top of the existing one.
+        /// </summary>
+        /// <remarks>
+        ///   For example, when overlaying a <c>5</c>-second delay on top of a <c>10</c>-second delay,
+        ///   which starts <c>7.5</c> seconds after the first one, the total delay becomes <c>12.5</c> seconds.
+        /// </remarks>
+        internal void OverlayDelay(TimeSpan delay) {
+            DelayTask = Task.Delay(delay, CancellationToken);
+        }
+
+        protected void CompleteTask() {
+            QueuedTaskHelperV2.RunningTasks.Remove(Key);
+        }
+    }
+
+    /// <summary>
+    ///   A queued task that executes an <see cref="Action"/> after a delay.
+    /// </summary>
+    /// <seealso cref="QueuedTaskHelperV2.Do(object, Action)"/>
+    public sealed class QueuedTask : QueuedTaskBase {
+        internal QueuedTask(object key, Action @delegate, TimeSpan delay, CancellationToken cancellationToken)
+            : base(key, delay, cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(@delegate);
+            Queued = Run(@delegate);
+        }
+
+        private async Task Run(Action @delegate) {
+            // force the task to run asynchronously by yielding - we don't want to block the main thread
+            await Task.Yield();
+
+            // we need to wait on loop because DelayTask could have been changed by OverlayDelay
+            do {
+                await DelayTask;
+            } while (!DelayTask.IsCompleted);
+
+            @delegate();
+            CompleteTask();
+        }
+    }
+
+    /// <summary>
+    ///   A queued task that executes a <see cref="Func{T}"/> after a delay.
+    /// </summary>
+    /// <seealso cref="QueuedTaskHelperV2.Get{T}(object, Func{T})"/>
+    public sealed class QueuedTask<T> : QueuedTaskBase {
+        /// <inheritdoc cref="QueuedTaskBase.Queued"/>
+        public new Task<T> Queued => (Task<T>) base.Queued;
+
+        internal QueuedTask(object key, Func<T> @delegate, TimeSpan delay, CancellationToken cancellationToken)
+            : base(key, delay, cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(@delegate);
+            base.Queued = Run(@delegate);
+        }
+
+        private async Task<T> Run(Func<T> @delegate) {
+            // force the task to run asynchronously by yielding - we don't want to block the main thread
+            await Task.Yield();
+
+            // we need to wait on loop because DelayTask could have been changed by OverlayDelay
+            do {
+                await DelayTask;
+            } while (!DelayTask.IsCompleted);
+
+            T value = @delegate();
+            CompleteTask();
+            return value;
+        }
     }
 }

--- a/Celeste.Mod.mm/Mod/Helpers/QueuedTaskHelper.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/QueuedTaskHelper.cs
@@ -371,7 +371,9 @@ namespace Celeste.Mod {
         }
 
         protected void CompleteTask() {
-            QueuedTaskHelperV2.RunningTasks.Remove(Key);
+            lock (QueuedTaskHelperV2.RunningTasks) {
+                QueuedTaskHelperV2.RunningTasks.Remove(Key);
+            }
         }
     }
 

--- a/Celeste.Mod.mm/Mod/Helpers/QueuedTaskHelper.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/QueuedTaskHelper.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 // the class has been part of the public API for years, so we can't just change the namespace
 // ReSharper disable CheckNamespace
 namespace Celeste.Mod {
-    [Obsolete("Use QueuedTaskHelperV2 instead.")]
+    [Obsolete($"Use {nameof(QueuedTaskHelperV2)} instead.")]
     public static class QueuedTaskHelper {
 
         // Make sure to lock Timers and update both of those at the same time before unlocking!
@@ -16,7 +16,7 @@ namespace Celeste.Mod {
 
         public static readonly double DefaultDelay = 0.5D;
 
-        [Obsolete($"Queued tasks now support {nameof(CancellationToken)}s. Pass the token when creating the task and cancel it when necessary.")]
+        [Obsolete($"{nameof(QueuedTaskHelperV2)} supports {nameof(CancellationToken)}s. Pass the token when creating the task and cancel it when necessary.")]
         public static void Cancel(object key) {
             lock (Timers) {
                 if (Timers.Remove(key, out Stopwatch timer)) {
@@ -27,11 +27,11 @@ namespace Celeste.Mod {
             }
         }
 
-        [Obsolete("Use QueuedTaskHelperV2.Do instead.")]
+        [Obsolete($"Use {nameof(QueuedTaskHelperV2)}.{nameof(QueuedTaskHelperV2.Do)} instead.")]
         public static Task Do(object key, Action a)
             => Do(key, DefaultDelay, a);
 
-        [Obsolete("Use QueuedTaskHelperV2.Do instead.")]
+        [Obsolete($"Use {nameof(QueuedTaskHelperV2)}.{nameof(QueuedTaskHelperV2.Do)} instead.")]
         public static Task Do(object key, double delay, Action a) {
             lock (Timers) {
                 if (!Timers.TryGetValue(key, out Stopwatch timer)) {
@@ -63,11 +63,11 @@ namespace Celeste.Mod {
             }
         }
 
-        [Obsolete("Use QueuedTaskHelperV2.Get instead.")]
+        [Obsolete($"Use {nameof(QueuedTaskHelperV2)}.{nameof(QueuedTaskHelperV2.Get)} instead.")]
         public static Task<T> Get<T>(object key, Func<T> f)
             => Get(key, DefaultDelay, f);
 
-        [Obsolete("Use QueuedTaskHelperV2.Get instead.")]
+        [Obsolete($"Use {nameof(QueuedTaskHelperV2)}.{nameof(QueuedTaskHelperV2.Get)} instead.")]
         public static Task<T> Get<T>(object key, double delay, Func<T> f) {
             lock (Timers) {
                 if (!Timers.TryGetValue(key, out Stopwatch timer)) {

--- a/Celeste.Mod.mm/Mod/Helpers/QueuedTaskHelper.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/QueuedTaskHelper.cs
@@ -108,9 +108,8 @@ namespace Celeste.Mod {
         ///   Schedules the given <paramref name="delegate"/> to execute asynchronously after the <see cref="DefaultDelay"/>.
         /// </summary>
         /// <remarks>
-        ///   If a task with the same key is scheduled twice, the delay time spans will be overlaid.
-        ///   That is, when the first execution delays for <c>10</c> seconds, and a second execution that delays for <c>5</c> seconds
-        ///   is scheduled <c>7.5</c> seconds after the first one, the actual delay time becomes <c>12.5</c> seconds.
+        ///   When a task is scheduled while another task is still running, multiple outcomes can occur depending on the state of the delay.
+        ///   See <see cref="QueuedTaskBase.UpdateDelay"/> for details.
         /// </remarks>
         /// <param name="key">
         ///   The identifier of the task.
@@ -131,9 +130,8 @@ namespace Celeste.Mod {
         ///   Schedules the given <paramref name="delegate"/> to execute asynchronously after a given <paramref name="delay"/>.
         /// </summary>
         /// <remarks>
-        ///   If a task with the same key is scheduled twice, the delay time spans will be overlaid.
-        ///   That is, when the first execution delays for <c>10</c> seconds, and a second execution that delays for <c>5</c> seconds
-        ///   is scheduled <c>7.5</c> seconds after the first one, the actual delay time becomes <c>12.5</c> seconds.
+        ///   When a task is scheduled while another task is still running, multiple outcomes can occur depending on the state of the delay.
+        ///   See <see cref="QueuedTaskBase.UpdateDelay"/> for details.
         /// </remarks>
         /// <param name="key">
         ///   The identifier of the task.
@@ -157,9 +155,8 @@ namespace Celeste.Mod {
         ///   Schedules the given <paramref name="delegate"/> to execute asynchronously after a given <paramref name="delay"/>.
         /// </summary>
         /// <remarks>
-        ///   If a task with the same key is scheduled twice, the delay time spans will be overlaid.
-        ///   That is, when the first execution delays for <c>10</c> seconds, and a second execution that delays for <c>5</c> seconds
-        ///   is scheduled <c>7.5</c> seconds after the first one, the actual delay time becomes <c>12.5</c> seconds.
+        ///   When a task is scheduled while another task is still running, multiple outcomes can occur depending on the state of the delay.
+        ///   See <see cref="QueuedTaskBase.UpdateDelay"/> for details.
         /// </remarks>
         /// <param name="key">
         ///   The identifier of the task.
@@ -185,7 +182,7 @@ namespace Celeste.Mod {
                     if (baseTask is not QueuedTask existingTask)
                         throw new InvalidOperationException("A queued task with an incompatible type is already running.");
 
-                    existingTask.OverlayDelay(delay);
+                    existingTask.UpdateDelay(delay);
                     return existingTask;
                 }
 
@@ -199,9 +196,8 @@ namespace Celeste.Mod {
         ///   Schedules the given <paramref name="delegate"/> to execute asynchronously after the <see cref="DefaultDelay"/>.
         /// </summary>
         /// <remarks>
-        ///   If a task with the same key is scheduled twice, the delay time spans will be overlaid.
-        ///   That is, when the first execution delays for <c>10</c> seconds, and a second execution that delays for <c>5</c> seconds
-        ///   is scheduled <c>7.5</c> seconds after the first one, the actual delay time becomes <c>12.5</c> seconds.
+        ///   When a task is scheduled while another task is still running, multiple outcomes can occur depending on the state of the delay.
+        ///   See <see cref="QueuedTaskBase.UpdateDelay"/> for details.
         /// </remarks>
         /// <typeparam name="T">
         ///   The return type of <paramref name="delegate"/>.
@@ -225,9 +221,8 @@ namespace Celeste.Mod {
         ///   Schedules the given <paramref name="delegate"/> to execute asynchronously after a given <paramref name="delay"/>.
         /// </summary>
         /// <remarks>
-        ///   If a task with the same key is scheduled twice, the delay time spans will be overlaid.
-        ///   That is, when the first execution delays for <c>10</c> seconds, and a second execution that delays for <c>5</c> seconds
-        ///   is scheduled <c>7.5</c> seconds after the first one, the actual delay time becomes <c>12.5</c> seconds.
+        ///   When a task is scheduled while another task is still running, multiple outcomes can occur depending on the state of the delay.
+        ///   See <see cref="QueuedTaskBase.UpdateDelay"/> for details.
         /// </remarks>
         /// <typeparam name="T">
         ///   The return type of <paramref name="delegate"/>.
@@ -254,9 +249,8 @@ namespace Celeste.Mod {
         ///   Schedules the given <paramref name="delegate"/> to execute asynchronously after a given <paramref name="delay"/>.
         /// </summary>
         /// <remarks>
-        ///   If a task with the same key is scheduled twice, the delay time spans will be overlaid.
-        ///   That is, when the first execution delays for <c>10</c> seconds, and a second execution that delays for <c>5</c> seconds
-        ///   is scheduled <c>7.5</c> seconds after the first one, the actual delay time becomes <c>12.5</c> seconds.
+        ///   When a task is scheduled while another task is still running, multiple outcomes can occur depending on the state of the delay.
+        ///   See <see cref="QueuedTaskBase.UpdateDelay"/> for details.
         /// </remarks>
         /// <typeparam name="T">
         ///   The return type of <paramref name="delegate"/>.
@@ -285,7 +279,7 @@ namespace Celeste.Mod {
                     if (baseTask is not QueuedTask<T> existingTask)
                         throw new InvalidOperationException("A queued task with an incompatible type is already running.");
 
-                    existingTask.OverlayDelay(delay);
+                    existingTask.UpdateDelay(delay);
                     return existingTask;
                 }
 
@@ -313,7 +307,7 @@ namespace Celeste.Mod {
         /// <summary>
         ///   A task that will complete after the given delay.
         /// </summary>
-        /// <seealso cref="OverlayDelay"/>
+        /// <seealso cref="UpdateDelay"/>
         protected Task DelayTask { get; private set; }
 
         /// <summary>
@@ -324,17 +318,38 @@ namespace Celeste.Mod {
         protected QueuedTaskBase(object key, TimeSpan delay, CancellationToken cancellationToken) {
             Key = key;
             CancellationToken = cancellationToken;
-            OverlayDelay(delay);
+            UpdateDelay(delay);
         }
 
         /// <summary>
-        ///   Overlays a new delay on top of the existing one.
+        ///   Updates the delay depending on its status.
+        ///   <list type="table">
+        ///     <listheader>
+        ///       <term>Delay State</term>
+        ///       <description>Outcome</description>
+        ///     </listheader>
+        ///     <item>
+        ///       <term>Not yet awaited</term>
+        ///       <description>The delay is replaced</description>
+        ///     </item>
+        ///     <item>
+        ///       <term>Awaiting</term>
+        ///       <description>The delay is overlaid (see remarks)</description>
+        ///     </item>
+        ///     <item>
+        ///       <term>Awaited</term>
+        ///       <description>The delay is ignored, as the callback is already executing</description>
+        ///     </item>
+        ///   </list>
         /// </summary>
         /// <remarks>
-        ///   For example, when overlaying a <c>5</c>-second delay on top of a <c>10</c>-second delay,
+        ///   When overlaying a <c>5</c>-second delay on top of a <c>10</c>-second delay,
         ///   which starts <c>7.5</c> seconds after the first one, the total delay becomes <c>12.5</c> seconds.
         /// </remarks>
-        internal void OverlayDelay(TimeSpan delay) {
+        /// <exception cref="InvalidOperationException">
+        ///   Attempted to overlay a delay on a completed task.
+        /// </exception>
+        internal void UpdateDelay(TimeSpan delay) {
             if (Queued?.IsCompleted ?? false)
                 throw new InvalidOperationException("Cannot overlay a delay on a completed task.");
             DelayTask = Task.Delay(delay, CancellationToken);
@@ -344,7 +359,7 @@ namespace Celeste.Mod {
             // force the task to run asynchronously by yielding - we don't want to block the main thread
             await Task.Yield();
 
-            // we need to wait on loop because DelayTask could have been changed by OverlayDelay
+            // we need to wait on loop because DelayTask could have been changed by UpdateDelay
             do {
                 await DelayTask;
             } while (!DelayTask.IsCompleted);

--- a/Celeste.Mod.mm/Mod/Helpers/QueuedTaskHelper.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/QueuedTaskHelper.cs
@@ -335,6 +335,8 @@ namespace Celeste.Mod {
         ///   which starts <c>7.5</c> seconds after the first one, the total delay becomes <c>12.5</c> seconds.
         /// </remarks>
         internal void OverlayDelay(TimeSpan delay) {
+            if (Queued?.IsCompleted ?? false)
+                throw new InvalidOperationException("Cannot overlay a delay on a completed task.");
             DelayTask = Task.Delay(delay, CancellationToken);
         }
 

--- a/Celeste.Mod.mm/Mod/Helpers/QueuedTaskHelper.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/QueuedTaskHelper.cs
@@ -181,7 +181,7 @@ namespace Celeste.Mod {
         /// </throws>
         public static QueuedTask Do(object key, TimeSpan delay, Action @delegate, CancellationToken cancellationToken) {
             lock (RunningTasks) {
-                if (RunningTasks.TryGetValue(key, out QueuedTaskBase baseTask)) {
+                if (RunningTasks.TryGetValue(key, out QueuedTaskBase baseTask) && !baseTask.Queued.IsCompleted) {
                     if (baseTask is not QueuedTask existingTask)
                         throw new InvalidOperationException("A queued task with an incompatible type is already running.");
 
@@ -281,7 +281,7 @@ namespace Celeste.Mod {
         /// </throws>
         public static QueuedTask<T> Get<T>(object key, Func<T> @delegate, TimeSpan delay, CancellationToken cancellationToken) {
             lock (RunningTasks) {
-                if (RunningTasks.TryGetValue(key, out QueuedTaskBase baseTask)) {
+                if (RunningTasks.TryGetValue(key, out QueuedTaskBase baseTask) && !baseTask.Queued.IsCompleted) {
                     if (baseTask is not QueuedTask<T> existingTask)
                         throw new InvalidOperationException("A queued task with an incompatible type is already running.");
 
@@ -338,6 +338,21 @@ namespace Celeste.Mod {
             DelayTask = Task.Delay(delay, CancellationToken);
         }
 
+        protected async Task WaitForDelay() {
+            // force the task to run asynchronously by yielding - we don't want to block the main thread
+            await Task.Yield();
+
+            // we need to wait on loop because DelayTask could have been changed by OverlayDelay
+            do {
+                await DelayTask;
+            } while (!DelayTask.IsCompleted);
+        }
+
+        protected void LogError(Exception exception) {
+            Logger.Error(nameof(QueuedTask), $"A queued task with key hashcode {Key.GetHashCode()} failed.");
+            Logger.LogDetailed(exception);
+        }
+
         protected void CompleteTask() {
             QueuedTaskHelperV2.RunningTasks.Remove(Key);
         }
@@ -356,16 +371,15 @@ namespace Celeste.Mod {
         }
 
         private async Task Run(Action @delegate) {
-            // force the task to run asynchronously by yielding - we don't want to block the main thread
-            await Task.Yield();
-
-            // we need to wait on loop because DelayTask could have been changed by OverlayDelay
-            do {
-                await DelayTask;
-            } while (!DelayTask.IsCompleted);
-
-            @delegate();
-            CompleteTask();
+            try {
+                await WaitForDelay();
+                @delegate();
+            } catch (Exception e) when (e is not OperationCanceledException) {
+                LogError(e);
+                throw;
+            } finally {
+                CompleteTask();
+            }
         }
     }
 
@@ -385,17 +399,15 @@ namespace Celeste.Mod {
         }
 
         private async Task<T> Run(Func<T> @delegate) {
-            // force the task to run asynchronously by yielding - we don't want to block the main thread
-            await Task.Yield();
-
-            // we need to wait on loop because DelayTask could have been changed by OverlayDelay
-            do {
-                await DelayTask;
-            } while (!DelayTask.IsCompleted);
-
-            T value = @delegate();
-            CompleteTask();
-            return value;
+            try {
+                await WaitForDelay();
+                return @delegate();
+            } catch (Exception e) when (e is not OperationCanceledException) {
+                LogError(e);
+                throw;
+            } finally {
+                CompleteTask();
+            }
         }
     }
 }

--- a/Celeste.Mod.mm/Patches/Level.cs
+++ b/Celeste.Mod.mm/Patches/Level.cs
@@ -567,7 +567,7 @@ namespace Celeste {
                 return;
             }
 
-            QueuedTaskHelper.Do(_GCCollectLock, () => {
+            QueuedTaskHelperV2.Do(_GCCollectLock, () => {
                 GC.Collect(1, GCCollectionMode.Forced, false);
             });
         }


### PR DESCRIPTION
Simplifies the implementation of `QueuedTaskHelper` and adds documentation. It also *should* fix asset reload issues - often mappers would save their map and there was a small chance that Everest would randomly stop reloading their map until the game is restarted.

This is because the previous implementation did not safeguard against waiting for a negative `TimeSpan`. The new implementation avoids this by creating the delay `Task` immediately after instantiating the `QueuedTask`. This ensures that a negative `TimeSpan` is never awaited (and if it is, now it becomes user error).

Briefly tested this myself and I can confirm that asset reloads seem to work the same.