### PR TITLE
Remove unused environment variables

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -291,12 +291,6 @@ namespace Celeste.Mod {
                 else if (arg == "--dump-all")
                     Content._DumpAll = true;
 
-                else if (arg == "--headless")
-                    Environment.SetEnvironmentVariable("EVEREST_HEADLESS", "1");
-
-                else if (arg == "--everest-disabled")
-                    Environment.SetEnvironmentVariable("EVEREST_DISABLED", "1");
-
                 else if (arg == "--whitelist" && queue.Count >= 1)
                     Loader.NameWhitelist = queue.Dequeue();
 


### PR DESCRIPTION
The environment variables `EVEREST_HEADLESS` and `EVEREST_DISABLED` are unused as far as I can tell, I could not find any usage of them.