### PR TITLE
Deprecate unused flags

### DIFF
--- a/Celeste.Mod.mm/Content/Dialog/Brazilian Portuguese.txt
+++ b/Celeste.Mod.mm/Content/Dialog/Brazilian Portuguese.txt
@@ -127,7 +127,6 @@
 	UPDATER_SRC_BUILDBOT= 			Versões automáticas
     
 # Everest Updater
-	EVERESTUPDATER_NOTSUPPORTED=	Atualização não suportada nesta plataforma - cancelando.
 	EVERESTUPDATER_NOUPDATE=		Sem atualizações - cancelando.
 	EVERESTUPDATER_UPDATING=		Atualizando para {0} (branch: {1}) @ {2}
 	EVERESTUPDATER_DOWNLOADING=		Instalando

--- a/Celeste.Mod.mm/Content/Dialog/English.txt
+++ b/Celeste.Mod.mm/Content/Dialog/English.txt
@@ -218,7 +218,6 @@
 	UPDATER_SRC_BUILDBOT= 			Automatic builds
 
 # Everest Updater
-	EVERESTUPDATER_NOTSUPPORTED=	Updating not supported on this platform - cancelling.
 	EVERESTUPDATER_NOUPDATE=		No update - cancelling.
 	EVERESTUPDATER_CREATINGLEGACYREF=	Creating base legacyRef install
 	EVERESTUPDATER_NOTAVAILABLE=	Required Everest build not available!

--- a/Celeste.Mod.mm/Content/Dialog/French.txt
+++ b/Celeste.Mod.mm/Content/Dialog/French.txt
@@ -199,7 +199,6 @@
 	UPDATER_SRC_BUILDBOT= 			Versions compilées automatiquement
 
 # Everest Updater
-	EVERESTUPDATER_NOTSUPPORTED=	La mise à jour n'est pas supportée sur cette plateforme - annulation.
 	EVERESTUPDATER_NOUPDATE=		Pas de mise à jour à installer - annulation.
 	EVERESTUPDATER_CREATINGLEGACYREF=	Création de l'installation legacyRef en cours
 	EVERESTUPDATER_NOTAVAILABLE=	La version d'Everest demandée n'est pas disponible !

--- a/Celeste.Mod.mm/Content/Dialog/German.txt
+++ b/Celeste.Mod.mm/Content/Dialog/German.txt
@@ -192,7 +192,6 @@
 	UPDATER_SRC_BUILDBOT= 			Automatische Builds
 	
 # Everest Updater
-	EVERESTUPDATER_NOTSUPPORTED=	Updates werden auf dieser Plattform nicht unterstützt - Abbruch.
 	EVERESTUPDATER_NOUPDATE=		Kein Update - Abbruch.
 	EVERESTUPDATER_CREATINGLEGACYREF=	Erstelle legacyRef Basisinstallation
 	EVERESTUPDATER_NOTAVAILABLE=	Benötigter Everest-Build nicht verfügbar!

--- a/Celeste.Mod.mm/Content/Dialog/Japanese.txt
+++ b/Celeste.Mod.mm/Content/Dialog/Japanese.txt
@@ -187,7 +187,6 @@
 	UPDATER_SRC_BUILDBOT= 			自動ビルド
 
 # Everest Updater
-	EVERESTUPDATER_NOTSUPPORTED=	このプラットフォームではサポートされていません - キャンセルします
 	EVERESTUPDATER_NOUPDATE=		アップデートが見つかりません - キャンセルします
 	EVERESTUPDATER_CREATINGLEGACYREF=	ベースのlegacyRefインストールを作成します
 	EVERESTUPDATER_NOTAVAILABLE=	必要なEverestビルドが見つかりません！

--- a/Celeste.Mod.mm/Content/Dialog/Korean.txt
+++ b/Celeste.Mod.mm/Content/Dialog/Korean.txt
@@ -212,7 +212,6 @@
 	UPDATER_SRC_BUILDBOT= 			자동 빌드
 
 # Everest Updater
-	EVERESTUPDATER_NOTSUPPORTED=	이 플랫폼에서 업데이트가 지원되지 않습니다. - 업데이트 취소
 	EVERESTUPDATER_NOUPDATE=		업데이트가 없습니다. - 업데이트 취소
 	EVERESTUPDATER_CREATINGLEGACYREF=	legacyRef 설치 준비 중
 	EVERESTUPDATER_NOTAVAILABLE=	요구하는 에베레스트 빌드를 사용할 수 없습니다!

--- a/Celeste.Mod.mm/Content/Dialog/Polish.txt
+++ b/Celeste.Mod.mm/Content/Dialog/Polish.txt
@@ -190,7 +190,6 @@
 	UPDATER_SRC_BUILDBOT=			Automatyczne kompilacje
 	
 # Everest Updater // Aktualizator Everest
