### PR TITLE
Force NoInlining on `Solid.HasPlayerRider`, `Solid.HasPlayerClimbing` and `Solid.HasPlayerOnTop`

### DIFF
--- a/Celeste.Mod.mm/Patches/Solid.cs
+++ b/Celeste.Mod.mm/Patches/Solid.cs
@@ -12,6 +12,10 @@ namespace Celeste {
         [MonoModIgnore]
         [PatchSolidAwake]
         public extern void Awake(Scene scene);
+        
+        [MonoModIgnore]
+        [ForceNoInlining]
+        public extern bool HasPlayerRider();
     }
 }
 

--- a/Celeste.Mod.mm/Patches/Solid.cs
+++ b/Celeste.Mod.mm/Patches/Solid.cs
@@ -15,6 +15,14 @@ namespace Celeste {
         
         [MonoModIgnore]
         [ForceNoInlining]
+        public extern bool HasPlayerClimbing();
+        
+        [MonoModIgnore]
+        [ForceNoInlining]
+        public extern bool HasPlayerOnTop();
+        
+        [MonoModIgnore]
+        [ForceNoInlining]
         public extern bool HasPlayerRider();
     }
 }


### PR DESCRIPTION
Forces a `[MethodImpl(MethodImplOptions.NoInlining)]` attribute on `Solid.HasPlayerRider`, `Solid.HasPlayerClimbing` and `Solid.HasPlayerOnTop`, to avoid [these](https://github.com/wanmaple/Celeste-Aqua/blob/b776ffe3560ed4e4e74017836b5c8c3f5172dc0e/Source/Core/Extensions/MoveBlockExtensions.cs#L33C9-L37C10) kinds of shenaningans.