### PR TITLE
Implement Interact Trigger API for mods

### DIFF
--- a/Celeste.Mod.mm/Mod/Entities/CustomEventAttribute.cs
+++ b/Celeste.Mod.mm/Mod/Entities/CustomEventAttribute.cs
@@ -3,7 +3,8 @@ using System;
 
 namespace Celeste.Mod.Entities {
     /// <summary>
-    /// Mark this entity as a Custom <see cref="CutsceneEntity"/> or other Event <see cref="Entity"/>.
+    /// Mark this entity as a Custom <see cref="CutsceneEntity"/> or other Event <see cref="Entity"/>,
+    /// for use with an <see cref="EventTrigger"/>.
     /// <br></br>
     /// This Entity will be added when a matching Event ID is triggered.
     /// <br></br>
@@ -18,7 +19,8 @@ namespace Celeste.Mod.Entities {
         public string[] IDs;
 
         /// <summary>
-        /// Mark this entity as a Custom <see cref="CutsceneEntity"/> or other Event <see cref="Entity"/>.
+        /// Mark this entity as a Custom <see cref="CutsceneEntity"/> or other Event <see cref="Entity"/>,
+        /// for use with an <see cref="EventTrigger"/>.
         /// </summary>
         /// <param name="ids">A list of unique identifiers for this Event.</param>
         public CustomEventAttribute(params string[] ids) {

--- a/Celeste.Mod.mm/Mod/Entities/CustomInteractAttribute.cs
+++ b/Celeste.Mod.mm/Mod/Entities/CustomInteractAttribute.cs
@@ -1,0 +1,36 @@
+﻿using Monocle;
+using System;
+
+namespace Celeste.Mod.Entities {
+#nullable enable
+    /// <summary>
+    /// Mark this entity as a custom <see cref="CutsceneEntity"/> or other Event <see cref="Entity"/>,
+    /// for use with an <see cref="InteractTrigger"/>.
+    /// <br/>
+    /// This entity will be added when a matching Event ID is interacted with.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public class CustomInteractAttribute : Attribute {
+
+        /// <summary>
+        /// A list of unique identifiers for this Interact Event.
+        /// </summary>
+        public string[] IDs;
+
+        /// <summary>
+        /// Whether to set an appropriate Session flag and progress the trigger's event index on interaction.<br/>
+        /// Default value is <see langword="true"/>.<br/>
+        /// This is ignored if the constructor / generator method has the parameter `<see langword="ref"/> <see cref="bool"/> progressEvent`.
+        /// </summary>
+        public bool ProgressEvent = true;
+
+        /// <summary>
+        /// Mark this entity as a custom <see cref="CutsceneEntity"/> or other Event <see cref="Entity"/>,
+        /// for use with an <see cref="InteractTrigger"/>.
+        /// </summary>
+        /// <param name="ids">A list of unique identifiers for this Interact Event.</param>
+        public CustomInteractAttribute(params string[] ids) {
+            IDs = ids;
+        }
+    }
+}

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Events.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Events.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using _Decal = Celeste.Decal;
 using _EventTrigger = Celeste.EventTrigger;
+using _InteractTrigger = Celeste.InteractTrigger;
 using _LevelEnter = Celeste.LevelEnter;
 using _LevelLoader = Celeste.LevelLoader;
 using _Level = Celeste.Level;
@@ -357,6 +358,23 @@ namespace Celeste.Mod {
                 public static event TriggerEventHandler OnEventTrigger;
                 internal static bool TriggerEvent(_EventTrigger trigger, _Player player, string eventID)
                     => OnEventTrigger?.InvokeWhileFalse(trigger, player, eventID) ?? false;
+            }
+
+            public static class InteractTrigger {
+                public delegate bool TriggerInteractHandler(_InteractTrigger trigger, _Player player, string eventID, ref bool progressEvent);
+                public static event TriggerInteractHandler OnInteractTrigger;
+                internal static bool TriggerInteract(_InteractTrigger trigger, _Player player, string eventID, ref bool progressEvent) {
+                    if (OnInteractTrigger is null)
+                        return false;
+
+                    // the InvokeWhileFalse method won't accept ref arguments, so we replicate it
+                    foreach (TriggerInteractHandler handler in OnInteractTrigger.GetInvocationList()) {
+                        if (handler(trigger, player, eventID, ref progressEvent))
+                            return true;
+                    }
+
+                    return false;
+                }
             }
 
             public static class CustomBirdTutorial {

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
@@ -760,6 +760,12 @@ namespace Celeste.Mod {
                                 goto RegisterCutsceneLoader;
                             }
 
+                            ctor = type.GetConstructor(new Type[] { typeof(Player) });
+                            if (ctor != null) {
+                                loader = (trigger, player, eventID) => (Entity) ctor.Invoke(new object[] { player });
+                                goto RegisterCutsceneLoader;
+                            }
+
                             ctor = type.GetConstructor(Type.EmptyTypes);
                             if (ctor != null) {
                                 loader = (trigger, player, eventID) => (Entity) ctor.Invoke(null);

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
@@ -781,6 +781,105 @@ namespace Celeste.Mod {
                         }
                     }
 
+                    // Search for all Entities marked with the CustomInteractAttribute.
+                    foreach (CustomInteractAttribute attrib in type.GetCustomAttributes<CustomInteractAttribute>()) {
+                        foreach (string idFull in attrib.IDs) {
+                            string id;
+                            string genName;
+                            string[] split = idFull.Split('=');
+
+                            if (split.Length == 1) {
+                                id = split[0];
+                                genName = "Load";
+
+                            } else if (split.Length == 2) {
+                                id = split[0];
+                                genName = split[1];
+
+                            } else {
+                                Logger.Warn("core", $"Invalid number of custom interact ID elements: {idFull} ({type.FullName})");
+                                continue;
+                            }
+
+                            id = id.Trim();
+                            genName = genName.Trim();
+
+                            patch_InteractTrigger.InteractLoader loader = null;
+
+                            ConstructorInfo ctor;
+                            MethodInfo gen;
+
+                            gen = type.GetMethod(genName, new Type[] { typeof(InteractTrigger), typeof(Player), typeof(string), typeof(bool).MakeByRefType() });
+                            if (gen != null && gen.IsStatic && gen.ReturnType.IsCompatible(typeof(Entity))) {
+                                loader = (InteractTrigger trigger, Player player, string eventID, ref bool progressEvent) => {
+                                    object[] parameters = new object[] { trigger, player, eventID, progressEvent };
+                                    var entity = (Entity) gen.Invoke(null, parameters);
+                                    progressEvent = (bool) parameters[3];
+                                    return entity;
+                                };
+                                goto RegisterInteractLoader;
+                            }
+
+                            gen = type.GetMethod(genName, new Type[] { typeof(InteractTrigger), typeof(Player), typeof(string) });
+                            if (gen != null && gen.IsStatic && gen.ReturnType.IsCompatible(typeof(Entity))) {
+                                bool flag = attrib.ProgressEvent;
+                                loader = (InteractTrigger trigger, Player player, string eventID, ref bool progressEvent) => {
+                                    progressEvent = flag;
+                                    return (Entity) gen.Invoke(null, new object[] { trigger, player, eventID });
+                                };
+                                goto RegisterInteractLoader;
+                            }
+
+                            ctor = type.GetConstructor(new Type[] { typeof(InteractTrigger), typeof(Player), typeof(string), typeof(bool).MakeByRefType() });
+                            if (ctor != null) {
+                                loader = (InteractTrigger trigger, Player player, string eventID, ref bool progressEvent) => {
+                                    object[] parameters = new object[] { trigger, player, eventID, progressEvent };
+                                    var entity = (Entity) ctor.Invoke(parameters);
+                                    progressEvent = (bool) parameters[3];
+                                    return entity;
+                                };
+                                goto RegisterInteractLoader;
+                            }
+
+                            ctor = type.GetConstructor(new Type[] { typeof(InteractTrigger), typeof(Player), typeof(string) });
+                            if (ctor != null) {
+                                bool flag = attrib.ProgressEvent;
+                                loader = (InteractTrigger trigger, Player player, string eventID, ref bool progressEvent) => {
+                                    progressEvent = flag;
+                                    return (Entity) ctor.Invoke(new object[] { trigger, player, eventID });
+                                };
+                                goto RegisterInteractLoader;
+                            }
+
+                            ctor = type.GetConstructor(new Type[] { typeof(Player) });
+                            if (ctor != null) {
+                                bool flag = attrib.ProgressEvent;
+                                loader = (InteractTrigger trigger, Player player, string eventID, ref bool progressEvent) => {
+                                    progressEvent = flag;
+                                    return (Entity) ctor.Invoke(new object[] { player });
+                                };
+                                goto RegisterInteractLoader;
+                            }
+
+                            ctor = type.GetConstructor(Type.EmptyTypes);
+                            if (ctor != null) {
+                                bool flag = attrib.ProgressEvent;
+                                loader = (InteractTrigger trigger, Player player, string eventID, ref bool progressEvent) => {
+                                    progressEvent = flag;
+                                    return (Entity) ctor.Invoke(null);
+                                };
+                                goto RegisterInteractLoader;
+                            }
+
+                            RegisterInteractLoader:
+                            if (loader == null) {
+                                Logger.Warn("core", $"Found custom interact without suitable constructor / {genName}(EventTrigger, Player, string, ref bool): {id} ({type.FullName})");
+                                continue;
+                            }
+                            patch_InteractTrigger.InteractLoaders[id] = loader;
+                        }
+                    }
+
                     // Search for all Backdrops marked with the CustomBackdropAttribute.
                     foreach (CustomBackdropAttribute attrib in type.GetCustomAttributes<CustomBackdropAttribute>()) {
                         foreach (string idFull in attrib.IDs) {

--- a/Celeste.Mod.mm/Patches/InteractTrigger.cs
+++ b/Celeste.Mod.mm/Patches/InteractTrigger.cs
@@ -1,0 +1,204 @@
+﻿using Celeste.Mod;
+using Microsoft.Xna.Framework;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Monocle;
+using MonoMod;
+using MonoMod.Cil;
+using MonoMod.InlineRT;
+using MonoMod.Utils;
+using System;
+using System.Collections.Generic;
+
+namespace Celeste {
+    class patch_InteractTrigger : InteractTrigger {
+
+        private static HashSet<string> _LoadStrings; // generated in MonoModRules.PatchInteractTriggerOnTalk
+
+        public delegate Entity InteractLoader(InteractTrigger trigger, Player player, string eventID, ref bool progressEvent);
+        public static readonly Dictionary<string, InteractLoader> InteractLoaders = new();
+
+        // MonoMod ignores this - this is only required to compile
+        public patch_InteractTrigger(EntityData data, Vector2 offset) : base(data, offset) { }
+
+        [MonoModIgnore] // don't change anything about this method...
+        [PatchInteractTriggerOnTalk] // ... except for injecting code into it via a MonoModRules patch.
+        public extern new void OnTalk(Player player);
+
+        public static bool TriggerCustomInteract(InteractTrigger trigger, Player player, string eventID, ref bool progressEvent) {
+            if (string.IsNullOrEmpty(eventID))
+                return false;
+
+            if (Everest.Events.InteractTrigger.TriggerInteract(trigger, player, eventID, ref progressEvent))
+                return true;
+
+            if (InteractLoaders.TryGetValue(eventID, out InteractLoader loader)) {
+                Entity loaded = loader(trigger, player, eventID, ref progressEvent);
+                if (loaded != null) {
+                    trigger.Scene.Add(loaded);
+                    return true;
+                }
+            }
+
+            if (!_LoadStrings.Contains(eventID)) {
+                Logger.Warn("InteractTrigger", $"Interact Event '{eventID}' does not exist!");
+            }
+
+            return false;
+        }
+    }
+}
+
+namespace MonoMod {
+    /// <summary>
+    /// Include a check for custom interact events.
+    /// </summary>
+    [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchInteractTriggerOnTalk))]
+    class PatchInteractTriggerOnTalkAttribute : Attribute { }
+
+    static partial class MonoModRules {
+
+        public static void PatchInteractTriggerOnTalk(MethodDefinition method, CustomAttribute attr) {
+            // we're also going to patch the static constructor from here.
+            MethodDefinition m_cctor = method.DeclaringType.FindMethod(".cctor");
+            FieldDefinition f_LoadStrings = method.DeclaringType.FindField("_LoadStrings");
+
+            MethodDefinition m_TriggerCustomInteract = method.DeclaringType.FindMethod("System.Boolean TriggerCustomInteract(Celeste.InteractTrigger,Celeste.Player,System.String,System.Boolean&)");
+
+            Mono.Collections.Generic.Collection<Instruction> cctor_instrs = m_cctor.Body.Instructions;
+            ILProcessor cctor_il = m_cctor.Body.GetILProcessor();
+
+            // the `ret` at the end of the cctor will be added again later
+            cctor_il.RemoveAt(cctor_instrs.Count - 1);
+
+            TypeDefinition td_LoadStrings = f_LoadStrings.FieldType.Resolve();
+            MethodReference m_LoadStrings_Add = MonoModRule.Modder.Module.ImportReference(td_LoadStrings.FindMethod("Add"));
+            m_LoadStrings_Add.DeclaringType = f_LoadStrings.FieldType;
+            MethodReference m_LoadStrings_ctor = MonoModRule.Modder.Module.ImportReference(td_LoadStrings.FindMethod("System.Void .ctor()"));
+            m_LoadStrings_ctor.DeclaringType = f_LoadStrings.FieldType;
+
+            // before we get the strings, we must first construct a new HashSet
+            cctor_il.Emit(OpCodes.Newobj, m_LoadStrings_ctor);
+
+            bool eventHandlerInjectionPointFound = false;
+            bool loadStringFound = false;
+
+            Mono.Collections.Generic.Collection<Instruction> instrs = method.Body.Instructions;
+            ILProcessor il = method.Body.GetILProcessor();
+
+            int loc_bool_flag = -1;
+            int loc_string_eventID = -1;
+            object afterSwitchLabel = null;
+
+            for (int i = 0; i < instrs.Count; i++) {
+                Instruction instr = instrs[i];
+
+                /*
+                 Plan:
+                 
+                 bool flag = true;
+                 string eventID = Events[eventIndex]; // the IL code actually stores this into a local.
+                  <-- if (TriggerCustomInteract(this, player, eventID, ref flag)) // point of injection here.
+                  <--     goto afterSwitch; // if true, branch past the switch block.
+                 switch (eventID) { [...] }
+                  <-- afterSwitch:
+                 
+                 Expected IL:
+                 
+                 ldc.i4.1
+                 stloc.0   // local bool flag
+                 ldarg.0
+                 ldfld    class [mscorlib]System.Collections.Generic.List`1<string> Celeste.InteractTrigger::Events
+                 ldarg.0
+                 ldfld    int32 Celeste.InteractTrigger::eventIndex
+                 callvirt instance !0 class [mscorlib]System.Collections.Generic.List`1<string>::get_Item(int32)
+                 stloc.1   // local string eventID
+                  <------- // we inject our instructions here.
+                 ldloc.1   // the switch block begins here
+                 ...
+                 br        // to an address just after the switch block
+                 */
+
+                // we only need to inject once
+                if (!eventHandlerInjectionPointFound) {
+                    bool flagFound = loc_bool_flag != -1;
+                    bool eventIDFound = loc_string_eventID != -1;
+
+                    // first, we find our two locals
+                    if (!flagFound
+                        && i < instrs.Count - 1
+                        && instr.MatchLdcI4(1)
+                        && instrs[i + 1].MatchStloc(out loc_bool_flag)) {
+                        flagFound = true;
+                    }
+                    if (!eventIDFound
+                        && i < instrs.Count - 2
+                        && instr.MatchLdfld("Celeste.InteractTrigger", "eventIndex")
+                        && instrs[i + 1].MatchCallvirt("System.Collections.Generic.List`1<System.String>", "get_Item")
+                        && instrs[i + 2].MatchStloc(out loc_string_eventID)) {
+                        eventIDFound = true;
+                    }
+
+                    if (flagFound && eventIDFound
+                        && i >= 1
+                        && instrs[i - 1].MatchStloc(loc_string_eventID)) {
+
+                        // any `br` after this point leads past the switch block
+                        for (int j = i; j < instrs.Count; j++) {
+                            if (instrs[j].OpCode == OpCodes.Br) {
+                                afterSwitchLabel = instrs[j].Operand;
+                                break;
+                            }
+                        }
+
+                        if (afterSwitchLabel is not null) {
+                            // we're ready to inject!
+
+                            instrs.Insert(i++, il.Create(OpCodes.Ldarg_0)); // `this` onto stack
+                            instrs.Insert(i++, il.Create(OpCodes.Ldarg_1)); // parameter `player` onto stack
+                            instrs.Insert(i++, CreateLdlocS(il, (byte) loc_string_eventID)); // local `eventID` onto stack
+                            instrs.Insert(i++, il.Create(OpCodes.Ldloca_S, (byte) loc_bool_flag)); // ref local `flag` onto stack
+
+                            instrs.Insert(i++, il.Create(OpCodes.Call, m_TriggerCustomInteract)); // call our static handler
+
+                            instrs.Insert(i++, il.Create(OpCodes.Brtrue, afterSwitchLabel)); // branch to label if true
+
+                            eventHandlerInjectionPointFound = true;
+
+                            static Instruction CreateLdlocS(ILProcessor il, byte index) {
+                                return index switch {
+                                    0 => il.Create(OpCodes.Ldloc_0),
+                                    1 => il.Create(OpCodes.Ldloc_1),
+                                    2 => il.Create(OpCodes.Ldloc_2),
+                                    3 => il.Create(OpCodes.Ldloc_3),
+                                    _ => il.Create(OpCodes.Ldloc_S, index)
+                                };
+                            }
+                        }
+                    }
+                }
+
+                // we've found a string. record it into the HashSet.
+                if (instr.OpCode == OpCodes.Ldstr) {
+                    cctor_il.Emit(OpCodes.Dup);
+                    cctor_il.Emit(OpCodes.Ldstr, instr.Operand);
+                    cctor_il.Emit(OpCodes.Callvirt, m_LoadStrings_Add);
+                    cctor_il.Emit(OpCodes.Pop); // HashSet.Add returns a bool. discard it.
+
+                    loadStringFound = true;
+                }
+            }
+
+            if (!eventHandlerInjectionPointFound) {
+                throw new Exception("Event handler injection point not found in " + method.FullName + "!");
+            }
+            if (!loadStringFound) {
+                throw new Exception("ldstr not found in " + method.FullName + "!");
+            }
+
+            cctor_il.Emit(OpCodes.Stsfld, f_LoadStrings);
+            cctor_il.Emit(OpCodes.Ret);
+        }
+
+    }
+}


### PR DESCRIPTION
## What is an Interact Trigger?

the Interact Trigger is a generalised trigger of which the function is to play a cutscene upon being interacted with, by pressing [Interact] while the player is within its bounds.

one particular feature of it is that it can have one or multiple events.
when it first appears, its "event index" begins at 0. this is used to get the current event, and is incremented on playing each event.
upon incrementing, a Session flag called `it_` plus the name of the current event, is also set. this is used to keep track of which events are done even if the player goes to a different room and comes back.
on the first interaction, the trigger plays event 1. then, given it has multiple events, on subsequent interactions it will play events 2, 3, and so on. when it has no more events to play (i.e. when its event index reaches the number of events it has), it disappears.

one thing to note however is that the event index increments on a local flag in the method, which is `true` by default.
certain events have that flag set to `false`, in which case the event index won't increment, the `it_` Session flag won't be set, no subsequent events will play, and the trigger won't disappear.

this PR implements an interface which modders can use to write events for the Interact Trigger.

## `Everest.Events.InteractTrigger.OnInteractTrigger`

this Everest Event accepts a method that returns a `bool` and has the following parameters: `InteractTrigger trigger, Player player, string eventID, ref bool progressEvent`.
the method should check the `eventID` if it matches a custom event. if there's a match, it should set up the event in some way (e.g. by adding the appropriate `CutsceneEntity` to the scene) and then return `true`. if there are no matches, it should return `false`.
the parameters are explained as follows:
- `InteractTrigger trigger` - the trigger that the player is using.
- `Player player` - the player using the trigger.
- `string eventID` - the ID for the current event.
- `ref bool progressEvent` - whether to progress to the next event (i.e. by incrementing the event index and setting the appropriate Session flag) or not. this is `true` by default.

## `[CustomInteract]` attribute

this attribute may be placed on a class that extends `CutsceneEntity` (or any class that extends `Entity`).
it accepts a string (can accept multiple) that represents the ID of the event. it's recommended that each string be unique to the mod (e.g. `myCampaignMod_ch1_theo`).
it can also take an optional property argument `ProgressEvent = `, which is a boolean and `true` by default. this indicates whether the trigger should progress to the next event and set the appropriate Session flag based on the event ID, or not.

when this attribute is in place, the class requires a `public` constructor of one of certain signatures for it to be registered. the following is checked in order:
1. `(InteractTrigger trigger, Player player, string eventID, ref bool progressEvent)`
2. `(InteractTrigger trigger, Player player, string eventID)`
3. `(Player player)`
4. `()`

alternatively, the modder may also use a generator method. Everest looks for one called `Load` by default, but a different generator may be specified with the ID in the attribute (e.g. `myCampaignMod_ch1_theo = LoadTheo`).
the matching generator method must be `public static`, return `Entity`, and have one of the following signatures:
1. `(InteractTrigger trigger, Player player, string eventID, ref bool progressEvent)`
2. `(InteractTrigger trigger, Player player, string eventID)`

note that if the `ref bool progressEvent` parameter is included, the `ProgressEvent` property of the attribute is ignored, and that is left to be handled within the method / constructor.

## Other changes

- Everest now accepts `(Player)` as a valid signature for entities marked with `[CustomEvent]`.
- the summary for `[CustomEvent]` has been edited, clarifying that it is for use with an `EventTrigger`.

---
### Additional notes

for map making tools such as Lönn, the Interact Trigger (entity name: `interactTrigger`) has the following features:
- it supports the attributes `event`, `event_2`, `event_3` ... up to `event_99`, whose numbers each correspond to the index of the event, and determines the order in which the events are played out.
- it can have up to 1 node, which indicates where to draw the input prompt graphic.

here's a simple Lönn plugin to try it out:
```lua
return {
    name = "interactTrigger",
    nodeLimits = {0, 1}, -- specifies the location of the input prompt graphic
    placements = {
        name = "interact",
        data = {
            event = "",
            event_2 = "",
            event_3 = ""
            --[[
              supports additional `event_` attributes up to 99.
              to include those, copy the placement into a text editor, and write the additional keys into it.
              then paste the modified data back into the map.
              ]]
        }
    }
}
```