-	EVERESTUPDATER_NOTSUPPORTED=			Aktualizowanie nie jest wspierane na tej platformie - anulowanie.
 	EVERESTUPDATER_NOUPDATE=				Brak aktualizacji - anulowanie.
 	EVERESTUPDATER_CREATINGLEGACYREF=			Konfigurowanie podstawowej instalacji legacyRef
 	EVERESTUPDATER_NOTAVAILABLE=				Wymagana wersja Everest jest niedostępna!

--- a/Celeste.Mod.mm/Content/Dialog/Russian.txt
+++ b/Celeste.Mod.mm/Content/Dialog/Russian.txt
@@ -167,7 +167,6 @@
 	UPDATER_SRC_BUILDBOT= 			Автоматические сборки
 
 # Everest Updater
-	EVERESTUPDATER_NOTSUPPORTED=	Обновление не поддерживается данной платформой - отменяю.
 	EVERESTUPDATER_NOUPDATE=		Нет обновлений - отменяю.
 	EVERESTUPDATER_UPDATING=		Обновление на {0} (branch: {1}) @ {2}
 	EVERESTUPDATER_DOWNLOADING=		Загрузка

--- a/Celeste.Mod.mm/Content/Dialog/Simplified Chinese.txt
+++ b/Celeste.Mod.mm/Content/Dialog/Simplified Chinese.txt
@@ -187,7 +187,6 @@
 	UPDATER_SRC_BUILDBOT= 			自动构建
 
 # Everest Updater
-	EVERESTUPDATER_NOTSUPPORTED=        本平台不支持更新，取消。
 	EVERESTUPDATER_NOUPDATE=	    	没有更新，取消。
     EVERESTUPDATER_CREATINGLEGACYREF=	正在进行安装 legacyRef 的基础工作
 	EVERESTUPDATER_NOTAVAILABLE=	    请求的 Everest 构建版本不可用！

--- a/Celeste.Mod.mm/Mod/Core/CoreModule.cs
+++ b/Celeste.Mod.mm/Mod/Core/CoreModule.cs
@@ -56,9 +56,6 @@ namespace Celeste.Mod.Core {
             if (Settings.DiscordRichPresence && !Everest.Flags.IsHeadless) {
                 Everest.DiscordSDK.CreateInstance();
             }
-
-            // If we're running in an environment that prefers this flag, forcibly enable them.
-            Settings.LazyLoading |= Everest.Flags.PreferLazyLoading;
         }
 
         public override void SaveSettings() {
@@ -137,12 +134,8 @@ namespace Celeste.Mod.Core {
                 }
             }
 
