### PR TITLE
Reset `DepthStencilState` to `None` before `Skybox.Draw`

### DIFF
--- a/Celeste.Mod.mm/Patches/Skybox.cs
+++ b/Celeste.Mod.mm/Patches/Skybox.cs
@@ -16,6 +16,9 @@ namespace Celeste {
         public extern void orig_Draw(Matrix matrix, Color color);
 
         public void Draw(Matrix matrix, Color color) {
+            // the orig method doesn't reset DepthStencilState to None.
+            // Some mods may begin a new SpriteBatch with DepthStencilState set to Default,
+            // which causes the Skybox to be rendered in front of the mountain.
             Engine.Graphics.GraphicsDevice.DepthStencilState = DepthStencilState.None;
             orig_Draw(matrix, color);
         }

--- a/Celeste.Mod.mm/Patches/Skybox.cs
+++ b/Celeste.Mod.mm/Patches/Skybox.cs
@@ -1,0 +1,23 @@
+﻿#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
+#pragma warning disable CS0108 // Member hides inherited member; missing new keyword
+
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Monocle;
+using MonoMod;
+
+namespace Celeste {
+    class patch_Skybox : Skybox {
+
+        public patch_Skybox(VirtualTexture texture, float size = 25) 
+            : base(texture, size) {
+        }
+
+        public extern void orig_Draw(Matrix matrix, Color color);
+
+        public void Draw(Matrix matrix, Color color) {
+            Engine.Graphics.GraphicsDevice.DepthStencilState = DepthStencilState.None;
+            orig_Draw(matrix, color);
+        }
+    }
+}


### PR DESCRIPTION
`Skybox.Draw` doesn't reset `DepthStencilState` to `None`. Some mods may begin a new `SpriteBatch` with `DepthStencilState` set to `Default`(such as [`CelesteTAS`](https://github.com/EverestAPI/CelesteTAS-EverestInterop/blob/6045d9ec1e39eadce2632502dbbe7d878cd9203b/CelesteTAS-EverestInterop/Source/Playback/PopupToast.cs#L84)), which causes the `Skybox` to be rendered in front of the mountain.
This pr resets `DepthStencilState` to `None` before `Skybox.Draw`.
Special thanks to @Qingfeng-UwU for identifying this issue.