### PR TITLE
Implement Fast Level Loading

### DIFF
--- a/Celeste.Mod.mm/Content/Dialog/English.txt
+++ b/Celeste.Mod.mm/Content/Dialog/English.txt
@@ -57,6 +57,7 @@
 	MODOPTIONS_TITLE= 										EVEREST
 	MODOPTIONS_NEEDSRELAUNCH=								Requires a restart to take effect
 	MODOPTIONS_DEFAULT=										DEFAULT
+	MODOPTIONS_ISEXPERIMENTAL=								Experimental (default OFF), please report issues if turning ON!
 
 # Core Module Options
 	MODOPTIONS_COREMODULE_UPDATE= 							Update Everest to ((version))
@@ -166,7 +167,6 @@
 	MODOPTIONS_COREMODULE_SEARCHBOX_PLACEHOLDER=			Press 'Tab' or 'Enter' to scroll to the next match
 
 	MODOPTIONS_COREMODULE_FASTLEVELLOADING=					Fast Level Loading
-	MODOPTIONS_COREMODULE_FASTLEVELLOADING_DESC=			Experimental (default OFF), please report issues if turning ON!
 
 	MODOPTIONS_VANILLATRISTATE_NEVER=						OFF
 	MODOPTIONS_VANILLATRISTATE_EVEREST=						EVEREST

--- a/Celeste.Mod.mm/Content/Dialog/English.txt
+++ b/Celeste.Mod.mm/Content/Dialog/English.txt
@@ -56,6 +56,7 @@
 # Mod Options
 	MODOPTIONS_TITLE= 										EVEREST
 	MODOPTIONS_NEEDSRELAUNCH=								Requires a restart to take effect
+	MODOPTIONS_DEFAULT=										DEFAULT
 
 # Core Module Options
 	MODOPTIONS_COREMODULE_UPDATE= 							Update Everest to ((version))
@@ -164,9 +165,13 @@
 
 	MODOPTIONS_COREMODULE_SEARCHBOX_PLACEHOLDER=			Press 'Tab' or 'Enter' to scroll to the next match
 
+	MODOPTIONS_COREMODULE_FASTLEVELLOADING=					Fast Level Loading
+	MODOPTIONS_COREMODULE_FASTLEVELLOADING_DESC=			Experimental (default OFF), please report issues if turning ON!
+
 	MODOPTIONS_VANILLATRISTATE_NEVER=						OFF
 	MODOPTIONS_VANILLATRISTATE_EVEREST=						EVEREST
 	MODOPTIONS_VANILLATRISTATE_ALWAYS=						ALWAYS
+
 
 # Sound Test
 	SOUNDTEST_TITLE=	SOUND TEST

--- a/Celeste.Mod.mm/Mod/Core/CoreModuleSettings.cs
+++ b/Celeste.Mod.mm/Mod/Core/CoreModuleSettings.cs
@@ -159,9 +159,8 @@ namespace Celeste.Mod.Core {
         [SettingIgnore]
         public int LogHistoryCountToKeep { get; set; } = 3;
 
-        [SettingNeedsRelaunch]
-        [SettingInGame(false)]
-        public bool FastLevelLoading { get; set; } = false;
+        // Rendering handled in CreateFastLevelLoadingEntry
+        public bool? FastLevelLoading { get; set; } = null;
 
         [SettingNeedsRelaunch]
         [SettingInGame(false)]
@@ -707,6 +706,40 @@ namespace Celeste.Mod.Core {
                     value: mirrorPreferences.IndexOf(MirrorPreferences)
                 ).Change(value => MirrorPreferences = mirrorPreferences[value])
             );
