### PR TITLE
Add null checks in EntityRegistry.RegisterSidToTypeConnection

### DIFF
--- a/Celeste.Mod.mm/Mod/Registry/EntityRegistry.cs
+++ b/Celeste.Mod.mm/Mod/Registry/EntityRegistry.cs
@@ -27,6 +27,9 @@ public static class EntityRegistry {
     public static IReadOnlySet<string> GetKnownSidsFromType(Type type) => TypeToSids.GetValueOrDefault(type) ?? EmptyStringSet;
     
     internal static void RegisterSidToTypeConnection(string sid, Type type) {
+        if (sid is null || type is null)
+            return;
+
         ref var sidToTypeEntry = ref CollectionsMarshal.GetValueRefOrAddDefault(SidToTypes, sid, out _);
         sidToTypeEntry ??= new(1);
         sidToTypeEntry.Add(type);


### PR DESCRIPTION
Fixes crashes with manually created EntityData instances, like in Frost Helper Ice Keys: <https://discord.com/channels/403698615446536203/1455101704142979154/1455101704142979154>