### PR TITLE
Some fixes for Static Mover Decals

### DIFF
--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/StaticMoverDecalRegistryHandler.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/StaticMoverDecalRegistryHandler.cs
@@ -4,6 +4,7 @@ namespace Celeste.Mod.Registry.DecalRegistryHandlers;
 
 internal sealed class StaticMoverDecalRegistryHandler : DecalRegistryHandler {
     private int _x, _y, _width, _height;
+    private bool _jumpThrus;
     
     public override string Name => "staticMover";
     
@@ -12,6 +13,7 @@ internal sealed class StaticMoverDecalRegistryHandler : DecalRegistryHandler {
         _y = Get(xml, "y", 0);
         _width = Get(xml, "width", 16);
         _height = Get(xml, "height", 16);
+        _jumpThrus = GetBool(xml, "jumpThrus", false);
     }
 
     public override void ApplyTo(Decal decal) {
@@ -19,6 +21,6 @@ internal sealed class StaticMoverDecalRegistryHandler : DecalRegistryHandler {
         
         decal.ScaleRectangle(ref x, ref y, ref width, ref height);
 
-        ((patch_Decal)decal).MakeStaticMover(x, y, width, height);
+        ((patch_Decal)decal).MakeStaticMover(x, y, width, height, _jumpThrus);
     }
 }

--- a/Celeste.Mod.mm/Patches/Decal.cs
+++ b/Celeste.Mod.mm/Patches/Decal.cs
@@ -249,7 +249,10 @@ namespace Celeste {
                         s.MoveV(v.Y, liftSpeed.Y);
                     });
                 },
