### PR TITLE
Maintain original entity / component order when refreshing tracker

### DIFF
--- a/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
@@ -178,6 +178,10 @@ namespace Monocle {
                 return;
             }
             tracker.currentVersion = TrackedTypeVersion;
+
+            var origEntities = tracker.Entities.ToDictionary(entry => entry.Key, entry => new List<Entity>(entry.Value));
+            var origComponents = tracker.Components.ToDictionary(entry => entry.Key, entry => new List<Component>(entry.Value));
+
             foreach (Type entityType in StoredEntityTypes) {
                 ref var list = ref CollectionsMarshal.GetValueRefOrAddDefault(tracker.Entities, entityType, out _);
                 list ??= new();
@@ -194,6 +198,37 @@ namespace Monocle {
                     tracker.ComponentAdded(component);
                 }
                 tracker.EntityAdded(entity);
+            }
+
+            // Keep original order of existing instances
+            // Especially important for the PlayerCollider component for example
+            foreach (Type entityType in StoredEntityTypes) {
+                ref var newList = ref CollectionsMarshal.GetValueRefOrAddDefault(tracker.Entities, entityType, out _);
+                if (newList == null || !origEntities.TryGetValue(entityType, out var oldList)) {
+                    continue;
+                }
+
+                newList.Sort((lhs, rhs) => {
+                    int lhsIdx = oldList.IndexOf(lhs);
+                    int rhsIdx = oldList.IndexOf(rhs);
+                    if (lhsIdx == -1) return  1;
+                    if (rhsIdx == -1) return -1;
+                    return lhsIdx - rhsIdx;
+                });
+            }
+            foreach (Type componentType in StoredComponentTypes) {
+                ref var newList = ref CollectionsMarshal.GetValueRefOrAddDefault(tracker.Components, componentType, out _);
+                if (newList == null || !origComponents.TryGetValue(componentType, out var oldList)) {
+                    continue;
+                }
+
+                newList.Sort((lhs, rhs) => {
+                    int lhsIdx = oldList.IndexOf(lhs);
+                    int rhsIdx = oldList.IndexOf(rhs);
+                    if (lhsIdx == -1) return  1;
+                    if (rhsIdx == -1) return -1;
+                    return lhsIdx - rhsIdx;
+                });
             }
         }
 

--- a/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Tracker.cs
@@ -201,30 +201,32 @@ namespace Monocle {
             }
 
             // Keep original order of existing instances
-            // Especially important for the PlayerCollider component for example
+            // Especially important in the case of overlapping PlayerCollider components
             foreach (Type entityType in StoredEntityTypes) {
-                ref var newList = ref CollectionsMarshal.GetValueRefOrAddDefault(tracker.Entities, entityType, out _);
-                if (newList == null || !origEntities.TryGetValue(entityType, out var oldList)) {
+                var newList = tracker.Entities[entityType];
+                if (!origEntities.TryGetValue(entityType, out var oldList)) {
                     continue;
                 }
 
                 newList.Sort((lhs, rhs) => {
                     int lhsIdx = oldList.IndexOf(lhs);
                     int rhsIdx = oldList.IndexOf(rhs);
+                    if (lhsIdx == rhsIdx) return 0;
                     if (lhsIdx == -1) return  1;
                     if (rhsIdx == -1) return -1;
                     return lhsIdx - rhsIdx;
                 });
             }
             foreach (Type componentType in StoredComponentTypes) {
-                ref var newList = ref CollectionsMarshal.GetValueRefOrAddDefault(tracker.Components, componentType, out _);
-                if (newList == null || !origComponents.TryGetValue(componentType, out var oldList)) {
+                var newList = tracker.Components[componentType];
+                if (!origComponents.TryGetValue(componentType, out var oldList)) {
                     continue;
                 }
 
                 newList.Sort((lhs, rhs) => {
                     int lhsIdx = oldList.IndexOf(lhs);
                     int rhsIdx = oldList.IndexOf(rhs);
+                    if (lhsIdx == rhsIdx) return 0;
                     if (lhsIdx == -1) return  1;
                     if (rhsIdx == -1) return -1;
                     return lhsIdx - rhsIdx;


### PR DESCRIPTION
On room load, the entites / components in the tracker will be in their load order.
However when something causes the tracker to refresh, it will sort them in the order of the entity list.
This can cause gameplay differences with overlapping `PlayerCollider`s, because of a different order.