### PR TITLE
Implement map-specific postcard textures

### DIFF
--- a/Celeste.Mod.mm/Mod/Meta/MapMeta.cs
+++ b/Celeste.Mod.mm/Mod/Meta/MapMeta.cs
@@ -54,7 +54,6 @@ namespace Celeste.Mod.Meta {
         public string CassetteSong { get; set; }
 
         public string PostcardSoundID { get; set; }
-        public string PostcardTexture { get; set; }
 
         public string ForegroundTiles { get; set; }
         public string BackgroundTiles { get; set; }
@@ -75,6 +74,8 @@ namespace Celeste.Mod.Meta {
         public MapMetaTextVignette LoadingVignetteText { get; set; }
 
         public MapMetaCassetteModifier CassetteModifier { get; set; }
+
+        public MapMetaPostcard Postcard { get; set; }
 
         public void Parse(BinaryPacker.Element meta) {
             meta.AttrIf("Parent", v => Parent = v);
@@ -246,8 +247,8 @@ namespace Celeste.Mod.Meta {
                 if (CassetteModifier != null)
                     meta.CassetteModifier = CassetteModifier;
 
-                if (PostcardTexture != null)
-                    meta.PostcardTexture = PostcardTexture;
+                if (Postcard != null)
+                    meta.Postcard = Postcard;
             }
         }
 
@@ -551,5 +552,9 @@ namespace Celeste.Mod.Meta {
             meta.AttrIfBool("ActiveDuringTransitions", v => ActiveDuringTransitions = v);
             meta.AttrIfBool("OldBehavior", v => OldBehavior = v);
         }
+    }
+
+    public class MapMetaPostcard {
+        public string Texture { get; set; }
     }
 }

--- a/Celeste.Mod.mm/Mod/Meta/MapMeta.cs
+++ b/Celeste.Mod.mm/Mod/Meta/MapMeta.cs
@@ -54,6 +54,7 @@ namespace Celeste.Mod.Meta {
         public string CassetteSong { get; set; }
 
         public string PostcardSoundID { get; set; }
+        public string PostcardTexture { get; set; }
 
         public string ForegroundTiles { get; set; }
         public string BackgroundTiles { get; set; }
@@ -244,6 +245,9 @@ namespace Celeste.Mod.Meta {
 
                 if (CassetteModifier != null)
                     meta.CassetteModifier = CassetteModifier;
+
+                if (PostcardTexture != null)
+                    meta.PostcardTexture = PostcardTexture;
             }
         }
 

--- a/Celeste.Mod.mm/Patches/LevelEnter.cs
+++ b/Celeste.Mod.mm/Patches/LevelEnter.cs
@@ -140,10 +140,17 @@ namespace Celeste {
             Engine.Scene = new OverworldLoader(Overworld.StartMode.AreaQuit);
         }
 
-        private IEnumerator EnterWithPostcardRoutine(string message, string soundId) {
+        private IEnumerator EnterWithPostcardRoutine(string message, string soundId)
+            => EnterWithPostcardRoutine(message, soundId, patch_AreaData.Get(session)?.Meta?.PostcardTexture);
+
+        private IEnumerator EnterWithPostcardRoutine(string message, string soundId, string postcardTexture) {
             yield return 1f;
 
-            Add(postcard = new patch_Postcard(message, soundId));
+            patch_Postcard localPostcard = new patch_Postcard(message, soundId);
+            if (postcardTexture is not null)
+                localPostcard.Postcard = GFX.Gui[postcardTexture];
+
+            Add(postcard = localPostcard);
             yield return postcard.DisplayRoutine();
 
             IEnumerator inner = orig_Routine();

--- a/Celeste.Mod.mm/Patches/LevelEnter.cs
+++ b/Celeste.Mod.mm/Patches/LevelEnter.cs
@@ -141,7 +141,7 @@ namespace Celeste {
         }
 
         private IEnumerator EnterWithPostcardRoutine(string message, string soundId)
-            => EnterWithPostcardRoutine(message, soundId, patch_AreaData.Get(session)?.Meta?.PostcardTexture);
+            => EnterWithPostcardRoutine(message, soundId, patch_AreaData.Get(session)?.Meta?.Postcard?.Texture);
 
         private IEnumerator EnterWithPostcardRoutine(string message, string soundId, string postcardTexture) {
             yield return 1f;

--- a/Celeste.Mod.mm/Patches/Postcard.cs
+++ b/Celeste.Mod.mm/Patches/Postcard.cs
@@ -1,7 +1,18 @@
-﻿using MonoMod;
+﻿using Monocle;
+using MonoMod;
 
 namespace Celeste {
     class patch_Postcard : Postcard {
+        // make the vanilla field accessible to our patch class
+        private MTexture postcard;
+
+        /// <summary>
+        ///   The texture of the postcard.
+        /// </summary>
+        public MTexture Postcard {
+            get => postcard;
+            set => postcard = value;
+        }
 
         public patch_Postcard(string msg, int area)
             : base(msg, area) {
@@ -50,6 +61,5 @@ namespace Celeste {
 
             ctor(msg, prefix + "_in", prefix + "_out");
         }
-
     }
 }


### PR DESCRIPTION
Closes #1043. Allows mappers to specify the texture of the postcard in the map's `.meta.yaml`, like so:
```yaml
# relative to the Gui atlas
PostcardTexture: "SnipUndercover/EverestDevelopment/postcard"
```
If the texture does not exist, the `__fallback` texture will be displayed. Because the fallback texture is so small, most of the text will be cut off by it.

I suppose a next PR could let mappers change the color of the savedata name text that's rendered on the postcard to allow dark postcards?