### PR TITLE
Add LevelSet check in GetFullCameraTargetAt

### DIFF
--- a/Celeste.Mod.mm/Patches/Level.cs
+++ b/Celeste.Mod.mm/Patches/Level.cs
@@ -574,14 +574,16 @@ namespace Celeste {
 
         public extern Vector2 orig_GetFullCameraTargetAt(Player player, Vector2 at);
         public new Vector2 GetFullCameraTargetAt(Player player, Vector2 at) {
-            Vector2 originalPosition = player.Position;
-            player.Position = at;
-            foreach (Entity trigger in Tracker.GetEntities<Trigger>()) {
-                if (trigger is ICameraTargetTrigger iCameraTarget && player.CollideCheck(trigger)) {
-                    iCameraTarget.OnStay(player);
+            if (Session.Area.GetLevelSet() != "Celeste") {
+                Vector2 originalPosition = player.Position;
+                player.Position = at;
+                foreach (Entity trigger in Tracker.GetEntities<Trigger>()) {
+                    if (trigger is ICameraTargetTrigger iCameraTarget && player.CollideCheck(trigger)) {
+                        iCameraTarget.OnStay(player);
+                    }
                 }
+                player.Position = originalPosition;
             }
-            player.Position = originalPosition;
 
             return orig_GetFullCameraTargetAt(player, at);
         }


### PR DESCRIPTION
the camera's position can have an effect on the gameplay in a few cases (e.g. spinner / lightning collidability).
this PR adds a check for whether the current LevelSet is "Celeste" before executing the modified method