-            if (firstLoad && !Everest.Flags.AvoidRenderTargets) {
+            if (firstLoad) {
                 SubHudRenderer.Buffer = VirtualContent.CreateRenderTarget("subhud-target", 1922, 1082);
-            }
-            if (Everest.Flags.AvoidRenderTargets && Celeste.HudTarget != null) {
-                Celeste.HudTarget.Dispose();
-                Celeste.HudTarget = null;
             }
         }
 

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Flags.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Flags.cs
@@ -45,11 +45,14 @@ namespace Celeste.Mod {
             /// <summary>
             /// Should the game avoid creating render targets if possible?
             /// </summary>
-            public static bool AvoidRenderTargets { get; private set; }
+            [Obsolete("`AvoidRenderTargets` is always false on Everest Core")]
+            public static bool AvoidRenderTargets => false;
+
             /// <summary>
             /// Does the environment (platform, ...) prefer lazy loading?
             /// </summary>
-            public static bool PreferLazyLoading { get; private set; }
+            [Obsolete("`PreferLazyLoading` is always false on Everest Core")]
+            public static bool PreferLazyLoading => false;
 
             /// <summary>
             /// Does the environment (renderer, framework ,...) prefer threaded GL?
@@ -60,12 +63,14 @@ namespace Celeste.Mod {
             /// <summary>
             /// Does the environment (platform, ...) support loading runtime mods?
             /// </summary>
-            public static bool SupportRuntimeMods { get; private set; }
+            [Obsolete("`SupportRuntimeMods` is always true on Everest Core")]
+            public static bool SupportRuntimeMods => true;
 
             /// <summary>
             /// Does the environment (platform, ...) support updating Everest?
             /// </summary>
-            public static bool SupportUpdatingEverest { get; private set; }
+            [Obsolete("`SupportUpdatingEverest` is always true on Everest Core")]
+            public static bool SupportUpdatingEverest => true;
 
             internal static void Initialize() {
                 // Determine vanilla install type
@@ -78,14 +83,7 @@ namespace Celeste.Mod {
                     VanillaIsFNA = metaReader.AssemblyReferences.Any(handle => metaReader.GetString(metaReader.GetAssemblyReference(handle).Name) == "FNA");
                     VanillaIsXNA = !VanillaIsFNA;
                 }
-
-                AvoidRenderTargets = Environment.GetEnvironmentVariable("EVEREST_NO_RT") == "1";
-                PreferLazyLoading = false;
-
-                SupportRuntimeMods = true;
-                SupportUpdatingEverest = true;
             }
-
         }
     }
 }

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
@@ -254,11 +254,6 @@ namespace Celeste.Mod {
             /// </summary>
             /// <param name="archive">The path to the mod .zip archive.</param>
             public static void LoadZip(string archive) {
-                if (!Flags.SupportRuntimeMods) {
-                    Logger.Warn("loader", "Loader disabled!");
-                    return;
-                }
-
                 if (!File.Exists(archive)) // Relative path? Let's just make it absolute.
                     archive = Path.Combine(PathMods, archive);
                 if (!File.Exists(archive)) { // It just doesn't exist.
@@ -360,11 +355,6 @@ namespace Celeste.Mod {
             /// </summary>
             /// <param name="dir">The path to the mod directory.</param>
             public static void LoadDir(string dir) {
-                if (!Flags.SupportRuntimeMods) {
-                    Logger.Warn("loader", "Loader disabled!");
-                    return;
-                }
-
                 if (!Directory.Exists(dir)) // Relative path?
                     dir = Path.Combine(PathMods, dir);
                 if (!Directory.Exists(dir)) { // It just doesn't exist.
@@ -449,11 +439,6 @@ namespace Celeste.Mod {
             /// <param name="meta">Metadata of the mod to load.</param>
             /// <param name="callback">Callback to be executed after the mod has been loaded. Executed immediately if meta == null.</param>
             public static void LoadModDelayed(EverestModuleMetadata meta, Action callback) {
-                if (!Flags.SupportRuntimeMods) {
-                    Logger.Warn("loader", "Loader disabled!");
-                    return;
-                }
-
                 if (meta == null) {
                     callback?.Invoke();
                     return;
@@ -495,11 +480,6 @@ namespace Celeste.Mod {
             /// <param name="meta">Metadata of the mod to load.</param>
             /// <returns>Whether the mod load was successful.</returns>
             public static bool LoadMod(EverestModuleMetadata meta) {
-                if (!Flags.SupportRuntimeMods) {
-                    Logger.Warn("loader", "Loader disabled!");
-                    return false;
-                }
-
                 if (meta == null)
                     return true;
 
@@ -534,11 +514,6 @@ namespace Celeste.Mod {
             /// <param name="meta">The mod metadata, preferably from the mod metadata.yaml file.</param>
             /// <param name="asm">The mod assembly, preferably relinked.</param>
             public static void LoadModAssembly(EverestModuleMetadata meta, Assembly asm) {
-                if (!Flags.SupportRuntimeMods) {
-                    Logger.Warn("loader", "Loader disabled!");
-                    return;
-                }
-
                 // Apply hackfixes
                 ApplyModHackfixes(meta, asm);
 
@@ -840,7 +815,7 @@ namespace Celeste.Mod {
             /// </summary>
             /// <param name="meta">Metadata of the mod to reload.</param>
             public static void ReloadMod(EverestModuleMetadata meta) {
-                if (!Flags.SupportRuntimeMods || meta.AssemblyContext == null)
+                if (meta.AssemblyContext == null)
                     return;
 
                 QueuedTaskHelperV2.Do($"ReloadModAssembly: {meta.Name}", () => {
@@ -905,10 +880,6 @@ namespace Celeste.Mod {
             /// <param name="meta">The metadata of the mod listing the dependencies.</param>
             /// <returns>True if the dependencies have already been loaded by Everest, false otherwise.</returns>
             public static bool DependenciesLoaded(EverestModuleMetadata meta) {
-                if (!Flags.SupportRuntimeMods) {
-                    return false;
-                }
-
                 // enforce dependencies.
                 foreach (EverestModuleMetadata dep in meta.Dependencies)
                     if (!DependencyLoaded(dep))

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Updater.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Updater.cs
@@ -191,9 +191,6 @@ namespace Celeste.Mod {
 
             internal static Task _VersionListRequestTask;
             public static Task RequestAll() {
-                if (!Flags.SupportUpdatingEverest)
-                    return new Task(() => { });
-
                 Task[] tasks = new Task[Sources.Count];
                 for (int i = 0; i < tasks.Length; i++) {
                     tasks[i] = Sources[i].Request();
@@ -366,13 +363,6 @@ namespace Celeste.Mod {
             }
 
             public static void Update(OuiLoggedProgress progress, Entry version = null) {
-                if (!Flags.SupportUpdatingEverest) {
-                    progress.Init<OuiModOptions>(Dialog.Clean("updater_title"), new Task(() => { }), 1).Progress = 1;
-                    progress.LogLine(Dialog.Clean("EVERESTUPDATER_NOTSUPPORTED"));
-                    progress.WaitForConfirmOnFinish = true;
-                    return;
-                }
-
                 if (version == null)
                     version = Newest;
                 if (version == null) {


### PR DESCRIPTION
This PR deprecates the following flags and removes associated usages:
- `AvoidRenderTargets`
- `PreferLazyLoading`
- `SupportRuntimeMods`
- `SupportUpdatingEverest`

These flags are unused as far as I can tell.