### PR TITLE
Add `CoreModeIceTileOverlay` map metadata property

### DIFF
--- a/Celeste.Mod.mm/Mod/Meta/MapMeta.cs
+++ b/Celeste.Mod.mm/Mod/Meta/MapMeta.cs
@@ -336,6 +336,7 @@ namespace Celeste.Mod.Meta {
         public bool? HeartIsEnd { get; set; }
         public bool? SeekerSlowdown { get; set; }
         public bool? TheoInBubble { get; set; }
+        public bool? CoreModeIceTileOverlay { get; set; }
 
         public patch_ModeProperties Convert()
             => new patch_ModeProperties() {
@@ -356,6 +357,7 @@ namespace Celeste.Mod.Meta {
             meta.AttrIfBool("HeartIsEnd", v => HeartIsEnd = v);
             meta.AttrIfBool("SeekerSlowdown", v => SeekerSlowdown = v);
             meta.AttrIfBool("TheoInBubble", v => TheoInBubble = v);
+            meta.AttrIfBool("CoreModeIceTileOverlay", v => CoreModeIceTileOverlay = v);
 
             BinaryPacker.Element child;
 

--- a/Celeste.Mod.mm/Patches/LevelLoader.cs
+++ b/Celeste.Mod.mm/Patches/LevelLoader.cs
@@ -250,6 +250,7 @@ namespace Celeste {
         [MonoModIgnore] // We don't want to change anything about the method...
         [PatchLoadingThreadAddEvent] // ... except for manually manipulating the method via MonoModRules
         [PatchLoadingThreadAddSubHudRenderer]
+        [PatchLoadingThreadForMapMetadata]
         private extern void LoadingThread();
 
         private void LoadingThread_Safe() {
@@ -325,6 +326,9 @@ namespace Celeste {
             }
         }
 
+        private static bool _ShouldAddIceTileOverlay(MapData mapData)
+            => ((patch_MapData) mapData).Meta?.CoreModeIceTileOverlay ?? false;
+
     }
 }
 
@@ -365,6 +369,12 @@ namespace MonoMod {
     /// </summary>
     [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchLoadingThreadAddEvent))]
     class PatchLoadingThreadAddEventAttribute : Attribute { }
+
+    /// <summary>
+    /// Handles map metadata properties in some places throughout the loading thread.
+    /// </summary>
+    [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchLoadingThreadForMapMetadata))]
+    class PatchLoadingThreadForMapMetadataAttribute : Attribute { }
 
     static partial class MonoModRules {
 
@@ -429,6 +439,41 @@ namespace MonoMod {
             cursor.Emit(OpCodes.Ldarg_0);
             cursor.Emit(OpCodes.Callvirt, m_LevelLoader_get_Level);
             cursor.Emit(OpCodes.Call, m_Everest_Events_LevelLoader_LoadingThread);
+        }
+
+        public static void PatchLoadingThreadForMapMetadata(ILContext context, CustomAttribute attrib) {
+            MethodDefinition m_shouldAddIceTileOverlay = context.Method.DeclaringType.FindMethod("_ShouldAddIceTileOverlay");
+
+            ILCursor cursor = new(context);
+
+            // first, get the local for MapData
+            int loc_mapData = -1;
+            cursor.GotoNext(
+                    instr => instr.MatchCallvirt("Celeste.Session", "get_MapData"),
+                    instr => instr.MatchStloc(out loc_mapData)
+                );
+
+            /*
+             now let's change this bit of code
+             if (session.Area.ID == 9) { ... }
+             to this
+             if (session.Area.ID == 9 || _ShouldAddIceTileOverlay(mapData)) { ... }
+             */
+            ILLabel addIceTileOverlaybel = cursor.DefineLabel();
+            ILLabel branchOutLabel = null;
+            cursor.GotoNext(instr => instr.MatchLdcI4(9));
+            cursor.GotoNext(MoveType.Before, instr => instr.MatchBneUn(out branchOutLabel));
+
+            // for simplicity, we'll remove the bne.un.s, and replace it with a different branch instruction
+            cursor.Remove();
+
+            cursor.Emit(OpCodes.Beq_S, addIceTileOverlaybel); // beq.s <=> bne.un.s
+
+            cursor.EmitLdloc(loc_mapData);
+            cursor.Emit(OpCodes.Call, m_shouldAddIceTileOverlay);
+            cursor.Emit(OpCodes.Brfalse_S, branchOutLabel);
+
+            cursor.MarkLabel(addIceTileOverlaybel);
         }
 
     }


### PR DESCRIPTION
this is an effect specific to vanilla Core, which has been unusable in custom maps (without writing a code mod) until now.
if enabled, an ice graphic will be overlaid on the surface of Solid Tiles when the Core Mode is Cold.
may be useful for maps looking to emulate vanilla Core