### PR TITLE
Show more verbose messages on duplicate tileset IDs

### DIFF
--- a/Celeste.Mod.mm/Content/Dialog/English.txt
+++ b/Celeste.Mod.mm/Content/Dialog/English.txt
@@ -26,6 +26,7 @@
 	POSTCARD_DECALREGERROR=		{big}Oops!{/big}{n}There was an error applying the{n}{#ff1144}((property)){#} property to {#ff1144}((decal)){#}{n}You may have a missing or invalid attribute in your {#44adf7}Decal Registry{#}.
 	POSTCARD_MISSINGTUTORIAL=	{big}Oops!{/big}{n}The playback tutorial {#ff1144}((tutorial)){#} could not be found.{n}Check your {#44adf7}log.txt{#} for more info.
 	POSTCARD_TILEXMLERROR=		{big}Oops!{/big}{n}There was an error parsing a tileset in {#ff1144}((path)){#}{n}Check your {#44adf7}log.txt{#} for more info.
+	POSTCARD_DUPLICATETILEID=   {big}Oops!{/big}{n}The tileset ID '{#ff1144}((tilechar)){#}' ({#ff1144}U+((tilehex)){#}) was defined more than once. Check your{n}{#44adf7}((filename)){#}{n}for duplicate tileset IDs.
 	POSTCARD_XMLERROR=			{big}Oops!{/big}{n}{#ff1144}((path)){#} has a syntax error.{n}Check your {#44adf7}log.txt{#} for more info.
 	POSTCARD_BOSSLASTNODEHIT=	{big}Oops!{/big}{n}{#ff1144}Badeline Boss{#} entity was hit on its last node, please add an additional node outside of the current room to ensure the player never hits it.
 	POSTCARD_LEVELNOROOMS=		{big}Oops!{/big}{n}This map has {#f94a4a}no rooms{#}!{n}Please make sure your map has{n}{#44adf7}at least one room{#}, and that{n}you've saved it since its creation.

--- a/Celeste.Mod.mm/Patches/Autotiler.cs
+++ b/Celeste.Mod.mm/Patches/Autotiler.cs
@@ -491,6 +491,11 @@ namespace Celeste {
 }
 
 namespace MonoMod {
+
+    /// <summary>
+    ///   Patches the <see cref="Celeste.Autotiler"/> constructor to explicitly throw
+    ///   an error when encountering a duplicate tileset ID.
+    /// </summary>
     [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchAutotilerCtor))]
     class PatchAutotilerCtorAttribute : Attribute { }
 
@@ -498,12 +503,16 @@ namespace MonoMod {
         public static void PatchAutotilerCtor(ILContext context, CustomAttribute attrib) {
             ILCursor cursor = new(context);
 
+            // insert a call to ThrowOnDuplicateId right after reading the tileset ID from the XML
             MethodDefinition m_throwOnDuplicateId = context.Method.DeclaringType.FindMethod("System.Void ThrowOnDuplicateId(System.Char,System.String)")!;
 
+            // char c = item.AttrChar("id");
+            //+ThrowOnDuplicateId(c, filename);
+
             cursor.GotoNext(MoveType.After, static instr => instr.MatchStloc3());
-            cursor.EmitLdarg0();
-            cursor.EmitLdloc3();
-            cursor.EmitLdarg1();
+            cursor.EmitLdarg0(); // this (Autotiler instance)
+            cursor.EmitLdloc3(); // char c (the tileset id)
+            cursor.EmitLdarg1(); // string filename (the xml path)
             cursor.EmitCallvirt(m_throwOnDuplicateId);
         }
     }

--- a/Celeste.Mod.mm/Patches/Autotiler.cs
+++ b/Celeste.Mod.mm/Patches/Autotiler.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
+#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
 #pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
 
 using Celeste.Mod;
@@ -413,7 +413,7 @@ namespace Celeste {
             return !string.IsNullOrEmpty(sfxEvent = lookup.TryGetValue(tiletype, out patch_TerrainType t) ? t.DebrisImpactSfx : "");
         }
 
-        public void ThrowOnDuplicateId(char id, string xmlName) {
+        private void ThrowOnDuplicateId(char id, string xmlName) {
             if (!lookup.ContainsKey(id))
                 return;
 

--- a/Celeste.Mod.mm/Patches/Autotiler.cs
+++ b/Celeste.Mod.mm/Patches/Autotiler.cs
@@ -2,10 +2,12 @@
 #pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
 
 using Celeste.Mod;
-using Celeste.Mod.Helpers;
 using Microsoft.Xna.Framework;
+using Mono.Cecil;
 using Monocle;
 using MonoMod;
+using MonoMod.Cil;
+using MonoMod.Utils;
 using System;
 using System.Collections.Generic;
 using System.Xml;
@@ -19,6 +21,11 @@ namespace Celeste {
             : base(filename) {
             // no-op. MonoMod ignores this - we only need this to make the compiler shut up.
         }
+
+        [MonoModConstructor]
+        [MonoModIgnore]
+        [PatchAutotilerCtor]
+        public extern void ctor(string filename);
 
         public extern Generated orig_GenerateOverlay(char id, int x, int y, int tilesX, int tilesY, VirtualMap<char> mapData);
         public new Generated GenerateOverlay(char id, int x, int y, int tilesX, int tilesY, VirtualMap<char> mapData) {
@@ -406,6 +413,22 @@ namespace Celeste {
             return !string.IsNullOrEmpty(sfxEvent = lookup.TryGetValue(tiletype, out patch_TerrainType t) ? t.DebrisImpactSfx : "");
         }
 
+        public void ThrowOnDuplicateId(char id, string xmlName) {
+            if (!lookup.ContainsKey(id))
+                return;
+
+            string idString = id.ToString();
+            string idHex = ((ushort) id).ToString("X4");
+            if (Dialog.Languages is not null)
+                // we can throw too early, check if dialogue is loaded first
+                patch_LevelEnter.ErrorMessage = Dialog.Get("POSTCARD_DUPLICATETILEID")
+                    .Replace("((tilechar))", idString)
+                    .Replace("((tilehex))", idHex)
+                    .Replace("((filename))", xmlName.Replace('\\', '/'));
+
+            throw new InvalidOperationException($"Duplicate tileset ID '{idString}' (U+{idHex}) found in {xmlName}.");
+        }
+
         // Required because TerrainType is private.
         private class patch_TerrainType {
             public char ID;
@@ -464,5 +487,24 @@ namespace Celeste {
 
         }
 
+    }
+}
+
+namespace MonoMod {
+    [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchAutotilerCtor))]
+    class PatchAutotilerCtorAttribute : Attribute { }
+
+    static partial class MonoModRules {
+        public static void PatchAutotilerCtor(ILContext context, CustomAttribute attrib) {
+            ILCursor cursor = new(context);
+
+            MethodDefinition m_throwOnDuplicateId = context.Method.DeclaringType.FindMethod("System.Void ThrowOnDuplicateId(System.Char,System.String)")!;
+
+            cursor.GotoNext(MoveType.After, static instr => instr.MatchStloc3());
+            cursor.EmitLdarg0();
+            cursor.EmitLdloc3();
+            cursor.EmitLdarg1();
+            cursor.EmitCallvirt(m_throwOnDuplicateId);
+        }
     }
 }


### PR DESCRIPTION
Makes the `Autotiler` constructor explicitly throw when a duplicate tileset ID is encountered. It also shows a new postcard when applicable. The Unicode code point is also printed in case the tileset ID happens to be an unprintable character, as several people reported that high tileset IDs (such as `U+5337`) turn into `?` (`U+003F`) when viewed in `log.txt`.

### IL patch, decompiled
<img width="994" height="219" alt="image" src="https://github.com/user-attachments/assets/e4eafedb-f21e-4e62-ae7f-97a1b1874068" />

### Postcard
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a877e263-07d1-4bda-a8bd-b1fdc0def98a" />

### Logged exception
<img width="840" height="480" alt="image" src="https://github.com/user-attachments/assets/05a4439c-6443-4b0d-9d34-5ee62c6082fb" />