-                OnShake = v => Position += v,
+                OnShake = v => {
+                    Position += v;
+                    solids.ForEach(s => s.OnShake(v));
+                },
                 OnAttach = p => {
                     p.Add(new EntityRemovedListener(() => {
                         RemoveSelf();

--- a/Celeste.Mod.mm/Patches/Decal.cs
+++ b/Celeste.Mod.mm/Patches/Decal.cs
@@ -316,7 +316,7 @@ namespace Celeste {
         public override void Awake(Scene scene) {
             base.Awake(scene);
 
-            ((patch_EntityList) (object) scene.Entities).PostAwake += () => {
+            ((patch_EntityList) (object) scene.Entities).OnEndOfAwake += () => {
                 if (staticMover?.Platform == null && CoreModule.Session.AttachedDecals.Contains(string.Format("{0}||{1}||{2}", Name, Position.X, Position.Y))) {
                     RemoveSelf();
                 }

--- a/Celeste.Mod.mm/Patches/Decal.cs
+++ b/Celeste.Mod.mm/Patches/Decal.cs
@@ -301,9 +301,12 @@ namespace Celeste {
 
         public override void Awake(Scene scene) {
             base.Awake(scene);
-            if (staticMover?.Platform == null && CoreModule.Session.AttachedDecals.Contains(string.Format("{0}||{1}||{2}", Name, Position.X, Position.Y))) {
-                RemoveSelf();
-            }
+
+            ((patch_EntityList) (object) scene.Entities).PostAwake += () => {
+                if (staticMover?.Platform == null && CoreModule.Session.AttachedDecals.Contains(string.Format("{0}||{1}||{2}", Name, Position.X, Position.Y))) {
+                    RemoveSelf();
+                }
+            };
         }
 
         public extern void orig_Added(Scene scene);

--- a/Celeste.Mod.mm/Patches/Decal.cs
+++ b/Celeste.Mod.mm/Patches/Decal.cs
@@ -233,15 +233,24 @@ namespace Celeste {
                 SolidChecker = s => !solids.Contains(s) && s.CollideRect(new Rectangle((int) X + x, (int) Y + y, w, h)),
                 OnDestroy = () => {
                     RemoveSelf();
-                    solids.ForEach(s => s.RemoveSelf());
+                    solids.ForEach(s => {
+                        s.DestroyStaticMovers();
+                        s.RemoveSelf();
+                    });
                 },
                 OnDisable = () => {
                     Active = Visible = Collidable = false;
-                    solids.ForEach(s => s.Collidable = false);
+                    solids.ForEach(s => {
+                        s.Collidable = false;
+                        s.DisableStaticMovers();
+                    });
                 },
                 OnEnable = () => {
                     Active = Visible = Collidable = true;
-                    solids.ForEach(s => s.Collidable = true);
+                    solids.ForEach(s => {
+                        s.Collidable = true;
+                        s.EnableStaticMovers();
+                    });
                 },
                 OnMove = v => {
                     Position += v;
@@ -258,7 +267,10 @@ namespace Celeste {
                 OnAttach = p => {
                     p.Add(new EntityRemovedListener(() => {
                         RemoveSelf();
-                        solids.ForEach(s => s.RemoveSelf());
+                        solids.ForEach(s => {
+                            s.DestroyStaticMovers();
+                            s.RemoveSelf();
+                        });
                     }));
                     CoreModule.Session.AttachedDecals.Add(string.Format("{0}||{1}||{2}", Name, Position.X, Position.Y));
                 }

--- a/Celeste.Mod.mm/Patches/Decal.cs
+++ b/Celeste.Mod.mm/Patches/Decal.cs
@@ -262,7 +262,7 @@ namespace Celeste {
                 }
             };
             if (jumpThrus)
-                staticMover.JumpThruChecker = s => s.CollideRect(new Rectangle((int) X + x, (int) X + y, w, h));
+                staticMover.JumpThruChecker = s => s.CollideRect(new Rectangle((int) X + x, (int) Y + y, w, h));
             Add(staticMover);
         }
 

--- a/Celeste.Mod.mm/Patches/Decal.cs
+++ b/Celeste.Mod.mm/Patches/Decal.cs
@@ -55,6 +55,8 @@ namespace Celeste {
 
         private StaticMover staticMover;
 
+        public List<Solid> Solids => solids;
+
         public patch_Decal(string texture, Vector2 position, Vector2 scale, int depth)
             : base(texture, position, scale, depth) {
             // no-op. MonoMod ignores this - we only need this to make the compiler shut up.

--- a/Celeste.Mod.mm/Patches/Monocle/EntityList.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/EntityList.cs
@@ -11,6 +11,7 @@ using MonoMod.Utils;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 
 namespace Monocle {
     // No public constructors.
@@ -24,6 +25,8 @@ namespace Monocle {
         /// The list of entities which are about to get added.
         /// </summary>
         public List<Entity> ToAdd => toAdd;
+
+        public event Action PostAwake;
 
         internal void ClearEntities() {
             entities.Clear();
@@ -53,6 +56,8 @@ namespace Monocle {
                 // so this should be very rare in practice.
             }
         }
+
+        private void _PostAwake() => Interlocked.Exchange(ref PostAwake, null)?.Invoke();
     }
 
     public static class EntityListExt {
@@ -107,6 +112,9 @@ namespace MonoMod {
         }
 
         public static void PatchEntityListUpdateLists(ILContext context, CustomAttribute attrib) {
+            TypeDefinition t_EntityList = MonoModRule.Modder.FindType("Monocle.EntityList").Resolve();
+            MethodDefinition m_PostAwake = t_EntityList.FindMethod("_PostAwake");
+
             ILCursor cursor = new ILCursor(context);
 
             // if (!current.Contains(entity)) {          if (current.Add(entity)) {
@@ -139,6 +147,11 @@ namespace MonoMod {
             cursor.GotoPrev(instr => instr.OpCode == OpCodes.Callvirt && (instr.Operand as MethodReference).GetID().Contains("List`1<Monocle.Entity>::Contains"));
             cursor.Prev.Previous.Operand = currentOperand;
             cursor.Next.Operand = hashRemoveOperand;
+
+            // at the end, call PostAwake
+            cursor.GotoNext(MoveType.AfterLabel, instr => instr.MatchRet());
+            cursor.EmitLdarg0();
+            cursor.EmitCallvirt(m_PostAwake);
         }
 
         public static void PatchEntityListAdd(ILContext context, CustomAttribute attrib) {

--- a/Celeste.Mod.mm/Patches/Monocle/EntityList.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/EntityList.cs
@@ -26,7 +26,7 @@ namespace Monocle {
         /// </summary>
         public List<Entity> ToAdd => toAdd;
 
-        public event Action PostAwake;
+        public event Action OnEndOfAwake;
 
         internal void ClearEntities() {
             entities.Clear();
@@ -57,7 +57,7 @@ namespace Monocle {
             }
         }
 
-        private void _PostAwake() => Interlocked.Exchange(ref PostAwake, null)?.Invoke();
+        private void _PostAwake() => Interlocked.Exchange(ref OnEndOfAwake, null)?.Invoke();
     }
 
     public static class EntityListExt {


### PR DESCRIPTION
- the Static Mover Decal Registry Handler now properly accepts the `jumpThrus` attribute.
- the Static Mover's OnShake callback now calls OnShake of each of the Decal's solids, if it has any. this ensures that entities attached to those solids have the same visual shake as well.
- the Static Mover's JumpThruChecker has a typo fixed: `(int) X + y` -> `(int) Y + y`
- a new event `EntityList.PostAwake` has been implemented. this is called at the end of `EntityList.UpdateLists()`, at which point it is exchanged for `null`. any additions to `PostAwake` during its invocation will be called the next time `UpdateLists()` is called.
- the Decal's Static Mover check on `Awake` has been delegated to the `PostAwake` event.
- there is now a public getter for `Decal.solids`.
- calls to `Destroy-`, `Disable-`, and `EnableStaticMovers` are included where appropriate.