### PR TITLE
Add Transitioning check to DelayAltMusic in Level.LoadLevel

### DIFF
--- a/Celeste.Mod.mm/Patches/Level.cs
+++ b/Celeste.Mod.mm/Patches/Level.cs
@@ -758,6 +758,8 @@ namespace MonoMod {
             FieldReference f_currentEntityId = context.Method.DeclaringType.FindField("_currentEntityId")!;
             MethodReference m_IsInDoNotLoadIncreased = context.Method.DeclaringType.FindMethod("_IsInDoNotLoadIncreased")!;
 
+            MethodReference f_get_Transitioning = context.Method.DeclaringType.FindMethod("get_Transitioning");
+
             ILCursor cursor = new ILCursor(context);
 
             // Insert our custom entity loader and use it for levelData.Entities and levelData.Triggers
@@ -905,6 +907,24 @@ namespace MonoMod {
                 );
                 cctorCursor.Emit(OpCodes.Stsfld, f_LoadStrings);
             });
+
+            // Reset to apply other patches
+            cursor.Index = 0;
+
+            // Patch DelayAltMusic check
+            //  before: if (!levelData.DelayAltMusic) { ... }
+            //  after:  if (!levelData.DelayAltMusic || !Transitioning) { ... }
+            ILLabel setAltMusicLabel = cursor.DefineLabel();
+
+            cursor.GotoNext(MoveType.After,
+                    instr => instr.MatchLdfld("Celeste.LevelData", "DelayAltMusic")
+                );
+            cursor.EmitBrfalse(setAltMusicLabel);
+            cursor.EmitLdarg0();
+            cursor.EmitCallvirt(f_get_Transitioning);
+
+            cursor.Index++; // after the brtrue
+            cursor.MarkLabel(setAltMusicLabel);
         }
 
         public static void PatchLevelLoaderDecalCreation(ILContext context, CustomAttribute attrib) {


### PR DESCRIPTION
to preface, rooms have an additional attribute called `delayAltMusicFade` (in Lönn, it's aliased to `delayAlternativeMusicFade`), which works with the room's alt music (set with the `alt_music` attribute, which in Lönn is aliased to `musicAlternative`).
when alt music is played, the main music is muted. so in order to be heard, alt music has to be routed differently to main music. the base game has them routed to `music/tunes/side_rooms`.

the value of `delayAltMusicFade` is assigned to the `LevelData`'s `DelayAltMusic` field, which is a boolean that determines at which moment to play or stop the alt music.
if it's `false`, as it is by default, the alt music is played or stopped as soon as the room is loaded.
if it's `true`, then that is delayed for when the transition into the next room is complete.

currently, due to an oversight, the `true` setting makes it only work during room transitions.
so what happens when you "Save and Quit" from that room, and then load the save again and return to it?
the main music will play, but the alt music won't, until you enter the room again via transition.

this PR attempts to fix this by adding a check for whether the level's transitioning routine is being played.

a base game example of an alt music room with the delay enabled is the secret room in Chapter 6.
for comparison, an example of an alt music room without the delay is Theo's camp in Chapter 1.