### PR TITLE
Custom Scenery Tiles

### DIFF
--- a/Celeste.Mod.mm/Mod/Meta/MapMeta.cs
+++ b/Celeste.Mod.mm/Mod/Meta/MapMeta.cs
@@ -61,6 +61,8 @@ namespace Celeste.Mod.Meta {
         public string Sprites { get; set; }
         public string Portraits { get; set; }
 
+        public string SceneryTiles { get; set; }
+
         public bool? OverrideASideMeta { get; set; }
 
         public MapMetaModeProperties[] Modes { get; set; }
@@ -114,6 +116,9 @@ namespace Celeste.Mod.Meta {
             meta.AttrIf("AnimatedTiles", v => AnimatedTiles = v);
             meta.AttrIf("Sprites", v => Sprites = v);
             meta.AttrIf("Portraits", v => Portraits = v);
+
+            meta.AttrIf("SceneryTiles", v => SceneryTiles = v);
+
             meta.AttrIfBool("OverrideASideMeta", v => OverrideASideMeta = v);
 
             BinaryPacker.Element child;
@@ -223,6 +228,9 @@ namespace Celeste.Mod.Meta {
 
                 if (!string.IsNullOrEmpty(Portraits))
                     meta.Portraits = Portraits;
+
+                if (!string.IsNullOrEmpty(SceneryTiles))
+                    meta.SceneryTiles = SceneryTiles;
 
                 if (OverrideASideMeta != null)
                     meta.OverrideASideMeta = OverrideASideMeta;

--- a/Celeste.Mod.mm/Patches/Level.cs
+++ b/Celeste.Mod.mm/Patches/Level.cs
@@ -758,6 +758,9 @@ namespace MonoMod {
             FieldReference f_currentEntityId = context.Method.DeclaringType.FindField("_currentEntityId")!;
             MethodReference m_IsInDoNotLoadIncreased = context.Method.DeclaringType.FindMethod("_IsInDoNotLoadIncreased")!;
 
+            TypeDefinition t_GFX = MonoModRule.Modder.FindType("Celeste.GFX").Resolve();
+            FieldDefinition f_GFX_SceneryTiles = t_GFX.FindField("SceneryTiles");
+
             ILCursor cursor = new ILCursor(context);
 
             // Insert our custom entity loader and use it for levelData.Entities and levelData.Triggers
@@ -881,6 +884,26 @@ namespace MonoMod {
             cursor.Emit(OpCodes.Ldarg_0);
             cursor.Next.OpCode = OpCodes.Call;
             cursor.Next.Operand = m_LoadNewPlayer;
+
+            // Reset to apply patch for Scenery Tiles
+            cursor.Index = 0;
+
+            // Patch this bit of code to use GFX.SceneryTiles instead of creating the same tileset again
+            //  before: Tileset tileset = new Tileset(GFX.Game["tilesets/scenery"], 8, 8);
+            //  after:  Tileset tileset = GFX.SceneryTiles;
+            cursor.GotoNext(MoveType.AfterLabel,
+                    instr => instr.MatchLdsfld("Celeste.GFX", "Game"),
+                    instr => instr.MatchLdstr("tilesets/scenery")
+                );
+            // to remove:
+            // - ldsfld Celeste.GFX::Game
+            // - ldstr "tilesets/scenery"
+            // - callvirt Monocle.Atlas::get_Item(string)
+            // - ldc.i4.8
+            // - ldc.i4.8
+            // - newobj Monocle.Tileset::.ctor(class Monocle.MTexture, int32, int32)
+            cursor.RemoveRange(6);
+            cursor.Emit(OpCodes.Ldsfld, f_GFX_SceneryTiles);
 
             // Reset to apply static constructor patch
             cursor.Index = 0;

--- a/Celeste.Mod.mm/Patches/LevelLoader.cs
+++ b/Celeste.Mod.mm/Patches/LevelLoader.cs
@@ -207,6 +207,12 @@ namespace Celeste {
                 if (string.IsNullOrEmpty(path))
                     path = Path.Combine("Graphics", "Portraits.xml");
                 GFX.PortraitsSpriteBank = new SpriteBank(GFX.Portraits, path);
+
+                path = meta?.SceneryTiles;
+                if (string.IsNullOrEmpty(path))
+                    path = "tilesets/scenery";
+                GFX.SceneryTiles = new Tileset(GFX.Game[path], 8, 8);
+
             } catch (Exception e) {
                 if (patch_LevelEnter.ErrorMessage == null) {
                     if (e is XmlException) {


### PR DESCRIPTION
Quick disclaimer: this isn't quite ready to merge yet. for the time being, this PR is mainly for discussion and gathering feedback.

## About Scenery Tiles
besides Solid and Background Tiles, a room has additional layers known as **"Scenery Tiles"**, which are placed in the same way and have the feature of overlaying on the tiles beneath them, replacing their appearance.
there are three layers of Scenery Tiles:
- **Scenery FG:** these are overlaid on Solid Tiles. they also mask lighting.
- **Scenery BG:** these are overlaid on Background Tiles.
- **Scenery Obj:** these are overlaid on entities with a Tile Interceptor component (e.g. Dash Blocks, Fake Walls). note that in order for this to work, those entities have to not be moved from their position before their `Update` is called.

the value of each Scenery Tile is an `integer` which corresponds to which tile to use from the Scenery Tileset. `-1` means that no Scenery Tile is overlaid on that position.

the Scenery Tileset is hardcoded for `"tilesets/scenery"`, but this PR aims to provide a way for mappers to set a custom path for it.

## `SceneryTiles` metadata
this PR implements a new Map Meta property called **`SceneryTiles`**, which takes a `string` value indicating the path, relative to the Gameplay atlas, for the custom texture to use. this will allow mappers to place their own tiles to overlay onto the terrain.

## Possible improvements?
while this has been a simple feature to implement, I've had some thoughts about how it could be improved.
as of now, the meta property just takes a path to a custom texture, but this might be better implemented as a new type of XML bank, providing more customisability for Scenery Tiles.
for example, one possible setting could be whether a tile should mask lighting or not.
an ability to use multiple Scenery Tilesets might also help for collabs where different maps would be brought together.
mods could also add their own options if desired.

of course, there's also the matter of supporting all this with map making tools like Lönn, but that's a topic for another time.
(by the way, I've written some Lönn plugins you could use to test it out. you can get them from my repositories)

for now, feel free to comment with more ways on how this feature could be improved