### PR TITLE
fix SeekerEffectsController overwriting music layer 3

### DIFF
--- a/Celeste.Mod.mm/Patches/SeekerEffectsController.cs
+++ b/Celeste.Mod.mm/Patches/SeekerEffectsController.cs
@@ -1,0 +1,20 @@
+using Monocle;
+using MonoMod;
+
+namespace Celeste {
+    public class patch_SeekerEffectsController : SeekerEffectsController {
+
+        [MonoModLinkTo("Monocle.Entity", "Added")]
+        [MonoModIgnore]
+        public extern void base_Added(Scene scene);
+
+        // In vanilla, this just sets music layer 3 to 0f.
+        // Since music layer 3 is otherwise untouched by SeekerEffectsController, this is most likely the remains of an incompletely implemented feature.
+        // This means that when saving and reentering any of the mirror temple seeker rooms causes layer 3 to become disabled when it shouldn't be.
+        [MonoModReplace]
+        public override void Added(Scene scene) {
+            base_Added(scene);
+        }
+
+    }
+}


### PR DESCRIPTION
since this behaviour is silly and inconsistent, and i can't think of any reason anyone would want it to happen on purpose, i think it's sensible to simply disable it globally including in vanilla maps.

tested and confirmed working in vanilla 5a. 

reported [here](https://discord.com/channels/403698615446536203/429775320720211968/1439856845362561134)