### PR TITLE
Implement fast FMOD bank loading

### DIFF
--- a/Celeste.Mod.mm/Mod/Core/CoreModuleSettings.cs
+++ b/Celeste.Mod.mm/Mod/Core/CoreModuleSettings.cs
@@ -162,6 +162,11 @@ namespace Celeste.Mod.Core {
         [SettingNeedsRelaunch]
         [SettingInGame(false)]
         [SettingIgnore] // TODO: Show as advanced setting.
+        public bool? FastFMODBankLoading { get; set; } = null;
+
+        [SettingNeedsRelaunch]
+        [SettingInGame(false)]
+        [SettingIgnore] // TODO: Show as advanced setting.
         public bool? ThreadedGL { get; set; } = null;
 
         [YamlMember(Alias = "FastTextureLoading")]

--- a/Celeste.Mod.mm/Patches/Audio.cs
+++ b/Celeste.Mod.mm/Patches/Audio.cs
@@ -11,9 +11,11 @@ using MonoMod;
 using SDL2;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace Celeste {
     static class patch_Audio {
@@ -106,11 +108,34 @@ namespace Celeste {
 
             // Load any additional banks.
             lock (Everest.Content.Map) {
+                bool nonBlockingLoad = CoreModule.Settings.FastFMODBankLoading ?? true;
+
+                if (nonBlockingLoad) {
+                    Logger.Info("Audio", "Loading FMOD banks in parallel");
+                }
+
                 foreach (ModAsset asset in Everest.Content.Map.Values.Where(asset => asset.Type == typeof(AssetTypeBank))) {
                     if (!ingestedModBankPaths.Contains(asset.PathVirtual)) {
-                        IngestBank(asset);
+                        additionalBanksMapping.Add(asset, IngestBank(asset, nonBlockingLoad));
                     }
                 }
+
+                if (nonBlockingLoad) {
+                    // pool loading state, and do post processing (GUID ingestion)
+                    while (IsAnyBankLoading()) {
+                        Logger.Info("Audio", "Sleeping waiting for bank/sample data to be loaded");
+                        Thread.Sleep(500);
+                    }
+
+                    foreach (ModAsset asset in Everest.Content.Map.Values.Where(asset => asset.Type == typeof(AssetTypeBank))) {
+                        IngestAllGUIDs(asset.PathVirtual);
+                    }
+
+                    CacheAllBanks();
+                }
+
+                ResetBankLoadingState();
+                Logger.Info("Audio", $"Loaded {cachedBankPaths.Count} banks and {cachedModEvents.Count} events");
             }
 
             AudioInitialized = true;
@@ -147,13 +172,63 @@ namespace Celeste {
             ready = false;
         }
 
+        // internal fields relecting bank loading state
+        internal readonly static Dictionary<ModAsset, Bank> additionalBanksMapping = new Dictionary<ModAsset, Bank>();
+        internal readonly static List<ModAsset> conflicts = new List<ModAsset>();
+
+        private static bool IsAnyBankLoading() {
+            foreach ((ModAsset asset, Bank bank) in additionalBanksMapping) {
+                if (conflicts.Contains(asset)) {
+                     // these assets are ignored, they will never be loaded and CheckFMOD will throw
+                    continue;
+                }
+
+                RESULT result = bank.getLoadingState(out LOADING_STATE loadingState);
+                if (result == RESULT.ERR_EVENT_ALREADY_LOADED) {
+                    Logger.Warn("Audio.IngestBank", $"Cannot load {asset.PathVirtual} due to conflicting events!");
+                    conflicts.Add(asset);
+                } else {
+                    result.CheckFMOD();
+                }
+
+                if (loadingState == LOADING_STATE.LOADING) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static void IngestAllGUIDs(string virtualPath) {
+            if (Everest.Content.TryGet<AssetTypeGUIDs>(virtualPath + ".guids", out ModAsset assetGUIDs)) {
+                IngestGUIDs(assetGUIDs);
+            }
+        }
+
+        private static void CacheAllBanks() {
+            foreach ((ModAsset asset, Bank bank) in additionalBanksMapping) {
+                if (!conflicts.Contains(asset)) {
+                    patch_Banks.ModCache[asset] = bank;
+                    bank.getID(out Guid id);
+                    cachedBankPaths[id] = $"bank:/mods/{asset.PathVirtual["Audio/".Length..]}";
+                }
+            }
+        }
+
+        private static void ResetBankLoadingState() {
+            additionalBanksMapping.Clear();
+            conflicts.Clear();
+        }
+
         /// <summary>
         /// Loads an FMOD Bank from the given asset.
         /// </summary>
-        public static Bank IngestBank(ModAsset asset) {
+        public static Bank IngestBank(ModAsset asset, bool nonBlockingLoad = false) {
             if (Everest.Flags.IsHeadless) {
                 return new Bank(IntPtr.Zero);
             }
+
+            LOAD_BANK_FLAGS flags = nonBlockingLoad ? LOAD_BANK_FLAGS.NONBLOCKING : LOAD_BANK_FLAGS.NORMAL;
 
             Logger.Verbose("Audio.IngestBank", asset.PathVirtual);
             ingestedModBankPaths.Add(asset.PathVirtual);
@@ -164,8 +239,7 @@ namespace Celeste {
 
             RESULT loadResult;
             if (CoreModule.Settings.UnpackFMODBanks) {
-                loadResult = system.loadBankFile(asset.GetCachedPath(), LOAD_BANK_FLAGS.NORMAL, out bank);
-
+                loadResult = system.loadBankFile(asset.GetCachedPath(), flags, out bank);
             } else {
                 IntPtr handle;
                 modBankAssets[handle = (IntPtr) (++modBankHandleLast)] = asset;
@@ -181,8 +255,11 @@ namespace Celeste {
                     seekcallback = ModBankSeek
                 };
 
-                loadResult = system.loadBankCustom(info, LOAD_BANK_FLAGS.NORMAL, out bank);
+                loadResult = system.loadBankCustom(info, flags, out bank);
             }
+
+            if (nonBlockingLoad)
+                return bank; // error handling and post-processing will be done in init later
 
             if (loadResult == RESULT.ERR_EVENT_ALREADY_LOADED) {
                 Logger.Warn("Audio.IngestBank", $"Cannot load {asset.PathVirtual} due to conflicting events!");
@@ -421,7 +498,7 @@ namespace Celeste {
         public static void CheckFMOD(this RESULT result)
             => patch_Audio.CheckFmod(result);
 
-        /// <inheritdoc cref="patch_Audio.IngestBank(ModAsset)"/>
+        /// <inheritdoc cref="patch_Audio.IngestBank(ModAsset, bool)"/>
         public static Bank IngestBank(ModAsset asset)
             => patch_Audio.IngestBank(asset);
 

--- a/Celeste.Mod.mm/Patches/Audio.cs
+++ b/Celeste.Mod.mm/Patches/Audio.cs
@@ -114,27 +114,18 @@ namespace Celeste {
                     Logger.Info("Audio", "Loading FMOD banks in parallel");
                 }
 
+                List<KeyValuePair<ModAsset, Bank>> additionalBanksMapping = new List<KeyValuePair<ModAsset, Bank>>();
                 foreach (ModAsset asset in Everest.Content.Map.Values.Where(asset => asset.Type == typeof(AssetTypeBank))) {
                     if (!ingestedModBankPaths.Contains(asset.PathVirtual)) {
-                        additionalBanksMapping.Add(asset, IngestBank(asset, nonBlockingLoad));
+                        additionalBanksMapping.Add(new KeyValuePair<ModAsset, Bank>(asset, IngestBank(asset, nonBlockingLoad)));
                     }
                 }
 
                 if (nonBlockingLoad) {
-                    // pool loading state, and do post processing (GUID ingestion)
-                    while (IsAnyBankLoading()) {
-                        Logger.Info("Audio", "Sleeping waiting for bank/sample data to be loaded");
-                        Thread.Sleep(500);
-                    }
-
-                    foreach (ModAsset asset in Everest.Content.Map.Values.Where(asset => asset.Type == typeof(AssetTypeBank))) {
-                        IngestAllGUIDs(asset.PathVirtual);
-                    }
-
-                    CacheAllBanks();
+                    PoolAndLoadBanksAndEvents(additionalBanksMapping);
                 }
 
-                ResetBankLoadingState();
+                additionalBanksMapping.Clear();
                 Logger.Info("Audio", $"Loaded {cachedBankPaths.Count} banks and {cachedModEvents.Count} events");
             }
 
@@ -172,58 +163,38 @@ namespace Celeste {
             ready = false;
         }
 
-        // internal fields relecting bank loading state
-        internal readonly static Dictionary<ModAsset, Bank> additionalBanksMapping = new Dictionary<ModAsset, Bank>();
-        internal readonly static List<ModAsset> conflicts = new List<ModAsset>();
+        private static void PoolAndLoadBanksAndEvents(List<KeyValuePair<ModAsset, Bank>> additionalBanksMapping) {
+            while (additionalBanksMapping.Count > 0) {
+                // we can't use foreach as we remove elements while iterating
+                for (int i = additionalBanksMapping.Count - 1; i >= 0; i--) {
+                    (ModAsset asset, Bank bank) = additionalBanksMapping[i];
 
-        private static bool IsAnyBankLoading() {
-            foreach ((ModAsset asset, Bank bank) in additionalBanksMapping) {
-                if (conflicts.Contains(asset)) {
-                     // these assets are ignored, they will never be loaded and CheckFMOD will throw
-                    continue;
+                    RESULT result = bank.getLoadingState(out LOADING_STATE loadingState);
+
+                    if (CheckForBankLoadingErrors(result, asset)) {
+                        bank.unload(); // failed asynchronous banks should be released according to FMOD documentation
+                        additionalBanksMapping.RemoveAt(i);
+                    } else if (loadingState != LOADING_STATE.LOADING) {
+                        // assume loading was done correctly
+                        PostProcessBank(bank, asset);
+                        additionalBanksMapping.RemoveAt(i);
+                    }
                 }
 
-                RESULT result = bank.getLoadingState(out LOADING_STATE loadingState);
-                if (result == RESULT.ERR_EVENT_ALREADY_LOADED) {
-                    Logger.Warn("Audio.IngestBank", $"Cannot load {asset.PathVirtual} due to conflicting events!");
-                    conflicts.Add(asset);
-                } else {
-                    result.CheckFMOD();
-                }
-
-                if (loadingState == LOADING_STATE.LOADING) {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        private static void IngestAllGUIDs(string virtualPath) {
-            if (Everest.Content.TryGet<AssetTypeGUIDs>(virtualPath + ".guids", out ModAsset assetGUIDs)) {
-                IngestGUIDs(assetGUIDs);
+                // wait before pooling loading state again
+                Logger.Info("Audio", "Sleeping waiting for bank/sample data to be loaded");
+                Thread.Sleep(100);
             }
         }
 
-        private static void CacheAllBanks() {
-            foreach ((ModAsset asset, Bank bank) in additionalBanksMapping) {
-                if (!conflicts.Contains(asset)) {
-                    patch_Banks.ModCache[asset] = bank;
-                    bank.getID(out Guid id);
-                    cachedBankPaths[id] = $"bank:/mods/{asset.PathVirtual["Audio/".Length..]}";
-                }
-            }
-        }
-
-        private static void ResetBankLoadingState() {
-            additionalBanksMapping.Clear();
-            conflicts.Clear();
-        }
+        // IngestBank(ModAsset) signature kept for ABI compatibility
+        public static Bank IngestBank(ModAsset asset)
+            => IngestBank(asset, false);
 
         /// <summary>
         /// Loads an FMOD Bank from the given asset.
         /// </summary>
-        public static Bank IngestBank(ModAsset asset, bool nonBlockingLoad = false) {
+        public static Bank IngestBank(ModAsset asset, bool nonBlockingLoad) {
             if (Everest.Flags.IsHeadless) {
                 return new Bank(IntPtr.Zero);
             }
@@ -261,22 +232,44 @@ namespace Celeste {
             if (nonBlockingLoad)
                 return bank; // error handling and post-processing will be done in init later
 
-            if (loadResult == RESULT.ERR_EVENT_ALREADY_LOADED) {
-                Logger.Warn("Audio.IngestBank", $"Cannot load {asset.PathVirtual} due to conflicting events!");
+            if (CheckForBankLoadingErrors(loadResult, asset)) {
                 return null;
             }
 
-            loadResult.CheckFMOD();
+            PostProcessBank(bank, asset);
 
+            return bank;
+        }
+
+        /// <summary>
+        /// Check for loading errors.
+        /// <br/>
+        /// Throws if there was an unrecoverable error
+        /// <br/>
+        /// Returns <c>true</c> if events were already loaded
+        /// <br/>
+        /// Returns <c>false</c> if no error was detected
+        /// </summary>
+        private static bool CheckForBankLoadingErrors(RESULT result, ModAsset asset) {
+            if (result == RESULT.ERR_EVENT_ALREADY_LOADED) {
+                Logger.Warn("Audio.IngestBank", $"Cannot load {asset.PathVirtual} due to conflicting events!");
+                return true;
+            } else {
+                result.CheckFMOD();
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Post process the bank (ingest GUIDs and cache it).
+        /// </summary>
+        private static void PostProcessBank(Bank bank, ModAsset asset) {
             if (Everest.Content.TryGet<AssetTypeGUIDs>(asset.PathVirtual + ".guids", out ModAsset assetGUIDs)) {
                 IngestGUIDs(assetGUIDs);
             }
-
             patch_Banks.ModCache[asset] = bank;
-
             bank.getID(out Guid id);
             cachedBankPaths[id] = $"bank:/mods/{asset.PathVirtual["Audio/".Length..]}";
-            return bank;
         }
 
         /// <summary>
@@ -498,7 +491,7 @@ namespace Celeste {
         public static void CheckFMOD(this RESULT result)
             => patch_Audio.CheckFmod(result);
 
-        /// <inheritdoc cref="patch_Audio.IngestBank(ModAsset, bool)"/>
+        /// <inheritdoc cref="patch_Audio.IngestBank(ModAsset)"/>
         public static Bank IngestBank(ModAsset asset)
             => patch_Audio.IngestBank(asset);
 

--- a/Celeste.Mod.mm/Patches/Audio.cs
+++ b/Celeste.Mod.mm/Patches/Audio.cs
@@ -106,28 +106,7 @@ namespace Celeste {
                 }
             }
 
-            // Load any additional banks.
-            lock (Everest.Content.Map) {
-                bool nonBlockingLoad = CoreModule.Settings.FastFMODBankLoading ?? true;
-
-                if (nonBlockingLoad) {
-                    Logger.Info("Audio", "Loading FMOD banks in parallel");
-                }
-
-                List<KeyValuePair<ModAsset, Bank>> additionalBanksMapping = new List<KeyValuePair<ModAsset, Bank>>();
-                foreach (ModAsset asset in Everest.Content.Map.Values.Where(asset => asset.Type == typeof(AssetTypeBank))) {
-                    if (!ingestedModBankPaths.Contains(asset.PathVirtual)) {
-                        additionalBanksMapping.Add(new KeyValuePair<ModAsset, Bank>(asset, IngestBank(asset, nonBlockingLoad)));
-                    }
-                }
-
-                if (nonBlockingLoad) {
-                    PoolAndLoadBanksAndEvents(additionalBanksMapping);
-                }
-
-                additionalBanksMapping.Clear();
-                Logger.Info("Audio", $"Loaded {cachedBankPaths.Count} banks and {cachedModEvents.Count} events");
-            }
+            IngestNewBanks();
 
             AudioInitialized = true;
         }
@@ -138,11 +117,24 @@ namespace Celeste {
             }
 
             lock (Everest.Content.Map) {
+                bool nonBlockingLoad = CoreModule.Settings.FastFMODBankLoading ?? true;
+
+                if (nonBlockingLoad) {
+                    Logger.Info("Audio", "Loading FMOD banks in parallel");
+                }
+
+                List<(ModAsset, Bank)> additionalBanksMapping = new List<(ModAsset, Bank)>();
                 foreach (ModAsset asset in Everest.Content.Map.Values.Where(asset => asset.Type == typeof(AssetTypeBank))) {
                     if (!ingestedModBankPaths.Contains(asset.PathVirtual)) {
-                        IngestBank(asset);
+                        additionalBanksMapping.Add((asset, IngestBank(asset, nonBlockingLoad)));
                     }
                 }
+
+                if (nonBlockingLoad) {
+                    PoolAndLoadBanksAndEvents(additionalBanksMapping);
+                }
+
+                Logger.Info("Audio", $"Loaded {cachedBankPaths.Count} banks and {cachedModEvents.Count} events");
             }
         }
 
@@ -163,7 +155,7 @@ namespace Celeste {
             ready = false;
         }
 
-        private static void PoolAndLoadBanksAndEvents(List<KeyValuePair<ModAsset, Bank>> additionalBanksMapping) {
+        private static void PoolAndLoadBanksAndEvents(List<(ModAsset, Bank)> additionalBanksMapping) {
             while (additionalBanksMapping.Count > 0) {
                 // we can't use foreach as we remove elements while iterating
                 for (int i = additionalBanksMapping.Count - 1; i >= 0; i--) {
@@ -172,7 +164,9 @@ namespace Celeste {
                     RESULT result = bank.getLoadingState(out LOADING_STATE loadingState);
 
                     if (CheckForBankLoadingErrors(result, asset)) {
-                        bank.unload(); // failed asynchronous banks should be released according to FMOD documentation
+                        if (result == RESULT.ERR_EVENT_ALREADY_LOADED) {
+                            bank.unload(); // failed asynchronous banks should be released according to FMOD documentation
+                        }
                         additionalBanksMapping.RemoveAt(i);
                     } else if (loadingState != LOADING_STATE.LOADING) {
                         // assume loading was done correctly
@@ -182,7 +176,6 @@ namespace Celeste {
                 }
 
                 // wait before pooling loading state again
-                Logger.Info("Audio", "Sleeping waiting for bank/sample data to be loaded");
                 Thread.Sleep(100);
             }
         }
@@ -229,8 +222,9 @@ namespace Celeste {
                 loadResult = system.loadBankCustom(info, flags, out bank);
             }
 
-            if (nonBlockingLoad)
+            if (nonBlockingLoad) {
                 return bank; // error handling and post-processing will be done in init later
+            }
 
             if (CheckForBankLoadingErrors(loadResult, asset)) {
                 return null;
@@ -242,21 +236,20 @@ namespace Celeste {
         }
 
         /// <summary>
-        /// Check for loading errors.
+        /// Check for loading errors and log them.
         /// <br/>
-        /// Throws if there was an unrecoverable error
-        /// <br/>
-        /// Returns <c>true</c> if events were already loaded
-        /// <br/>
-        /// Returns <c>false</c> if no error was detected
+        /// Returns <c>true</c> if an error was detected, <c>false</c> otherwise.
         /// </summary>
         private static bool CheckForBankLoadingErrors(RESULT result, ModAsset asset) {
-            if (result == RESULT.ERR_EVENT_ALREADY_LOADED) {
-                Logger.Warn("Audio.IngestBank", $"Cannot load {asset.PathVirtual} due to conflicting events!");
-                return true;
-            } else {
-                result.CheckFMOD();
-                return false;
+            switch (result) {
+                case RESULT.OK:
+                    return false;
+                case RESULT.ERR_EVENT_ALREADY_LOADED:
+                    Logger.Warn("Audio.IngestBank", $"Cannot load {asset.PathVirtual} due to conflicting events!");
+                    return true;
+                default:
+                    Logger.Error("Audio.IngestBank", $"FMOD bank load failed on {asset.PathVirtual}: {result} ({Error.String(result)})");
+                    return true;
             }
         }
 


### PR DESCRIPTION
This PR implements "Fast FMOD Bank Loading" (like Fast Texture Loading, but for FMOD banks).

It relies on a non blocking bank loading API in FMOD.

The implementations loads all banks in parallel using the non blocking API, pool until all banks are loaded, and then do the same post processing of banks.

This implementation was tested against duplicated GUIDs (with duplicated bank files), which logs a warning; and with invalid bank data (with a truncated bank file), which logs an error (previously throwing an exception).

Right now, the non blocking implementation is enabled by default, and loading state is pooled every 100ms.

On my end, this reduced audio loading time when loading the "Strawberry Jam Collab", from about  6 seconds when using blocking loading, to less than 1 second when using non blocking loading.