### PR TITLE
Fix weird behaviour and freeze with SubMenu with enterOnSelect and no hoverable items

### DIFF
--- a/Celeste.Mod.mm/Mod/UI/TextMenuExt.cs
+++ b/Celeste.Mod.mm/Mod/UI/TextMenuExt.cs
@@ -446,7 +446,7 @@ namespace Celeste {
             /// <inheritdoc cref="TextMenu.Current"/>
             public TextMenu.Item Current {
                 get {
-                    if (Items.Count <= 0 || Selection < 0) {
+                    if (Items.Count <= 0 || Selection < 0 || Selection >= Items.Count) {
                         return null;
                     }
                     return Items[Selection];
@@ -640,8 +640,8 @@ namespace Celeste {
             /// Set the selection to the last possible <see cref="TextMenu.Item"/>.
             /// </summary>
             public void LastSelection() {
-                Selection = LastPossibleSelection;
-                MoveSelection(0, false);
+                Selection = Items.Count;
+                MoveSelection(-1, false);
             }
 
             /// <inheritdoc cref="TextMenu.MoveSelection(int, bool)"/>

--- a/Celeste.Mod.mm/Mod/UI/TextMenuExt.cs
+++ b/Celeste.Mod.mm/Mod/UI/TextMenuExt.cs
@@ -558,9 +558,6 @@ namespace Celeste {
                     Container.Add(item.ValueWiggler = Wiggler.Create(0.25f, 3f, null, false, false));
                     Container.Add(item.SelectWiggler = Wiggler.Create(0.25f, 3f, null, false, false));
                     item.ValueWiggler.UseRawDeltaTime = (item.SelectWiggler.UseRawDeltaTime = true);
-                    if (Selection == -1) {
-                        FirstSelection();
-                    }
                     RecalculateSize();
                     item.Added();
                     return this;
@@ -583,9 +580,6 @@ namespace Celeste {
                     Container.Add(item.ValueWiggler = Wiggler.Create(0.25f, 3f, null, false, false));
                     Container.Add(item.SelectWiggler = Wiggler.Create(0.25f, 3f, null, false, false));
                     item.ValueWiggler.UseRawDeltaTime = (item.SelectWiggler.UseRawDeltaTime = true);
-                    if (Selection == -1) {
-                        FirstSelection();
-                    }
                     RecalculateSize();
                     item.Added();
                     return this;
@@ -763,12 +757,12 @@ namespace Celeste {
                 if (Items.Count > 0) {
                     Container.Focused = false;
                     Focused = true;
+                    containerAutoScroll = Container.AutoScroll;
+                    Container.AutoScroll = false;
                     if (Input.MenuUp.Pressed)
                         LastSelection();
                     else
                         FirstSelection();
-                    containerAutoScroll = Container.AutoScroll;
-                    Container.AutoScroll = false;
                     if (!Input.MenuUp.Repeating && !Input.MenuDown.Repeating)
                         Audio.Play(ConfirmSfx);
                     base.ConfirmPressed();

--- a/Celeste.Mod.mm/Mod/UI/TextMenuExt.cs
+++ b/Celeste.Mod.mm/Mod/UI/TextMenuExt.cs
@@ -485,7 +485,9 @@ namespace Celeste {
                 get {
                     float min = Engine.Height - 150f - Container.Height * Container.Justify.Y;
                     float max = 150f + Container.Height * Container.Justify.Y;
-                    return Calc.Clamp((Engine.Height / 2) + Container.Height * Container.Justify.Y - GetYOffsetOf(Current), min, max);
+
+                    float y_offset = Current is not null ? GetYOffsetOf(Current) : GetYOffsetOf(Items[Calc.Clamp(Selection, 0, Items.Count-1)]);
+                    return Calc.Clamp((Engine.Height / 2) + Container.Height * Container.Justify.Y - y_offset, min, max);
                 }
             }
 
@@ -507,6 +509,7 @@ namespace Celeste {
             public bool Focused;
 
             private bool enterOnSelect;
+            private bool entering;
             private float ease;
 
             private bool containerAutoScroll;
@@ -655,7 +658,7 @@ namespace Celeste {
                 }
                 do {
                     Selection += direction;
-                    if (enterOnSelect) {
+                    if (enterOnSelect && !entering) {
                         if (Selection < 0 || Selection >= Items.Count) {
                             // Avoid crash when getting Current item
                             Selection = selection;
@@ -681,7 +684,7 @@ namespace Celeste {
                     Selection = selection;
                 }
                 if (Selection != selection && Current != null) {
-                    if (selection >= 0 && Items[selection] != null && Items[selection].OnLeave != null) {
+                    if (selection >= 0 && selection < Items.Count && Items[selection] != null && Items[selection].OnLeave != null) {
                         Items[selection].OnLeave();
                     }
                     Current.OnEnter?.Invoke();
@@ -759,10 +762,14 @@ namespace Celeste {
                     Focused = true;
                     containerAutoScroll = Container.AutoScroll;
                     Container.AutoScroll = false;
+
+                    entering = true;
                     if (Input.MenuUp.Pressed)
                         LastSelection();
                     else
                         FirstSelection();
+                    entering = false;
+
                     if (!Input.MenuUp.Repeating && !Input.MenuDown.Repeating)
                         Audio.Play(ConfirmSfx);
                     base.ConfirmPressed();


### PR DESCRIPTION
Fixes three small bugs that happen when SubMenu has `enterOnSelect` flag and no hoverable items. I'll refer to these SubMenus as special. 
My first actual pull request so I might be a bit overly verbose. That's probably a good thing? Please let me know.

## 1. TextMenu selection moves one item down per special SubMenu and loses auto scroll when entering Mod Options
Expected behaviour: No selection movement, TextMenu auto scrolls

Why it happens:
1. SubMenu runs `FirstSelection()` when added for the first time
2. `FirstSelection()` calls `MoveNext(1, ...)`, trying to move the selection down
3. do while loop iterates over all elements but can't find any, `Selection >= Items.Count` triggers an exit from the submenu
4. `Exit()` is called that attempts to recover `Container.AutoScroll` state but `containerAutoScroll` was never set because `ConfirmPressed` wasn't called. `Container.AutoScroll` becomes false.
5. `Container.MoveSelection(direction, true)` moves TextMenu selection one item down

Fix: Remove `FirstSelection` calls in `Add` and `Insert`. It seems that these calls are redundant because `FirstSelection` and `LastSelection` methods are called in `ConfirmPressed` and that method is the only one that can get the menu focused.

## 2. TextMenu loses auto scroll when selecting special SubMenu from above
Expected behaviour: TextMenu auto scrolls

Why it happens:
The preservation of `Container.AutoScroll` state is after the Selection methods, so similarly, `Exit()` gets called and AutoScroll's corrupts.

Fix: Place `containerAutoScroll` assignment before Selection calculations 

## 3. Game freezes when selecting special SubMenu from below
Expected behaviour: SubMenu is skipped, the item above is selected

Why it happens:
`LastSelection` is called from `ConfirmPressed` and because there's no Hoverable items it returns 0. `MoveSelection(0, ...)` doesn't move `Selection` because `Math.Sign(0)` is 0. The game stuck in an infinite loop.
```c#
            public void LastSelection() {
                Selection = LastPossibleSelection;
                MoveSelection(0, false);
            }
```

Fix: Make `LastSelection` an inverse of `FirstSelection`, set `Selection` to the upper bound and move down.

A mod with a special SubMenu for replication: [LastSelectionSubMenuFreeze.zip](https://github.com/user-attachments/files/22689151/LastSelectionSubMenuFreeze.zip)
