### PR TITLE
Add option to skip checking GameChecksum

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Relinker.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Relinker.cs
@@ -22,6 +22,11 @@ namespace Celeste.Mod {
             private static string _GameChecksum;
 
             /// <summary>
+            /// Skips checking the GameChecksum when checking if mods should be relinked.
+            /// </summary>
+            internal static bool SkipGameChecksum;
+
+            /// <summary>
             /// The lock which the relinker holds when relinking assemblies
             /// </summary>
             public static readonly object RelinkerLock = new object();

--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -311,6 +311,9 @@ namespace Celeste.Mod {
                 else if (arg == "--use-scancodes") {
                     Environment.SetEnvironmentVariable("FNA_KEYBOARD_USE_SCANCODES", "1");
                 }
+                
+                else if (arg == "--no-game-checksum")
+                    Relinker.SkipGameChecksum = true;
             }
         }
 

--- a/Celeste.Mod.mm/Mod/Module/EverestModuleAssemblyContext.cs
+++ b/Celeste.Mod.mm/Mod/Module/EverestModuleAssemblyContext.cs
@@ -344,7 +344,7 @@ namespace Celeste.Mod {
             /// <returns>Whether this is compatible with <paramref name="other"/></returns>
             public bool IsValidWith(AsmChecksums other) {
                 if (other == null) return false;
-                if (GameChecksum != other.GameChecksum) return false;
+                if (GameChecksum != other.GameChecksum && !Everest.Relinker.SkipGameChecksum) return false;
                 if (FileChecksum != other.FileChecksum) return false;
                 if (SymFileChecksum != other.SymFileChecksum) return false;
 


### PR DESCRIPTION
Extremely useful to save time when testing Everest changes that do not alter the relinking process while having lots of mods enabled.