### PR TITLE
Various `DialogCutsceneTrigger` additions

### DIFF
--- a/Celeste.Mod.mm/Mod/Entities/DialogCutsceneTrigger.cs
+++ b/Celeste.Mod.mm/Mod/Entities/DialogCutsceneTrigger.cs
@@ -7,14 +7,16 @@ namespace Celeste.Mod.Entities {
         private string dialogEntry;
         private bool triggered;
         private EntityID id;
-        private bool onlyOnce;
+        private bool noRespawnAfterUse;
+        private bool triggerOnlyOnce;
         private bool endLevel;
         private int deathCount;
 
         public DialogCutsceneTrigger(EntityData data, Vector2 offset, EntityID entId)
             : base(data, offset) {
             dialogEntry = data.Attr("dialogId");
-            onlyOnce = data.Bool("onlyOnce", true);
+            noRespawnAfterUse = data.Bool("onlyOnce", true); // don't rename the EntityData name for backwards compat
+            triggerOnlyOnce = data.Bool("triggerOnlyOnce", true);
             endLevel = data.Bool("endLevel", false);
             deathCount = data.Int("deathCount", -1);
             triggered = false;
@@ -28,16 +30,16 @@ namespace Celeste.Mod.Entities {
             if (triggered || (deathCount >= 0 && level.Session.DeathsInCurrentLevel != deathCount))
                 return;
 
-            triggered = true;
+            if (triggerOnlyOnce)
+                triggered = true;
 
             Scene.Add(new DialogCutscene(dialogEntry, player, endLevel));
 
-            if (onlyOnce) {
+            if (noRespawnAfterUse) {
                 // can't remove the flag, some maps might depend on it
                 level.Session.SetFlag("DoNotLoad" + id, true);
                 level.Session.DoNotLoad.Add(id);
             }
         }
-
     }
 }

--- a/Celeste.Mod.mm/Mod/Entities/DialogCutsceneTrigger.cs
+++ b/Celeste.Mod.mm/Mod/Entities/DialogCutsceneTrigger.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework;
 using Monocle;
 
 namespace Celeste.Mod.Entities {
@@ -67,7 +67,8 @@ namespace Celeste.Mod.Entities {
             Scene.Add(new DialogCutscene(dialogEntry, player, endLevel));
 
             if (noRespawnAfterUse) {
-                // can't remove the flag, some maps might depend on it
+                // this flag is unused in vanilla and Everest, but mods may still make use of it,
+                // so it remains here for backwards compatibility
                 level.Session.SetFlag("DoNotLoad" + id, true);
                 level.Session.DoNotLoad.Add(id);
             }

--- a/Celeste.Mod.mm/Mod/Entities/DialogCutsceneTrigger.cs
+++ b/Celeste.Mod.mm/Mod/Entities/DialogCutsceneTrigger.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.Xna.Framework;
+using Monocle;
 
 namespace Celeste.Mod.Entities {
+    [Tracked]
     [CustomEntity("everest/dialogTrigger", "dialog/dialogtrigger", "cavern/dialogtrigger")]
     public class DialogCutsceneTrigger : Trigger {
 
@@ -36,6 +38,10 @@ namespace Celeste.Mod.Entities {
                 return;
 
             if (ignoreIntroState && ((patch_Player) player).IsIntroState)
+                return;
+
+            // don't activate if some dialog is already in progress
+            if (level.Tracker.GetEntity<Textbox>() is not null)
                 return;
 
             triggered = true;

--- a/Celeste.Mod.mm/Mod/Entities/DialogCutsceneTrigger.cs
+++ b/Celeste.Mod.mm/Mod/Entities/DialogCutsceneTrigger.cs
@@ -9,6 +9,7 @@ namespace Celeste.Mod.Entities {
         private EntityID id;
         private bool noRespawnAfterUse;
         private bool triggerOnlyOnce;
+        private bool ignoreIntroState;
         private bool endLevel;
         private int deathCount;
 
@@ -17,21 +18,27 @@ namespace Celeste.Mod.Entities {
             dialogEntry = data.Attr("dialogId");
             noRespawnAfterUse = data.Bool("onlyOnce", true); // don't rename the EntityData name for backwards compat
             triggerOnlyOnce = data.Bool("triggerOnlyOnce", true);
+            ignoreIntroState = data.Bool("ignoreIntroState", false);
             endLevel = data.Bool("endLevel", false);
             deathCount = data.Int("deathCount", -1);
             triggered = false;
             id = entId;
         }
 
-        public override void OnEnter(Player player) {
+        public override void OnStay(Player player) {
             if (Scene is not Level level)
                 return;
 
-            if (triggered || (deathCount >= 0 && level.Session.DeathsInCurrentLevel != deathCount))
+            if (triggered)
                 return;
 
-            if (triggerOnlyOnce)
-                triggered = true;
+            if (deathCount >= 0 && level.Session.DeathsInCurrentLevel != deathCount)
+                return;
+
+            if (ignoreIntroState && ((patch_Player) player).IsIntroState)
+                return;
+
+            triggered = true;
 
             Scene.Add(new DialogCutscene(dialogEntry, player, endLevel));
 
@@ -41,5 +48,11 @@ namespace Celeste.Mod.Entities {
                 level.Session.DoNotLoad.Add(id);
             }
         }
+
+        public override void OnLeave(Player player) {
+            if (!triggerOnlyOnce)
+                triggered = false;
+        }
+
     }
 }

--- a/Celeste.Mod.mm/Mod/Entities/DialogCutsceneTrigger.cs
+++ b/Celeste.Mod.mm/Mod/Entities/DialogCutsceneTrigger.cs
@@ -27,7 +27,25 @@ namespace Celeste.Mod.Entities {
             id = entId;
         }
 
+        // do not remove OnEnter! doing so will break maps that rely on third-party triggers to start dialog cutscenes.
+        // vanilla naturally calls OnEnter and OnStay in the same frame when entering the trigger,
+        // which would mean that we don't need the OnEnter method.
+        // however, sj's "in filtration" uses a Trigger Trigger (CrystallineHelper) to start a dialog cutscene;
+        // it only calls OnEnter and not OnStay, so removing OnEnter will make the dialog not appear and cause a tas desync!
+        public override void OnEnter(Player player) {
+            TriggerCutscene(player);
+        }
+
         public override void OnStay(Player player) {
+            TriggerCutscene(player);
+        }
+
+        public override void OnLeave(Player player) {
+            if (!triggerOnlyOnce)
+                triggered = false;
+        }
+
+        private void TriggerCutscene(Player player) {
             if (Scene is not Level level)
                 return;
 
@@ -54,11 +72,5 @@ namespace Celeste.Mod.Entities {
                 level.Session.DoNotLoad.Add(id);
             }
         }
-
-        public override void OnLeave(Player player) {
-            if (!triggerOnlyOnce)
-                triggered = false;
-        }
-
     }
 }

--- a/Celeste.Mod.mm/Mod/Entities/DialogCutsceneTrigger.cs
+++ b/Celeste.Mod.mm/Mod/Entities/DialogCutsceneTrigger.cs
@@ -22,18 +22,21 @@ namespace Celeste.Mod.Entities {
         }
 
         public override void OnEnter(Player player) {
-            if (triggered || (Scene as Level).Session.GetFlag("DoNotLoad" + id) ||
-                (deathCount >= 0 && SceneAs<Level>().Session.DeathsInCurrentLevel != deathCount)) {
-
+            if (Scene is not Level level)
                 return;
-            }
+
+            if (triggered || (deathCount >= 0 && level.Session.DeathsInCurrentLevel != deathCount))
+                return;
 
             triggered = true;
 
             Scene.Add(new DialogCutscene(dialogEntry, player, endLevel));
 
-            if (onlyOnce)
-                (Scene as Level).Session.SetFlag("DoNotLoad" + id, true); // Sets flag to not load
+            if (onlyOnce) {
+                // can't remove the flag, some maps might depend on it
+                level.Session.SetFlag("DoNotLoad" + id, true);
+                level.Session.DoNotLoad.Add(id);
+            }
         }
 
     }


### PR DESCRIPTION
- Prevents the dialog cutscene trigger from spawning if `onlyOnce` (now `noRespawnAfterUse`) is set
- Allows the dialog cutscene to be triggered multiple times
  - Useful if someone wants to the dialog cutscene to be retriggered
- Allows delaying the dialog cutscene until after the intro state is complete
  - Makes the dialog transition smoother if the trigger is placed on the spawnpoint
  
The two new entity properties will need support from map-maker programs like Lönn.