### PR TITLE
Change Atlas.FallbackStack to ConcurrentStack to avoid threading-related errors

### DIFF
--- a/Celeste.Mod.mm/Patches/Monocle/Atlas.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Atlas.cs
@@ -7,6 +7,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using MonoMod;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Xml;
@@ -23,7 +24,7 @@ namespace Monocle {
         public Dictionary<string, MTexture> Textures => textures;
         private Dictionary<string, string> links = new Dictionary<string, string>();
         private Dictionary<string, List<MTexture>> orderedTexturesCache;
-        private Stack<MTexture> FallbackStack;
+        private ConcurrentStack<MTexture> FallbackStack;
 
         public MTexture DefaultFallback;
 
@@ -329,8 +330,8 @@ namespace Monocle {
         }
 
         public MTexture GetFallback() {
-            if (FallbackStack != null && FallbackStack.Count > 0)
-                return FallbackStack.Peek();
+            if (FallbackStack != null && FallbackStack.TryPeek(out MTexture texture))
+                return texture;
 
             if (DefaultFallback != null || textures.TryGetValue("__fallback", out DefaultFallback))
                 return DefaultFallback;
@@ -340,12 +341,14 @@ namespace Monocle {
 
         public void PushFallback(MTexture fallback) {
             if (FallbackStack == null)
-                FallbackStack = new Stack<MTexture>();
+                FallbackStack = new ConcurrentStack<MTexture>();
             FallbackStack.Push(fallback);
         }
 
         public MTexture PopFallback() {
-            return FallbackStack.Pop();
+            if (FallbackStack.TryPop(out MTexture texture))
+                return texture;
+            throw new InvalidOperationException("Fallback stack is empty.");
         }
 
         /// <summary>

--- a/Celeste.Mod.mm/Patches/Monocle/Atlas.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/Atlas.cs
@@ -330,7 +330,7 @@ namespace Monocle {
         }
 
         public MTexture GetFallback() {
-            if (FallbackStack != null && FallbackStack.TryPeek(out MTexture texture))
+            if (FallbackStack?.TryPeek(out MTexture texture) ?? false)
                 return texture;
 
             if (DefaultFallback != null || textures.TryGetValue("__fallback", out DefaultFallback))
@@ -340,15 +340,14 @@ namespace Monocle {
         }
 
         public void PushFallback(MTexture fallback) {
-            if (FallbackStack == null)
-                FallbackStack = new ConcurrentStack<MTexture>();
+            FallbackStack ??= new ConcurrentStack<MTexture>();
             FallbackStack.Push(fallback);
         }
 
         public MTexture PopFallback() {
-            if (FallbackStack.TryPop(out MTexture texture))
+            if (FallbackStack?.TryPop(out MTexture texture) ?? false)
                 return texture;
-            throw new InvalidOperationException("Fallback stack is empty.");
+            throw new InvalidOperationException("Fallback stack is empty or has not been created.");
         }
 
         /// <summary>


### PR DESCRIPTION
There's an annoying bug where pushes/pops on `Atlas.FallbackStack` can become unbalanced, which causes very intermittent crashes, and sometimes even makes the game unplayable until a restart. It turns out the root cause is that [`Stack<T>`](https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.stack-1?view=net-8.0) is not thread-safe, and trying to modify it from multiple threads concurrently can leave it in an inconsistent state:

<img height="300" alt="image" src="https://github.com/user-attachments/assets/7021d9b8-5a55-4ed4-a797-efae68fdef18" />

This issue can uncommonly pop up during level loading, since that runs on its own thread. This PR changes the stack to be a [`ConcurrentStack<T>`](https://learn.microsoft.com/en-us/dotnet/api/system.collections.concurrent.concurrentstack-1?view=net-8.0) instead, which is supposed to be thread-safe for purposes like this. 

This should be compatible with existing mods, since Everest only exposes `PushFallback`/`PopFallback` methods and doesn't expose the stack itself. I've tested this on a setup with many mods installed and haven't been able to reproduce the crash (whereas I can fairly easily on current stable), and didn't find any other immediate issues from my brief testing, but my testing hasn't been very exhaustive.

Other considerations:
- I'm not sure how this might impact performance, I didn't notice anything while playing but my PC is pretty good, someone should definitely profile this to make sure the performance is acceptable.
- `ConcurrentStack<T>` doesn't have plain `Peek`/`Pop` methods, only `TryPeek`/`TryPop`. This shouldn't be a big deal, though I'm slightly uncertain about the best thing to do for the failure case in `PopFallback()`. Currently I just have it throw to match current behavior, but maybe there are better ways to handle it? (Also, are there other failure modes other than an empty stack? My code is currently assuming not, but the documentation doesn't really specify.)