+        }
+
+        public void CreateFastLevelLoadingEntry(TextMenu menu, bool inGame) {
+            if (inGame) return;
+
+            Dictionary<string, bool?> fastLevelLoadingPreferences = new() {
+                {"MODOPTIONS_DEFAULT", null},
+                {"OPTIONS_ON", true},
+                {"OPTIONS_OFF", false},
+            };
+
+            List<string> dialogKeys = fastLevelLoadingPreferences.Keys
+                .Select(setting => setting)
+                .ToList();
+
+            TextMenu.Slider slider = new TextMenu.Slider(
+                label: Dialog.Clean("MODOPTIONS_COREMODULE_FASTLEVELLOADING"),
+                values: index => Dialog.Clean(dialogKeys[index]),
+                min: 0,
+                max: fastLevelLoadingPreferences.Count - 1,
+                value: fastLevelLoadingPreferences.Values.ToList().IndexOf(FastLevelLoading)
+            );
+
+            menu.Add(slider.Change(value => FastLevelLoading = fastLevelLoadingPreferences.Values.ToList()[value]));
+            slider.NeedsRelaunch((patch_TextMenu) menu);
+
+            TextMenuExt.EaseInSubHeaderExt description = new TextMenuExt.EaseInSubHeaderExt(Dialog.Clean("MODOPTIONS_COREMODULE_FASTLEVELLOADING_DESC"), false, menu) {
+                TextColor = Color.OrangeRed,
+                HeightExtra = 0f
+            };
+            slider.OnEnter += () => description.FadeVisible = true;
+            slider.OnLeave += () => description.FadeVisible = false;
+
+            menu.Add(description);
         }
 
         public enum VanillaTristate {

--- a/Celeste.Mod.mm/Mod/Core/CoreModuleSettings.cs
+++ b/Celeste.Mod.mm/Mod/Core/CoreModuleSettings.cs
@@ -159,7 +159,9 @@ namespace Celeste.Mod.Core {
         [SettingIgnore]
         public int LogHistoryCountToKeep { get; set; } = 3;
 
-        // Rendering handled in CreateFastLevelLoadingEntry
+        [SettingInGame(false)]
+        [SettingExperimental]
+        [SettingNeedsRelaunch]
         public bool? FastLevelLoading { get; set; } = null;
 
         [SettingNeedsRelaunch]
@@ -706,40 +708,6 @@ namespace Celeste.Mod.Core {
                     value: mirrorPreferences.IndexOf(MirrorPreferences)
                 ).Change(value => MirrorPreferences = mirrorPreferences[value])
             );
-        }
-
-        public void CreateFastLevelLoadingEntry(TextMenu menu, bool inGame) {
-            if (inGame) return;
-
-            Dictionary<string, bool?> fastLevelLoadingPreferences = new() {
-                {"MODOPTIONS_DEFAULT", null},
-                {"OPTIONS_ON", true},
-                {"OPTIONS_OFF", false},
-            };
-
-            List<string> dialogKeys = fastLevelLoadingPreferences.Keys
-                .Select(setting => setting)
-                .ToList();
-
-            TextMenu.Slider slider = new TextMenu.Slider(
-                label: Dialog.Clean("MODOPTIONS_COREMODULE_FASTLEVELLOADING"),
-                values: index => Dialog.Clean(dialogKeys[index]),
-                min: 0,
-                max: fastLevelLoadingPreferences.Count - 1,
-                value: fastLevelLoadingPreferences.Values.ToList().IndexOf(FastLevelLoading)
-            );
-
-            menu.Add(slider.Change(value => FastLevelLoading = fastLevelLoadingPreferences.Values.ToList()[value]));
-            slider.NeedsRelaunch((patch_TextMenu) menu);
-
-            TextMenuExt.EaseInSubHeaderExt description = new TextMenuExt.EaseInSubHeaderExt(Dialog.Clean("MODOPTIONS_COREMODULE_FASTLEVELLOADING_DESC"), false, menu) {
-                TextColor = Color.OrangeRed,
-                HeightExtra = 0f
-            };
-            slider.OnEnter += () => description.FadeVisible = true;
-            slider.OnLeave += () => description.FadeVisible = false;
-
-            menu.Add(description);
         }
 
         public enum VanillaTristate {

--- a/Celeste.Mod.mm/Mod/Core/CoreModuleSettings.cs
+++ b/Celeste.Mod.mm/Mod/Core/CoreModuleSettings.cs
@@ -161,8 +161,7 @@ namespace Celeste.Mod.Core {
 
         [SettingNeedsRelaunch]
         [SettingInGame(false)]
-        [SettingIgnore] // TODO: Show as advanced setting.
-        public bool? FastLevelLoading { get; set; } = null;
+        public bool FastLevelLoading { get; set; } = false;
 
         [SettingNeedsRelaunch]
         [SettingInGame(false)]

--- a/Celeste.Mod.mm/Mod/Core/CoreModuleSettings.cs
+++ b/Celeste.Mod.mm/Mod/Core/CoreModuleSettings.cs
@@ -162,6 +162,11 @@ namespace Celeste.Mod.Core {
         [SettingNeedsRelaunch]
         [SettingInGame(false)]
         [SettingIgnore] // TODO: Show as advanced setting.
+        public bool? FastLevelLoading { get; set; } = null;
+
+        [SettingNeedsRelaunch]
+        [SettingInGame(false)]
+        [SettingIgnore] // TODO: Show as advanced setting.
         public bool? ThreadedGL { get; set; } = null;
 
         [YamlMember(Alias = "FastTextureLoading")]

--- a/Celeste.Mod.mm/Mod/Everest/Extensions.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Extensions.cs
@@ -227,6 +227,35 @@ namespace Celeste.Mod {
         }
 
         /// <summary>
+        /// Add an Enter and Leave handler, notifying the user that the current setting is experimental.
+        /// </summary>
+        /// <param name="option">The input TextMenu.Item option.</param>
+        /// <param name="containingMenu">The menu containing the TextMenu.Item option.</param>
+        /// <param name="isExperimental">This method does nothing if this is set to false.</param>
+        /// <returns>The passed option.</returns>
+        public static TextMenu.Item IsExperimental(this TextMenu.Item option, patch_TextMenu containingMenu, bool isExperimental = true) {
+            if (!isExperimental)
+                return option;
+
+            // build the text menu entry
+            TextMenuExt.EaseInSubHeaderExt isExperimentalText = new TextMenuExt.EaseInSubHeaderExt(Dialog.Clean("MODOPTIONS_ISEXPERIMENTAL"), false, containingMenu) {
+                TextColor = Color.OrangeRed,
+                HeightExtra = 0f
+            };
+
+            List<TextMenu.Item> items = containingMenu.Items;
+            if (items.Contains(option)) {
+                // insert the text after the option
+                containingMenu.Insert(items.IndexOf(option) + 1, isExperimentalText);
+            }
+
+            option.OnEnter += delegate { isExperimentalText.FadeVisible = true; };
+            option.OnLeave += delegate { isExperimentalText.FadeVisible = false; };
+
+            return option;
+        }
+
+        /// <summary>
         /// Add an Enter and Leave handler, displaying a description if selected.
         /// </summary>
         /// <param name="option">The input TextMenu.Item option.</param>

--- a/Celeste.Mod.mm/Mod/Module/EverestModule.cs
+++ b/Celeste.Mod.mm/Mod/Module/EverestModule.cs
@@ -662,6 +662,7 @@ namespace Celeste.Mod {
             SettingInGameAttribute attribInGame;
             SettingRangeAttribute attribRange;
             SettingNumberInputAttribute attribNumber;
+            SettingExperimentalAttribute attribExperimental;
 
             // If the settings type has got the InGame attrib, only show it in the matching situation.
             if ((attribInGame = type.GetCustomAttribute<SettingInGameAttribute>()) != null &&
@@ -794,6 +795,23 @@ namespace Celeste.Mod {
                                 minValueLength
                             );
                         });
+                } else if (propType == typeof(bool?) && (attribExperimental = prop.GetCustomAttribute<SettingExperimentalAttribute>()) != null) {
+                    Dictionary<string, bool?> preferences = new() {
+                        {"MODOPTIONS_DEFAULT", null},
+                        {"OPTIONS_ON", true},
+                        {"OPTIONS_OFF", false},
+                    };
+
+                    List<string> dialogKeys = preferences.Keys.ToList();
+                    List<bool?> dialogValues = preferences.Values.ToList();
+
+                    item = new TextMenu.Slider(
+                        label: name,
+                        values: index => Dialog.Clean(dialogKeys[index]),
+                        min: 0,
+                        max: preferences.Count - 1,
+                        value: preferences.Values.ToList().IndexOf((bool?)prop.GetValue(settingsObject))
+                    ).Change(value => prop.SetValue(settingsObject, dialogValues[value]));
                 }
 
                 if (item is not null)
@@ -878,6 +896,10 @@ namespace Celeste.Mod {
 
                 if (prop.GetCustomAttribute<SettingNeedsRelaunchAttribute>() != null)
                     item.NeedsRelaunch(menu);
+
+                if (prop.GetCustomAttribute<SettingExperimentalAttribute>() != null)
+                    item.IsExperimental(menu);
+
 
                 string description = prop.GetCustomAttribute<SettingSubTextAttribute>()?.Description;
                 if (description != null)

--- a/Celeste.Mod.mm/Mod/Module/EverestModuleSettings.cs
+++ b/Celeste.Mod.mm/Mod/Module/EverestModuleSettings.cs
@@ -126,6 +126,15 @@ namespace Celeste.Mod {
         public SettingIgnoreAttribute() {
         }
     }
+
+    /// <summary>
+    /// Experimental setting, only supported on bool? property type
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public class SettingExperimentalAttribute : Attribute {
+        public SettingExperimentalAttribute() {
+        }
+    }
     
     /// <summary>
     /// Insert a subheader before the setting.

--- a/Celeste.Mod.mm/Patches/AreaData.cs
+++ b/Celeste.Mod.mm/Patches/AreaData.cs
@@ -2,6 +2,7 @@
 #pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
 
 using Celeste.Mod;
+using Celeste.Mod.Core;
 using Celeste.Mod.Meta;
 using Microsoft.Xna.Framework;
 using Monocle;
@@ -10,6 +11,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 
 namespace Celeste {
     public class patch_AreaData : AreaData {
@@ -365,7 +367,7 @@ namespace Celeste {
                 }
             }
 
-            for (int i = 0; i < Areas.Count; i++) {
+            static void ProcessMapData(int i) {
                 patch_AreaData area = Areas[i];
                 area.ID = i;
 
@@ -378,7 +380,9 @@ namespace Celeste {
                 }
                 Array.Resize(ref area.Mode, modei);
 
-                Logger.Verbose("AreaData", string.Format("{0}: {1} - {2} sides", i, area.SID, area.Mode.Length));
+                // Do not clutter the log if Fast Level Loading is disabled
+                LogLevel level = (CoreModule.Settings.FastLevelLoading ?? true) ? LogLevel.Info : LogLevel.Verbose;
+                Logger.Log(level, "AreaData", $"{i}: {area.SID} - {area.Mode.Length} sides");
 
                 // Update old MapData areas and load any new areas.
 
@@ -389,7 +393,7 @@ namespace Celeste {
                     area.Mode[0].MapData = new patch_MapData(area.ToKey());
 
                 if (area.IsInterludeUnsafe())
-                    continue;
+                    return;
 
                 // A and (some) B sides have PoemIDs. Can be overridden via empty PoemID.
                 if (area.Mode[0].PoemID == null)
@@ -408,6 +412,15 @@ namespace Celeste {
                         area.Mode[mode].MapData.Area = area.ToKey((AreaMode) mode);
                     else
                         area.Mode[mode].MapData = new patch_MapData(area.ToKey((AreaMode) mode));
+                }
+            }
+
+            if (CoreModule.Settings.FastLevelLoading ?? true) {
+                Logger.Info("AreaData", $"Loading map data in parallel");
+                Parallel.For(0, Areas.Count, ProcessMapData);
+            } else {
+                for (int i = 0; i < Areas.Count; i++) {
+                    ProcessMapData(i);
                 }
             }
 

--- a/Celeste.Mod.mm/Patches/AreaData.cs
+++ b/Celeste.Mod.mm/Patches/AreaData.cs
@@ -379,9 +379,8 @@ namespace Celeste {
                         break;
                 }
                 Array.Resize(ref area.Mode, modei);
-
                 // Do not clutter the log if Fast Level Loading is disabled
-                LogLevel level = (CoreModule.Settings.FastLevelLoading ?? true) ? LogLevel.Info : LogLevel.Verbose;
+                LogLevel level = CoreModule.Settings.FastLevelLoading ? LogLevel.Info : LogLevel.Verbose;
                 Logger.Log(level, "AreaData", $"{i}: {area.SID} - {area.Mode.Length} sides");
 
                 // Update old MapData areas and load any new areas.
@@ -415,7 +414,7 @@ namespace Celeste {
                 }
             }
 
-            if (CoreModule.Settings.FastLevelLoading ?? true) {
+            if (CoreModule.Settings.FastLevelLoading) {
                 Logger.Info("AreaData", $"Loading map data in parallel");
                 Parallel.For(0, Areas.Count, ProcessMapData);
             } else {

--- a/Celeste.Mod.mm/Patches/AreaData.cs
+++ b/Celeste.Mod.mm/Patches/AreaData.cs
@@ -380,7 +380,7 @@ namespace Celeste {
                 }
                 Array.Resize(ref area.Mode, modei);
                 // Do not clutter the log if Fast Level Loading is disabled
-                LogLevel level = CoreModule.Settings.FastLevelLoading ? LogLevel.Info : LogLevel.Verbose;
+                LogLevel level = (CoreModule.Settings.FastLevelLoading ?? false) ? LogLevel.Info : LogLevel.Verbose;
                 Logger.Log(level, "AreaData", $"{i}: {area.SID} - {area.Mode.Length} sides");
 
                 // Update old MapData areas and load any new areas.
@@ -414,7 +414,7 @@ namespace Celeste {
                 }
             }
 
-            if (CoreModule.Settings.FastLevelLoading) {
+            if (CoreModule.Settings.FastLevelLoading ?? false) {
                 Logger.Info("AreaData", $"Loading map data in parallel");
                 Parallel.For(0, Areas.Count, ProcessMapData);
             } else {

--- a/Celeste.Mod.mm/Patches/BinaryPacker.cs
+++ b/Celeste.Mod.mm/Patches/BinaryPacker.cs
@@ -9,7 +9,7 @@ using System.Globalization;
 
 namespace Celeste {
     static class patch_BinaryPacker {
-        [MonoModIgnore]
+        [ThreadStatic]
         private static string[] stringLookup;
 
         [MonoModIgnore] // We don't want to change anything about the method...

--- a/Celeste.Mod.mm/Patches/MapData.cs
+++ b/Celeste.Mod.mm/Patches/MapData.cs
@@ -16,6 +16,8 @@ using Celeste.Mod.Helpers;
 namespace Celeste {
     public class patch_MapData : MapData {
 
+        private static readonly object locker = new object();
+
         public bool DetectedCassette;
         public int DetectedStrawberriesIncludingUntracked;
         public List<EntityData> DashlessGoldenberries = new List<EntityData>();
@@ -177,7 +179,9 @@ namespace Celeste {
             if (root.Children.Find(element => element.Name == "meta") is BinaryPacker.Element meta)
                 ProcessMeta(meta);
 
-            new MapDataFixup(this).Process(root);
+            lock (locker) {
+                new MapDataFixup(this).Process(root);
+            }
 
             return root;
         }


### PR DESCRIPTION
This PR implements "Fast Level Loading" (like Fast Texture Loading, but for levels).

In collabs, levels can take a lot of time to load (especially since texture loading times have already been improved).

The implementation uses `Parallel.For` (which uses CPU core count as degree of parallelism), is enabled by default (this could be changed), and logs level loading order (to help diagnose potential issues).

It adds a `ThreadStatic` attribute to `stringLookup` in `BinaryPacker`, so each thread has its own lookup.

It also adds a lock in `MapData`, because map data processors from mods don't expect concurrent access and may fail.

During testing, these changes improved loading times on my end, loading "Strawberry Jam Collab" levels takes about 6 seconds before changes, and about 4 seconds after changes.