### PR TITLE
Allow concurrent cutscenes

### DIFF
--- a/.github/tas-check/run-locally.sh
+++ b/.github/tas-check/run-locally.sh
@@ -11,14 +11,14 @@ set -xeo pipefail
 
 case "$1" in
     "Celeste")
-        TAS_URL="https://github.com/VampireFlower/CelesteTAS/archive/0747f018e7c92abcd1bf900bd02d24de2be190e4.zip"
-        TAS_PATH="CelesteTAS-0747f018e7c92abcd1bf900bd02d24de2be190e4/0 - 100%.tas"
+        TAS_URL="https://github.com/VampireFlower/CelesteTAS/archive/49f624c3947d28b60e48cf15d2789b5bb0880931.zip"
+        TAS_PATH="CelesteTAS-49f624c3947d28b60e48cf15d2789b5bb0880931/0 - 100%.tas"
         ;;
 
     "StrawberryJam2021")
-        TAS_URL="https://github.com/VampireFlower/StrawberryJamTAS/archive/39ff44444566e56667df665effce88cf272aef75.zip"
-        TAS_PATH="StrawberryJamTAS-39ff44444566e56667df665effce88cf272aef75/0-SJ All Levels.tas"
-        BUNDLE_DOWNLOAD="https://celestemodupdater.0x0a.de/pinned-mods/StrawberryJam2021-Bundle-d7d15a6d.zip"
+        TAS_URL="https://github.com/VampireFlower/StrawberryJamTAS/archive/c6621edccff1df2aec0531d377a8475ceff55e29.zip"
+        TAS_PATH="StrawberryJamTAS-c6621edccff1df2aec0531d377a8475ceff55e29/0-SJ All Levels.tas"
+        BUNDLE_DOWNLOAD="https://celestemodupdater.0x0a.de/pinned-mods/StrawberryJam2021-Bundle-b55b9595.zip"
         ;;
 
     *)

--- a/.github/workflows/tas-sync-check.yml
+++ b/.github/workflows/tas-sync-check.yml
@@ -10,13 +10,13 @@ jobs:
       matrix:
         tas:
           - name: Celeste 100%
-            url: "https://github.com/VampireFlower/CelesteTAS/archive/0747f018e7c92abcd1bf900bd02d24de2be190e4.zip"
-            path: "CelesteTAS-0747f018e7c92abcd1bf900bd02d24de2be190e4/0 - 100%.tas"
+            url: "https://github.com/VampireFlower/CelesteTAS/archive/49f624c3947d28b60e48cf15d2789b5bb0880931.zip"
+            path: "CelesteTAS-49f624c3947d28b60e48cf15d2789b5bb0880931/0 - 100%.tas"
 
           - name: Strawberry Jam All Levels
-            url: "https://github.com/VampireFlower/StrawberryJamTAS/archive/39ff44444566e56667df665effce88cf272aef75.zip"
-            path: "StrawberryJamTAS-39ff44444566e56667df665effce88cf272aef75/0-SJ All Levels.tas"
-            bundle: "https://celestemodupdater.0x0a.de/pinned-mods/StrawberryJam2021-Bundle-d7d15a6d.zip"
+            url: "https://github.com/VampireFlower/StrawberryJamTAS/archive/c6621edccff1df2aec0531d377a8475ceff55e29.zip"
+            path: "StrawberryJamTAS-c6621edccff1df2aec0531d377a8475ceff55e29/0-SJ All Levels.tas"
+            bundle: "https://celestemodupdater.0x0a.de/pinned-mods/StrawberryJam2021-Bundle-b55b9595.zip"
 
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/Celeste.Mod.mm/Mod/Entities/DialogCutsceneTrigger.cs
+++ b/Celeste.Mod.mm/Mod/Entities/DialogCutsceneTrigger.cs
@@ -58,10 +58,6 @@ namespace Celeste.Mod.Entities {
             if (ignoreIntroState && ((patch_Player) player).IsIntroState)
                 return;
 
-            // don't activate if some dialog is already in progress
-            if (level.Tracker.GetEntity<Textbox>() is not null)
-                return;
-
             triggered = true;
 
             Scene.Add(new DialogCutscene(dialogEntry, player, endLevel));


### PR DESCRIPTION
Follow up on #999, this PR removes the check preventing multiple cutscenes from running concurrently.

Running multiple cutscenes concurrently is usually not desirable for a player/mapper, but it is currently used by TASes.
The consensus right now is to allow this behavior.

This change was tested against [Monika's D-Sides - Trust chapter TAS](https://github.com/fishmcmuffins/D-Sides-TAS/blob/5dfd6183add29cdb392b0041e4ebe778995ad458/9D/9D_10_Trust.tas):
- without this change, there is a desync in the room `hh-01`
- with this change, the TAS runs normally