### PR TITLE
Add customization for room colors on the debug map

### DIFF
--- a/Celeste.Mod.mm/Patches/LevelData.cs
+++ b/Celeste.Mod.mm/Patches/LevelData.cs
@@ -4,6 +4,7 @@ using Microsoft.Xna.Framework;
 using System;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
+using Monocle;
 using MonoMod;
 using MonoMod.Cil;
 using MonoMod.InlineRT;
@@ -15,6 +16,10 @@ namespace Celeste {
     public class patch_LevelData : LevelData {
 
         public Vector2? DefaultSpawn;
+
+        // custom room color
+        // if null, `EditorColorIndex` will be used to determine the room color
+        public Color? EditorColor;
 
         public patch_LevelData(BinaryPacker.Element data) : base(data) {
             // no-op. MonoMod ignores this - we only need this to make the compiler shut up.
@@ -29,6 +34,9 @@ namespace Celeste {
         [MonoModConstructor]
         public void ctor(BinaryPacker.Element data) {
             orig_ctor(data);
+
+            string color = data.Attr("color");
+            EditorColor = string.IsNullOrEmpty(color) ? null : Calc.HexToColor(color);
         }
 
         private void CheckForDefaultSpawn(BinaryPacker.Element spawn, Vector2 coords) {

--- a/Celeste.Mod.mm/Patches/LevelData.cs
+++ b/Celeste.Mod.mm/Patches/LevelData.cs
@@ -19,7 +19,7 @@ namespace Celeste {
 
         // custom room color
         // if null, `EditorColorIndex` will be used to determine the room color
-        public Color? EditorColor;
+        public Color? CustomEditorColor;
 
         public patch_LevelData(BinaryPacker.Element data) : base(data) {
             // no-op. MonoMod ignores this - we only need this to make the compiler shut up.
@@ -36,7 +36,7 @@ namespace Celeste {
             orig_ctor(data);
 
             string color = data.Attr("color");
-            EditorColor = string.IsNullOrEmpty(color) ? null : Calc.HexToColor(color);
+            CustomEditorColor = string.IsNullOrEmpty(color) ? null : Calc.HexToColor(color);
         }
 
         private void CheckForDefaultSpawn(BinaryPacker.Element spawn, Vector2 coords) {

--- a/Celeste.Mod.mm/Patches/LevelTemplate.cs
+++ b/Celeste.Mod.mm/Patches/LevelTemplate.cs
@@ -12,53 +12,45 @@ using System.Runtime.CompilerServices;
 namespace Celeste.Editor {
     class patch_LevelTemplate : LevelTemplate {
         // expose this private field to our patch
-        private static Color[] fgTilesColor;
+        private static new Color[] fgTilesColor;
+
+        // custom room color
+        // if null, `EditorColorIndex` will be used to determine the room color
+        private Color? editorColor;
+        public Color EditorColor => editorColor ?? fgTilesColor[EditorColorIndex];
         
         public patch_LevelTemplate(LevelData data)
             : base(data) {
             // no-op. MonoMod ignores this - we only need this to make the compiler shut up.
         }
-
-        [MonoModConstructor]
+        
         [MonoModIgnore] // we don't want to change anything in the method...
         [PatchTrackableStrawberryCheck] // except manipulating it with MonoModRules
-        public extern void ctor(LevelData data);
+        public extern void orig_ctor(LevelData data);
+        
+        [MonoModConstructor]
+        public void ctor(LevelData data) {
+            orig_ctor(data);
 
+            editorColor = ((patch_LevelData) data).EditorColor;
+        }
+        
+        [MonoModIgnore]
         [AddLevelTemplateCulling]
         [PatchLevelTemplateRenderContents]
-        [MonoModIgnore]
         public new extern void RenderContents(Camera camera, System.Collections.Generic.List<LevelTemplate> allLevels);
-
-        [AddLevelTemplateCulling]
+        
         [MonoModIgnore]
+        [AddLevelTemplateCulling]
         public new extern void RenderOutline(Camera camera);
-
-        [AddLevelTemplateCulling]
+        
         [MonoModIgnore]
+        [AddLevelTemplateCulling]
         public new extern void RenderHighlight(Camera camera, bool hovered, bool selected);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private bool IsVisible(Camera camera) {
             return CullHelper.IsRectangleVisible(X, Y, Width, Height, camera: camera);
-        }
-
-        // gets the room's color from the editor color index (either directly from the list of colors or by unpacking it)
-        private static Color GetEditorColor(int editorColorIndex) {
-            // fallback for negative indices
-            if (editorColorIndex < 0)
-                return Color.White;
-            
-            // look it up in the list of colors if we can
-            if (editorColorIndex < fgTilesColor.Length)
-                return fgTilesColor[editorColorIndex];
-            
-            // else, unpack the color from the integer
-            // should be in format 0x00RRGGBB (we must leave space for color indices, so we can't use all 32 bits with an alpha channel)
-            uint packedColor = Convert.ToUInt32(editorColorIndex - fgTilesColor.Length);
-            byte red = (byte) (packedColor >> 16 & 0xFF);
-            byte green = (byte) (packedColor >> 8 & 0xFF);
-            byte blue = (byte) (packedColor >> 0 & 0xFF);
-            return new Color(red, green, blue);
         }
     }
 }
@@ -96,15 +88,14 @@ namespace MonoMod {
 
         public static void PatchLevelTemplateRenderContents(ILContext il, CustomAttribute attrib) {
             /*
-             * patch the `fgTilesColor` lookup to use `GetEditorColor` instead
+             * patch the `fgTilesColor` lookup to use `EditorColor` instead
              * ```diff
              * - Draw.Rect(X + solid.X, Y + solid.Y, solid.Width, solid.Height, Dummy ? dummyFgTilesColor : fgTilesColor[EditorColorIndex]);
-             * + Draw.Rect(X + solid.X, Y + solid.Y, solid.Width, solid.Height, Dummy ? dummyFgTilesColor : GetEditorColor(EditorColorIndex));
+             * + Draw.Rect(X + solid.X, Y + solid.Y, solid.Width, solid.Height, Dummy ? dummyFgTilesColor : EditorColor);
              * ```
              */
             
-            FieldDefinition f_LevelTemplate_EditorColorIndex = il.Method.DeclaringType.FindField("EditorColorIndex");
-            MethodDefinition m_LevelTemplate_GetEditorColor = il.Method.DeclaringType.FindMethod("GetEditorColor");
+            MethodDefinition m_LevelTemplate_get_EditorColor = il.Method.DeclaringType.FindMethod("get_EditorColor")!;
             
             ILCursor cursor = new(il);
             
@@ -121,8 +112,7 @@ namespace MonoMod {
                 instr => instr.MatchLdelemAny("Microsoft.Xna.Framework.Color"));
             cursor.RemoveRange(4);
             cursor.EmitLdarg0();
-            cursor.EmitLdfld(f_LevelTemplate_EditorColorIndex);
-            cursor.EmitCall(m_LevelTemplate_GetEditorColor);
+            cursor.EmitCall(m_LevelTemplate_get_EditorColor);
         }
     }
 }

--- a/Celeste.Mod.mm/Patches/LevelTemplate.cs
+++ b/Celeste.Mod.mm/Patches/LevelTemplate.cs
@@ -16,8 +16,8 @@ namespace Celeste.Editor {
 
         // custom room color
         // if null, `EditorColorIndex` will be used to determine the room color
-        private Color? editorColor;
-        public Color EditorColor => editorColor ?? fgTilesColor[EditorColorIndex];
+        public Color? CustomEditorColor;
+        public Color EditorColor => CustomEditorColor ?? fgTilesColor[EditorColorIndex];
         
         public patch_LevelTemplate(LevelData data)
             : base(data) {
@@ -32,7 +32,7 @@ namespace Celeste.Editor {
         public void ctor(LevelData data) {
             orig_ctor(data);
 
-            editorColor = ((patch_LevelData) data).EditorColor;
+            CustomEditorColor = ((patch_LevelData) data).CustomEditorColor;
         }
         
         [MonoModIgnore]

--- a/Celeste.Mod.mm/Patches/LevelTemplate.cs
+++ b/Celeste.Mod.mm/Patches/LevelTemplate.cs
@@ -1,4 +1,5 @@
 ﻿using Celeste.Mod.Helpers;
+using Microsoft.Xna.Framework;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Monocle;
@@ -10,6 +11,9 @@ using System.Runtime.CompilerServices;
 
 namespace Celeste.Editor {
     class patch_LevelTemplate : LevelTemplate {
+        // expose this private field to our patch
+        private static Color[] fgTilesColor;
+        
         public patch_LevelTemplate(LevelData data)
             : base(data) {
             // no-op. MonoMod ignores this - we only need this to make the compiler shut up.
@@ -21,6 +25,7 @@ namespace Celeste.Editor {
         public extern void ctor(LevelData data);
 
         [AddLevelTemplateCulling]
+        [PatchLevelTemplateRenderContents]
         [MonoModIgnore]
         public new extern void RenderContents(Camera camera, System.Collections.Generic.List<LevelTemplate> allLevels);
 
@@ -36,6 +41,24 @@ namespace Celeste.Editor {
         private bool IsVisible(Camera camera) {
             return CullHelper.IsRectangleVisible(X, Y, Width, Height, camera: camera);
         }
+
+        private static Color GetEditorColor(int editorColorIndex) {
+            // fallback for negative indices
+            if (editorColorIndex < 0)
+                return Color.White;
+            
+            // look it up in the list of colors if we can
+            if (editorColorIndex < fgTilesColor.Length)
+                return fgTilesColor[editorColorIndex];
+            
+            // else, unpack the color from the integer
+            // should be in format 0x00RRGGBB (we must leave space for color indices, so we can't use all 32 bits with an alpha channel)
+            uint packedColor = Convert.ToUInt32(editorColorIndex - fgTilesColor.Length);
+            byte red = (byte) (packedColor >> 16 & 0xFF);
+            byte green = (byte) (packedColor >> 8 & 0xFF);
+            byte blue = (byte) (packedColor >> 0 & 0xFF);
+            return new Color(red, green, blue);
+        }
     }
 }
 
@@ -45,6 +68,12 @@ namespace MonoMod {
     /// </summary>
     [MonoModCustomMethodAttribute(nameof(MonoModRules.AddLevelTemplateCulling))]
     class AddLevelTemplateCullingAttribute : Attribute { }
+
+    /// <summary>
+    /// Patch `LevelTemplate.RenderContent` to support custom template colors.
+    /// </summary>
+    [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchLevelTemplateRenderContents))]
+    class PatchLevelTemplateRenderContents : Attribute { }
 
     static partial class MonoModRules {
         public static void AddLevelTemplateCulling(ILContext il, CustomAttribute attrib) {
@@ -62,6 +91,37 @@ namespace MonoMod {
             cursor.Emit(OpCodes.Brtrue, label);
             cursor.Emit(OpCodes.Ret);
             cursor.MarkLabel(label);
+        }
+
+        public static void PatchLevelTemplateRenderContents(ILContext il, CustomAttribute attrib) {
+            /*
+             * patch the `fgTilesColor` lookup to use `GetEditorColor` instead
+             * ```diff
+             * - Draw.Rect(X + solid.X, Y + solid.Y, solid.Width, solid.Height, Dummy ? dummyFgTilesColor : fgTilesColor[EditorColorIndex]);
+             * + Draw.Rect(X + solid.X, Y + solid.Y, solid.Width, solid.Height, Dummy ? dummyFgTilesColor : GetEditorColor(EditorColorIndex));
+             * ```
+             */
+            
+            FieldDefinition f_LevelTemplate_EditorColorIndex = il.Method.DeclaringType.FindField("EditorColorIndex");
+            MethodDefinition m_LevelTemplate_GetEditorColor = il.Method.DeclaringType.FindMethod("GetEditorColor");
+            
+            ILCursor cursor = new(il);
+            
+            /*
+             * IL_0170: ldsfld valuetype [FNA]Microsoft.Xna.Framework.Color[] Celeste.Editor.LevelTemplate::fgTilesColor
+             * IL_0175: ldarg.0
+             * IL_0176: ldfld int32 Celeste.Editor.LevelTemplate::EditorColorIndex
+             * IL_017b: ldelem [FNA]Microsoft.Xna.Framework.Color
+             */
+            cursor.GotoNext(MoveType.Before,
+                instr => instr.MatchLdsfld("Celeste.Editor.LevelTemplate", "fgTilesColor"),
+                instr => instr.MatchLdarg0(),
+                instr => instr.MatchLdfld("Celeste.Editor.LevelTemplate", "EditorColorIndex"),
+                instr => instr.MatchLdelemAny("Microsoft.Xna.Framework.Color"));
+            cursor.RemoveRange(4);
+            cursor.EmitLdarg0();
+            cursor.EmitLdfld(f_LevelTemplate_EditorColorIndex);
+            cursor.EmitCall(m_LevelTemplate_GetEditorColor);
         }
     }
 }

--- a/Celeste.Mod.mm/Patches/LevelTemplate.cs
+++ b/Celeste.Mod.mm/Patches/LevelTemplate.cs
@@ -42,6 +42,7 @@ namespace Celeste.Editor {
             return CullHelper.IsRectangleVisible(X, Y, Width, Height, camera: camera);
         }
 
+        // gets the room's color from the editor color index (either directly from the list of colors or by unpacking it)
         private static Color GetEditorColor(int editorColorIndex) {
             // fallback for negative indices
             if (editorColorIndex < 0)


### PR DESCRIPTION
This PR allows mappers to specify custom room colors on the debug map, instead of only being limited to the small number of hardcoded ones. This is done by adding a new `color` field to `level` elements, which will be used for the room color in the debug map if present.