### PR TITLE
Add TemporarySpriteBatch

### DIFF
--- a/Celeste.Mod.mm/Celeste.Mod.mm.csproj
+++ b/Celeste.Mod.mm/Celeste.Mod.mm.csproj
@@ -5,8 +5,6 @@
     <AssemblyName>Celeste.Mod.mm</AssemblyName>
     <RootNamespace>Celeste</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- C# 13 was introduced with the .NET 9 SDK, and we need .NET 9 to compile MonoMod anyway -->
-    <LangVersion>13</LangVersion>
     <ShouldIncludeNativeLua>false</ShouldIncludeNativeLua>
   </PropertyGroup>
 

--- a/Celeste.Mod.mm/Celeste.Mod.mm.csproj
+++ b/Celeste.Mod.mm/Celeste.Mod.mm.csproj
@@ -5,7 +5,8 @@
     <AssemblyName>Celeste.Mod.mm</AssemblyName>
     <RootNamespace>Celeste</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>11</LangVersion>
+    <!-- C# 13 was introduced with the .NET 9 SDK, and we need .NET 9 to compile MonoMod anyway -->
+    <LangVersion>13</LangVersion>
     <ShouldIncludeNativeLua>false</ShouldIncludeNativeLua>
   </PropertyGroup>
 

--- a/Celeste.Mod.mm/Mod/Helpers/TemporarySpriteBatch.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/TemporarySpriteBatch.cs
@@ -1,8 +1,8 @@
-﻿using System;
-using Microsoft.Xna.Framework;
+﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Monocle;
 using MonoMod.Utils;
+using System.Buffers;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Celeste.Mod.Helpers;
@@ -25,6 +25,11 @@ namespace Celeste.Mod.Helpers;
 /// <seealso cref="TemporarySpriteBatchBuilder"/>
 public ref struct TemporarySpriteBatch
 {
+    // we don't really expect the RenderTargetBinding[] array size to exceed 1,
+    // so a max of 16 seems reasonable
+    private static readonly ArrayPool<RenderTargetBinding> _renderTargetPool
+        = ArrayPool<RenderTargetBinding>.Create(0x10, 50);
+
     /// <summary>
     ///   The <see cref="SpriteSortMode"/> of this <see cref="TemporarySpriteBatch"/>.
     /// </summary>
@@ -179,7 +184,7 @@ public ref struct TemporarySpriteBatch
             int renderTargetCount = graphicsDevice.GetRenderTargetsNoAllocEXT(null);
             if (renderTargetCount > 0)
             {
-                PreviousRenderTargets = new RenderTargetBinding[renderTargetCount];
+                PreviousRenderTargets = _renderTargetPool.Rent(renderTargetCount);
                 graphicsDevice.GetRenderTargetsNoAllocEXT(PreviousRenderTargets);
             }
             CurrentRenderTarget = renderTarget;
@@ -220,6 +225,8 @@ public ref struct TemporarySpriteBatch
             PreviousRasterizerState,
             PreviousCustomEffect,
             PreviousTransformMatrix);
+
+        _renderTargetPool.Return(PreviousRenderTargets, clearArray: true);
     }
 
     private static void GetSpriteBatchFields(

--- a/Celeste.Mod.mm/Mod/Helpers/TemporarySpriteBatch.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/TemporarySpriteBatch.cs
@@ -1,0 +1,244 @@
+﻿using System;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Monocle;
+using MonoMod.Utils;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Celeste.Mod.Helpers;
+
+/// <summary>
+///   A temporary <see cref="SpriteBatch"/>.
+/// </summary>
+/// <remarks>
+///   When constructed, the current <see cref="SpriteBatch"/> properties and <see cref="RenderTarget2D"/> are preserved.
+///   Then, the <see cref="SpriteBatch"/> is ended, the <see cref="RenderTarget2D"/> is swapped if necessary,
+///   and finally the <see cref="SpriteBatch"/> is restarted with the new properties.<br/>
+///   When disposed, the previous <see cref="SpriteBatch"/> properties and <see cref="RenderTarget2D"/> are restored.
+///   <br/>
+///   Useful when interrupting a <see cref="SpriteBatch"/> mid-render to, for example, render a specific entity to a
+///   temporary <see cref="RenderTarget2D"/> while applying a custom shader, all while preserving the previous
+///   configuration.<br/>
+///   <br/>
+///   Note: Restarting a spritebatch flushes it to the GPU, which is costly.
+/// </remarks>
+/// <seealso cref="TemporarySpriteBatchBuilder"/>
+public ref struct TemporarySpriteBatch : IDisposable
+{
+    /// <summary>
+    ///   The <see cref="SpriteSortMode"/> of this <see cref="TemporarySpriteBatch"/>.
+    /// </summary>
+    public readonly SpriteSortMode CurrentSortMode;
+
+    /// <summary>
+    ///   The <see cref="BlendState"/> of this <see cref="TemporarySpriteBatch"/>.
+    /// </summary>
+    [NotNull]
+    public readonly BlendState CurrentBlendState;
+
+    /// <summary>
+    ///   The <see cref="SamplerState"/> of this <see cref="TemporarySpriteBatch"/>.
+    /// </summary>
+    [NotNull]
+    public readonly SamplerState CurrentSamplerState;
+
+    /// <summary>
+    ///   The <see cref="DepthStencilState"/> of this <see cref="TemporarySpriteBatch"/>.
+    /// </summary>
+    [NotNull]
+    public readonly DepthStencilState CurrentDepthStencilState;
+
+    /// <summary>
+    ///   The <see cref="RasterizerState"/> of this <see cref="TemporarySpriteBatch"/>.
+    /// </summary>
+    [NotNull]
+    public readonly RasterizerState CurrentRasterizerState;
+
+    /// <summary>
+    ///   The custom <see cref="Effect"/> of this <see cref="TemporarySpriteBatch"/>.
+    /// </summary>
+    [MaybeNull]
+    public readonly Effect CurrentCustomEffect;
+
+    /// <summary>
+    ///   The transformation <see cref="Matrix"/> of this <see cref="TemporarySpriteBatch"/>.
+    /// </summary>
+    public readonly Matrix CurrentTransformMatrix;
+
+    /// <summary>
+    ///   The <see cref="RenderTarget2D"/> swapped in for the duration of this <see cref="TemporarySpriteBatch"/>
+    ///   or <c>null</c> to draw to the screen if <see cref="HasRenderTarget"/> is <c>true</c>; else always <c>null</c>.
+    /// </summary>
+    [MaybeNull]
+    public readonly RenderTarget2D CurrentRenderTarget;
+
+
+    /// <summary>
+    ///   The <see cref="SpriteSortMode"/> that was used prior to the start of this
+    ///   <see cref="TemporarySpriteBatch"/>.
+    /// </summary>
+    public readonly SpriteSortMode PreviousSortMode;
+
+    /// <summary>
+    ///   The <see cref="BlendState"/> that was used prior to the start of this
+    ///   <see cref="TemporarySpriteBatch"/>.
+    /// </summary>
+    [NotNull]
+    public readonly BlendState PreviousBlendState;
+
+    /// <summary>
+    ///   The <see cref="SamplerState"/> that was used prior to the start of this
+    ///   <see cref="TemporarySpriteBatch"/>.
+    /// </summary>
+    [NotNull]
+    public readonly SamplerState PreviousSamplerState;
+
+    /// <summary>
+    ///   The <see cref="DepthStencilState"/> that was used prior to the start of this
+    ///   <see cref="TemporarySpriteBatch"/>.
+    /// </summary>
+    [NotNull]
+    public readonly DepthStencilState PreviousDepthStencilState;
+
+    /// <summary>
+    ///   The <see cref="RasterizerState"/> that was used prior to the start of this
+    ///   <see cref="TemporarySpriteBatch"/>.
+    /// </summary>
+    [NotNull]
+    public readonly RasterizerState PreviousRasterizerState;
+
+    /// <summary>
+    ///   The custom <see cref="Effect"/> that was used prior to the start of this
+    ///   <see cref="TemporarySpriteBatch"/>.
+    /// </summary>
+    [MaybeNull]
+    public readonly Effect PreviousCustomEffect;
+
+    /// <summary>
+    ///   The transformation <see cref="Matrix"/> that was used prior to the start of this
+    ///   <see cref="TemporarySpriteBatch"/>.
+    /// </summary>
+    public readonly Matrix PreviousTransformMatrix;
+
+    /// <summary>
+    ///   The <see cref="RenderTargetBinding"/>s that were used prior to the start of this <see cref="TemporarySpriteBatch"/>
+    ///   or <c>null</c> to draw to the screen if <see cref="HasRenderTarget"/> is <c>true</c>; else always <c>null</c>.
+    /// </summary>
+    [MaybeNull]
+    public readonly RenderTargetBinding[] PreviousRenderTargets;
+
+
+    /// <summary>
+    ///   Whether a <see cref="RenderTarget2D"/> was swapped in for the duration of this
+    ///   <see cref="TemporarySpriteBatch"/>.
+    /// </summary>
+    public readonly bool HasRenderTarget;
+
+    /// <summary>
+    ///   Whether this <see cref="TemporarySpriteBatch"/> is still active.
+    /// </summary>
+    public bool Active { get; private set; }
+
+
+    /// <summary>
+    ///   Create and immediately begin a new <see cref="TemporarySpriteBatch"/>.
+    /// </summary>
+    /// <seealso cref="TemporarySpriteBatchBuilder"/>
+    internal TemporarySpriteBatch(
+        bool hasSortMode, SpriteSortMode? sortMode,
+        bool hasBlendState, [MaybeNull] BlendState blendState,
+        bool hasSamplerState, [MaybeNull] SamplerState samplerState,
+        bool hasDepthStencilState, [MaybeNull] DepthStencilState depthStencilState,
+        bool hasRasterizerState, [MaybeNull] RasterizerState rasterizerState,
+        bool hasCustomEffect, [MaybeNull] Effect customEffect,
+        bool hasTransformMatrix, Matrix? transformMatrix,
+        bool hasRenderTarget, [MaybeNull] RenderTarget2D renderTarget)
+    {
+        GetSpriteBatchFields(
+            out PreviousSortMode,
+            out PreviousBlendState,
+            out PreviousSamplerState,
+            out PreviousDepthStencilState,
+            out PreviousRasterizerState,
+            out PreviousCustomEffect,
+            out PreviousTransformMatrix);
+
+        CurrentSortMode = hasSortMode ? sortMode!.Value : PreviousSortMode;
+        CurrentBlendState = hasBlendState ? blendState : PreviousBlendState;
+        CurrentSamplerState = hasSamplerState ? samplerState : PreviousSamplerState;
+        CurrentDepthStencilState = hasDepthStencilState ? depthStencilState : PreviousDepthStencilState;
+        CurrentRasterizerState = hasRasterizerState ? rasterizerState : PreviousRasterizerState;
+        CurrentCustomEffect = hasCustomEffect ? customEffect : PreviousCustomEffect;
+        CurrentTransformMatrix = hasTransformMatrix ? transformMatrix!.Value : PreviousTransformMatrix;
+
+        HasRenderTarget = hasRenderTarget;
+
+        GraphicsDevice graphicsDevice = Engine.Graphics.GraphicsDevice;
+        if (hasRenderTarget)
+        {
+            int renderTargetCount = graphicsDevice.GetRenderTargetsNoAllocEXT(null);
+            if (renderTargetCount > 0)
+            {
+                PreviousRenderTargets = new RenderTargetBinding[renderTargetCount];
+                graphicsDevice.GetRenderTargetsNoAllocEXT(PreviousRenderTargets);
+            }
+            CurrentRenderTarget = renderTarget;
+        }
+
+        Active = true;
+        Draw.SpriteBatch.End();
+        if (hasRenderTarget)
+            Engine.Graphics.GraphicsDevice.SetRenderTarget(CurrentRenderTarget);
+        Draw.SpriteBatch.Begin(
+            CurrentSortMode,
+            CurrentBlendState,
+            CurrentSamplerState,
+            CurrentDepthStencilState,
+            CurrentRasterizerState,
+            CurrentCustomEffect,
+            CurrentTransformMatrix);
+    }
+
+    /// <summary>
+    ///   End this <see cref="TemporarySpriteBatch"/>, restore the previous render targets if necessary, and restore
+    ///   the previous <see cref="SpriteBatch"/> properties.
+    /// </summary>
+    public void Dispose()
+    {
+        ObjectDisposedException.ThrowIf(!Active, typeof(TemporarySpriteBatch));
+
+        Active = false;
+        Draw.SpriteBatch.End();
+        if (HasRenderTarget)
+            Engine.Graphics.GraphicsDevice.SetRenderTargets(PreviousRenderTargets);
+        Draw.SpriteBatch.Begin(
+            PreviousSortMode,
+            PreviousBlendState,
+            PreviousSamplerState,
+            PreviousDepthStencilState,
+            PreviousRasterizerState,
+            PreviousCustomEffect,
+            PreviousTransformMatrix);
+    }
+
+    private static void GetSpriteBatchFields(
+        out SpriteSortMode sortMode,
+        [NotNull] out BlendState blendState,
+        [NotNull] out SamplerState samplerState,
+        [NotNull] out DepthStencilState depthStencilState,
+        [NotNull] out RasterizerState rasterizerState,
+        [MaybeNull] out Effect customEffect,
+        out Matrix transformMatrix)
+    {
+        // life would be good if we could just access these directly...
+
+        DynamicData dynData = DynamicData.For(Draw.SpriteBatch);
+        sortMode = dynData.Get<SpriteSortMode>("sortMode");
+        blendState = dynData.Get<BlendState>("blendState");
+        samplerState = dynData.Get<SamplerState>("samplerState");
+        depthStencilState = dynData.Get<DepthStencilState>("depthStencilState");
+        rasterizerState = dynData.Get<RasterizerState>("rasterizerState");
+        customEffect = dynData.Get<Effect>("customEffect");
+        transformMatrix = dynData.Get<Matrix>("transformMatrix");
+    }
+}

--- a/Celeste.Mod.mm/Mod/Helpers/TemporarySpriteBatch.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/TemporarySpriteBatch.cs
@@ -1,9 +1,10 @@
-﻿using Microsoft.Xna.Framework;
+﻿#nullable enable
+
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Monocle;
 using MonoMod.Utils;
 using System.Buffers;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Celeste.Mod.Helpers;
 
@@ -38,32 +39,27 @@ public ref struct TemporarySpriteBatch
     /// <summary>
     ///   The <see cref="BlendState"/> of this <see cref="TemporarySpriteBatch"/>.
     /// </summary>
-    [NotNull]
     public readonly BlendState CurrentBlendState;
 
     /// <summary>
     ///   The <see cref="SamplerState"/> of this <see cref="TemporarySpriteBatch"/>.
     /// </summary>
-    [NotNull]
     public readonly SamplerState CurrentSamplerState;
 
     /// <summary>
     ///   The <see cref="DepthStencilState"/> of this <see cref="TemporarySpriteBatch"/>.
     /// </summary>
-    [NotNull]
     public readonly DepthStencilState CurrentDepthStencilState;
 
     /// <summary>
     ///   The <see cref="RasterizerState"/> of this <see cref="TemporarySpriteBatch"/>.
     /// </summary>
-    [NotNull]
     public readonly RasterizerState CurrentRasterizerState;
 
     /// <summary>
     ///   The custom <see cref="Effect"/> of this <see cref="TemporarySpriteBatch"/>.
     /// </summary>
-    [MaybeNull]
-    public readonly Effect CurrentCustomEffect;
+    public readonly Effect? CurrentCustomEffect;
 
     /// <summary>
     ///   The transformation <see cref="Matrix"/> of this <see cref="TemporarySpriteBatch"/>.
@@ -74,8 +70,7 @@ public ref struct TemporarySpriteBatch
     ///   The <see cref="RenderTarget2D"/> swapped in for the duration of this <see cref="TemporarySpriteBatch"/>
     ///   or <c>null</c> to draw to the screen if <see cref="HasRenderTarget"/> is <c>true</c>; else always <c>null</c>.
     /// </summary>
-    [MaybeNull]
-    public readonly RenderTarget2D CurrentRenderTarget;
+    public readonly RenderTarget2D? CurrentRenderTarget;
 
 
     /// <summary>
@@ -88,36 +83,31 @@ public ref struct TemporarySpriteBatch
     ///   The <see cref="BlendState"/> that was used prior to the start of this
     ///   <see cref="TemporarySpriteBatch"/>.
     /// </summary>
-    [NotNull]
     public readonly BlendState PreviousBlendState;
 
     /// <summary>
     ///   The <see cref="SamplerState"/> that was used prior to the start of this
     ///   <see cref="TemporarySpriteBatch"/>.
     /// </summary>
-    [NotNull]
     public readonly SamplerState PreviousSamplerState;
 
     /// <summary>
     ///   The <see cref="DepthStencilState"/> that was used prior to the start of this
     ///   <see cref="TemporarySpriteBatch"/>.
     /// </summary>
-    [NotNull]
     public readonly DepthStencilState PreviousDepthStencilState;
 
     /// <summary>
     ///   The <see cref="RasterizerState"/> that was used prior to the start of this
     ///   <see cref="TemporarySpriteBatch"/>.
     /// </summary>
-    [NotNull]
     public readonly RasterizerState PreviousRasterizerState;
 
     /// <summary>
     ///   The custom <see cref="Effect"/> that was used prior to the start of this
     ///   <see cref="TemporarySpriteBatch"/>.
     /// </summary>
-    [MaybeNull]
-    public readonly Effect PreviousCustomEffect;
+    public readonly Effect? PreviousCustomEffect;
 
     /// <summary>
     ///   The transformation <see cref="Matrix"/> that was used prior to the start of this
@@ -129,8 +119,7 @@ public ref struct TemporarySpriteBatch
     ///   The <see cref="RenderTargetBinding"/>s that were used prior to the start of this <see cref="TemporarySpriteBatch"/>
     ///   or <c>null</c> to draw to the screen if <see cref="HasRenderTarget"/> is <c>true</c>; else always <c>null</c>.
     /// </summary>
-    [MaybeNull]
-    public readonly RenderTargetBinding[] PreviousRenderTargets;
+    public readonly RenderTargetBinding[]? PreviousRenderTargets;
 
 
     /// <summary>
@@ -151,13 +140,13 @@ public ref struct TemporarySpriteBatch
     /// <seealso cref="TemporarySpriteBatchBuilder"/>
     internal TemporarySpriteBatch(
         SpriteSortMode? sortMode,
-        [MaybeNull] BlendState blendState,
-        [MaybeNull] SamplerState samplerState,
-        [MaybeNull] DepthStencilState depthStencilState,
-        [MaybeNull] RasterizerState rasterizerState,
-        [MaybeNull] Effect customEffect,
+        BlendState? blendState,
+        SamplerState? samplerState,
+        DepthStencilState? depthStencilState,
+        RasterizerState? rasterizerState,
+        Effect? customEffect,
         Matrix? transformMatrix,
-        [MaybeNull] RenderTarget2D renderTarget,
+        RenderTarget2D? renderTarget,
         bool hasCustomEffect,
         bool hasRenderTarget)
     {
@@ -233,21 +222,21 @@ public ref struct TemporarySpriteBatch
 
     private static void GetSpriteBatchFields(
         out SpriteSortMode sortMode,
-        [NotNull] out BlendState blendState,
-        [NotNull] out SamplerState samplerState,
-        [NotNull] out DepthStencilState depthStencilState,
-        [NotNull] out RasterizerState rasterizerState,
-        [MaybeNull] out Effect customEffect,
+        out BlendState blendState,
+        out SamplerState samplerState,
+        out DepthStencilState depthStencilState,
+        out RasterizerState rasterizerState,
+        out Effect? customEffect,
         out Matrix transformMatrix)
     {
         // life would be good if we could just access these directly...
 
         DynamicData dynData = DynamicData.For(Draw.SpriteBatch);
         sortMode = dynData.Get<SpriteSortMode>("sortMode");
-        blendState = dynData.Get<BlendState>("blendState");
-        samplerState = dynData.Get<SamplerState>("samplerState");
-        depthStencilState = dynData.Get<DepthStencilState>("depthStencilState");
-        rasterizerState = dynData.Get<RasterizerState>("rasterizerState");
+        blendState = dynData.Get<BlendState>("blendState")!;
+        samplerState = dynData.Get<SamplerState>("samplerState")!;
+        depthStencilState = dynData.Get<DepthStencilState>("depthStencilState")!;
+        rasterizerState = dynData.Get<RasterizerState>("rasterizerState")!;
         customEffect = dynData.Get<Effect>("customEffect");
         transformMatrix = dynData.Get<Matrix>("transformMatrix");
     }

--- a/Celeste.Mod.mm/Mod/Helpers/TemporarySpriteBatch.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/TemporarySpriteBatch.cs
@@ -150,14 +150,16 @@ public ref struct TemporarySpriteBatch
     /// </summary>
     /// <seealso cref="TemporarySpriteBatchBuilder"/>
     internal TemporarySpriteBatch(
-        bool hasSortMode, SpriteSortMode? sortMode,
-        bool hasBlendState, [MaybeNull] BlendState blendState,
-        bool hasSamplerState, [MaybeNull] SamplerState samplerState,
-        bool hasDepthStencilState, [MaybeNull] DepthStencilState depthStencilState,
-        bool hasRasterizerState, [MaybeNull] RasterizerState rasterizerState,
-        bool hasCustomEffect, [MaybeNull] Effect customEffect,
-        bool hasTransformMatrix, Matrix? transformMatrix,
-        bool hasRenderTarget, [MaybeNull] RenderTarget2D renderTarget)
+        SpriteSortMode? sortMode,
+        [MaybeNull] BlendState blendState,
+        [MaybeNull] SamplerState samplerState,
+        [MaybeNull] DepthStencilState depthStencilState,
+        [MaybeNull] RasterizerState rasterizerState,
+        [MaybeNull] Effect customEffect,
+        Matrix? transformMatrix,
+        [MaybeNull] RenderTarget2D renderTarget,
+        bool hasCustomEffect,
+        bool hasRenderTarget)
     {
         GetSpriteBatchFields(
             out PreviousSortMode,
@@ -168,13 +170,13 @@ public ref struct TemporarySpriteBatch
             out PreviousCustomEffect,
             out PreviousTransformMatrix);
 
-        CurrentSortMode = hasSortMode ? sortMode!.Value : PreviousSortMode;
-        CurrentBlendState = hasBlendState ? blendState : PreviousBlendState;
-        CurrentSamplerState = hasSamplerState ? samplerState : PreviousSamplerState;
-        CurrentDepthStencilState = hasDepthStencilState ? depthStencilState : PreviousDepthStencilState;
-        CurrentRasterizerState = hasRasterizerState ? rasterizerState : PreviousRasterizerState;
+        CurrentSortMode = sortMode ?? PreviousSortMode;
+        CurrentBlendState = blendState ?? PreviousBlendState;
+        CurrentSamplerState = samplerState ?? PreviousSamplerState;
+        CurrentDepthStencilState = depthStencilState ?? PreviousDepthStencilState;
+        CurrentRasterizerState = rasterizerState ?? PreviousRasterizerState;
         CurrentCustomEffect = hasCustomEffect ? customEffect : PreviousCustomEffect;
-        CurrentTransformMatrix = hasTransformMatrix ? transformMatrix!.Value : PreviousTransformMatrix;
+        CurrentTransformMatrix = transformMatrix ?? PreviousTransformMatrix;
 
         HasRenderTarget = hasRenderTarget;
 

--- a/Celeste.Mod.mm/Mod/Helpers/TemporarySpriteBatch.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/TemporarySpriteBatch.cs
@@ -207,7 +207,10 @@ public ref struct TemporarySpriteBatch
         Active = false;
         Draw.SpriteBatch.End();
         if (HasRenderTarget)
+        {
             Engine.Graphics.GraphicsDevice.SetRenderTargets(PreviousRenderTargets);
+            _renderTargetPool.Return(PreviousRenderTargets!, clearArray: true);
+        }
         Draw.SpriteBatch.Begin(
             PreviousSortMode,
             PreviousBlendState,
@@ -216,8 +219,6 @@ public ref struct TemporarySpriteBatch
             PreviousRasterizerState,
             PreviousCustomEffect,
             PreviousTransformMatrix);
-
-        _renderTargetPool.Return(PreviousRenderTargets, clearArray: true);
     }
 
     private static void GetSpriteBatchFields(

--- a/Celeste.Mod.mm/Mod/Helpers/TemporarySpriteBatch.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/TemporarySpriteBatch.cs
@@ -205,7 +205,8 @@ public ref struct TemporarySpriteBatch : IDisposable
     /// </summary>
     public void Dispose()
     {
-        ObjectDisposedException.ThrowIf(!Active, typeof(TemporarySpriteBatch));
+        if (!Active)
+            return;
 
         Active = false;
         Draw.SpriteBatch.End();

--- a/Celeste.Mod.mm/Mod/Helpers/TemporarySpriteBatch.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/TemporarySpriteBatch.cs
@@ -19,8 +19,8 @@ namespace Celeste.Mod.Helpers;
 ///   Useful when interrupting a <see cref="SpriteBatch"/> mid-render to, for example, render a specific entity to a
 ///   temporary <see cref="RenderTarget2D"/> while applying a custom shader, all while preserving the previous
 ///   configuration.<br/>
-///   <br/>
-///   Note: Restarting a spritebatch flushes it to the GPU, which is costly.
+///   <b>Note: Restarting a spritebatch flushes it to the GPU.</b>
+///   While the cost is not that significant, it's best to avoid restarting the spritebatch too often per frame.
 /// </remarks>
 /// <seealso cref="TemporarySpriteBatchBuilder"/>
 public ref struct TemporarySpriteBatch : IDisposable

--- a/Celeste.Mod.mm/Mod/Helpers/TemporarySpriteBatch.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/TemporarySpriteBatch.cs
@@ -23,7 +23,7 @@ namespace Celeste.Mod.Helpers;
 ///   While the cost is not that significant, it's best to avoid restarting the spritebatch too often per frame.
 /// </remarks>
 /// <seealso cref="TemporarySpriteBatchBuilder"/>
-public ref struct TemporarySpriteBatch : IDisposable
+public ref struct TemporarySpriteBatch
 {
     /// <summary>
     ///   The <see cref="SpriteSortMode"/> of this <see cref="TemporarySpriteBatch"/>.

--- a/Celeste.Mod.mm/Mod/Helpers/TemporarySpriteBatchBuilder.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/TemporarySpriteBatchBuilder.cs
@@ -19,53 +19,11 @@ namespace Celeste.Mod.Helpers;
 public sealed class TemporarySpriteBatchBuilder
 {
     /// <summary>
-    ///   Whether the <see cref="SpriteBatch"/>'s
-    ///   <see cref="Microsoft.Xna.Framework.Graphics.SpriteSortMode"/> should be overridden.
-    /// </summary>
-    /// <seealso cref="SortMode"/>
-    public bool HasSortMode { get; private set; }
-
-    /// <summary>
-    ///   Whether the <see cref="SpriteBatch"/>'s
-    ///   <see cref="Microsoft.Xna.Framework.Graphics.BlendState"/> should be overridden.
-    /// </summary>
-    /// <seealso cref="BlendState"/>
-    public bool HasBlendState { get; private set; }
-
-    /// <summary>
-    ///   Whether the <see cref="SpriteBatch"/>'s
-    ///   <see cref="Microsoft.Xna.Framework.Graphics.SamplerState"/> should be overridden.
-    /// </summary>
-    /// <seealso cref="SamplerState"/>
-    public bool HasSamplerState { get; private set; }
-
-    /// <summary>
-    ///   Whether the <see cref="SpriteBatch"/>'s
-    ///   <see cref="Microsoft.Xna.Framework.Graphics.DepthStencilState"/> should be overridden.
-    /// </summary>
-    /// <seealso cref="DepthStencilState"/>
-    public bool HasDepthStencilState { get; private set; }
-
-    /// <summary>
-    ///   Whether the <see cref="SpriteBatch"/>'s
-    ///   <see cref="Microsoft.Xna.Framework.Graphics.RasterizerState"/> should be overridden.
-    /// </summary>
-    /// <seealso cref="RasterizerState"/>
-    public bool HasRasterizerState { get; private set; }
-
-    /// <summary>
     ///   Whether the <see cref="SpriteBatch"/>'s custom
     ///   <see cref="Microsoft.Xna.Framework.Graphics.Effect"/> should be overridden.
     /// </summary>
     /// <seealso cref="CustomEffect"/>
     public bool HasCustomEffect { get; private set; }
-
-    /// <summary>
-    ///   Whether the <see cref="SpriteBatch"/>'s transformation
-    ///   <see cref="Microsoft.Xna.Framework.Matrix"/> should be overridden.
-    /// </summary>
-    /// <seealso cref="TransformMatrix"/>
-    public bool HasTransformMatrix { get; private set; }
 
     /// <summary>
     ///   Whether to swap the current <see cref="Microsoft.Xna.Framework.Graphics.RenderTarget2D"/>
@@ -77,78 +35,62 @@ public sealed class TemporarySpriteBatchBuilder
 
     /// <summary>
     ///   The <see cref="Microsoft.Xna.Framework.Graphics.SpriteSortMode"/> that the new
-    ///   <see cref="SpriteBatch"/> should use.
+    ///   <see cref="SpriteBatch"/> should use, or <c>null</c> if the old value should be preserved.
     /// </summary>
-    /// <remarks>
-    ///    Contains a value when <see cref="HasSortMode"/> is <c>true</c>; <c>null</c> otherwise.
-    /// </remarks>
     public SpriteSortMode? SortMode { get; private set; }
 
     /// <summary>
     ///   The <see cref="Microsoft.Xna.Framework.Graphics.BlendState"/> that the new
-    ///   <see cref="SpriteBatch"/> should use.
+    ///   <see cref="SpriteBatch"/> should use, or <c>null</c> if the old value should be preserved.
     /// </summary>
-    /// <remarks>
-    ///    Contains a value when <see cref="HasBlendState"/> is <c>true</c>; <c>null</c> otherwise.
-    /// </remarks>
     [MaybeNull]
     public BlendState BlendState { get; private set; }
 
     /// <summary>
     ///   The <see cref="Microsoft.Xna.Framework.Graphics.SamplerState"/> that the new
-    ///   <see cref="SpriteBatch"/> should use.
+    ///   <see cref="SpriteBatch"/> should use, or <c>null</c> if the old value should be preserved.
     /// </summary>
-    /// <remarks>
-    ///    Contains a value when <see cref="HasSamplerState"/> is <c>true</c>; <c>null</c> otherwise.
-    /// </remarks>
     [MaybeNull]
     public SamplerState SamplerState { get; private set; }
 
     /// <summary>
     ///   The <see cref="Microsoft.Xna.Framework.Graphics.DepthStencilState"/> that the new
-    ///   <see cref="SpriteBatch"/> should use.
+    ///   <see cref="SpriteBatch"/> should use, or <c>null</c> if the old value should be preserved.
     /// </summary>
-    /// <remarks>
-    ///    Contains a value when <see cref="HasDepthStencilState"/> is <c>true</c>; <c>null</c> otherwise.
-    /// </remarks>
     [MaybeNull]
     public DepthStencilState DepthStencilState { get; private set; }
 
     /// <summary>
     ///   The <see cref="Microsoft.Xna.Framework.Graphics.RasterizerState"/> that the new
-    ///   <see cref="SpriteBatch"/> should use.
+    ///   <see cref="SpriteBatch"/> should use, or <c>null</c> if the old value should be preserved.
     /// </summary>
-    /// <remarks>
-    ///    Contains a value when <see cref="HasRasterizerState"/> is <c>true</c>; <c>null</c> otherwise.
-    /// </remarks>
     [MaybeNull]
     public RasterizerState RasterizerState { get; private set; }
 
     /// <summary>
     ///   The custom <see cref="Microsoft.Xna.Framework.Graphics.Effect"/> that the new
-    ///   <see cref="SpriteBatch"/> should use.
+    ///   <see cref="SpriteBatch"/> should use, or <c>null</c> if no shader should be used.
     /// </summary>
     /// <remarks>
-    ///    Contains a value when <see cref="HasCustomEffect"/> is <c>true</c>; <c>null</c> otherwise.
+    ///    When <see cref="HasCustomEffect"/> is <c>false</c>, the old value will be preserved
+    ///    and this property will always be <c>null</c>.
     /// </remarks>
     [MaybeNull]
     public Effect CustomEffect { get; private set; }
 
     /// <summary>
     ///   The transformation <see cref="Microsoft.Xna.Framework.Matrix"/> that the new
-    ///   <see cref="SpriteBatch"/> should use.
+    ///   <see cref="SpriteBatch"/> should use, or <c>null</c> if the old value should be preserved.
     /// </summary>
-    /// <remarks>
-    ///    Contains a value when <see cref="HasTransformMatrix"/> is <c>true</c>; <c>null</c> otherwise.
-    /// </remarks>
     public Matrix? TransformMatrix { get; private set; }
 
     /// <summary>
     ///   The <see cref="Microsoft.Xna.Framework.Graphics.RenderTarget2D"/> that should be swapped to
-    ///   in-between <see cref="SpriteBatch"/>es.
+    ///   in-between <see cref="SpriteBatch"/>es, or <c>null</c> to render to the screen.
     /// </summary>
     /// <remarks>
-    ///    Contains a value when <see cref="HasRenderTarget"/> is <c>true</c>; <c>null</c> otherwise.
+    ///    When <see cref="HasRenderTarget"/> is <c>false</c>, no render target changes will be done
+    ///    and this property will always be <c>null</c>.
     /// </remarks>
     [MaybeNull]
     public RenderTarget2D RenderTarget { get; private set; }
@@ -164,7 +106,6 @@ public sealed class TemporarySpriteBatchBuilder
     /// </param>
     public TemporarySpriteBatchBuilder WithSortMode(SpriteSortMode sortMode)
     {
-        HasSortMode = true;
         SortMode = sortMode;
         return this;
     }
@@ -177,7 +118,6 @@ public sealed class TemporarySpriteBatchBuilder
     /// </param>
     public TemporarySpriteBatchBuilder WithBlendState([MaybeNull] BlendState blendState)
     {
-        HasBlendState = true;
         BlendState = blendState ?? BlendState.AlphaBlend;
         return this;
     }
@@ -190,7 +130,6 @@ public sealed class TemporarySpriteBatchBuilder
     /// </param>
     public TemporarySpriteBatchBuilder WithSamplerState([MaybeNull] SamplerState samplerState)
     {
-        HasSamplerState = true;
         SamplerState = samplerState ?? SamplerState.LinearClamp;
         return this;
     }
@@ -203,7 +142,6 @@ public sealed class TemporarySpriteBatchBuilder
     /// </param>
     public TemporarySpriteBatchBuilder WithDepthStencilState([MaybeNull] DepthStencilState depthStencilState)
     {
-        HasDepthStencilState = true;
         DepthStencilState = depthStencilState ?? DepthStencilState.None;
         return this;
     }
@@ -216,7 +154,6 @@ public sealed class TemporarySpriteBatchBuilder
     /// </param>
     public TemporarySpriteBatchBuilder WithRasterizerState([MaybeNull] RasterizerState rasterizerState)
     {
-        HasRasterizerState = true;
         RasterizerState = rasterizerState ?? RasterizerState.CullCounterClockwise;
         return this;
     }
@@ -242,7 +179,6 @@ public sealed class TemporarySpriteBatchBuilder
     /// </param>
     public TemporarySpriteBatchBuilder WithTransformMatrix(Matrix transformMatrix)
     {
-        HasTransformMatrix = true;
         TransformMatrix = transformMatrix;
         return this;
     }
@@ -269,13 +205,14 @@ public sealed class TemporarySpriteBatchBuilder
     /// </returns>
     public TemporarySpriteBatch Use()
         => new(
-            HasSortMode, SortMode,
-            HasBlendState, BlendState,
-            HasSamplerState, SamplerState,
-            HasDepthStencilState, DepthStencilState,
-            HasRasterizerState, RasterizerState,
-            HasCustomEffect, CustomEffect,
-            HasTransformMatrix, TransformMatrix,
-            HasRenderTarget, RenderTarget
+            SortMode,
+            BlendState,
+            SamplerState,
+            DepthStencilState,
+            RasterizerState,
+            CustomEffect,
+            TransformMatrix,
+            RenderTarget,
+            HasCustomEffect, HasRenderTarget
         );
 }

--- a/Celeste.Mod.mm/Mod/Helpers/TemporarySpriteBatchBuilder.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/TemporarySpriteBatchBuilder.cs
@@ -1,0 +1,281 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Celeste.Mod.Helpers;
+
+/// <summary>
+///   A <see cref="TemporarySpriteBatch"/> builder.
+/// </summary>
+/// <remarks>
+///   This class lets users configure the creation of a new <see cref="TemporarySpriteBatch"/>, which allows
+///   users to interrupt an existing <see cref="SpriteBatch"/>, optionally swap in a <see cref="RenderTarget2D"/>
+///   and restart the <see cref="SpriteBatch"/> with custom properties.<br/>
+///   When done, the <see cref="SpriteBatch"/> is ended, the previous <see cref="RenderTarget2D"/> is restored and the
+///   old <see cref="SpriteBatch"/> is resumed.<br/>
+///   <br/>
+///   Note: Restarting a spritebatch flushes it to the GPU, which is costly.
+/// </remarks>
+public sealed class TemporarySpriteBatchBuilder
+{
+    /// <summary>
+    ///   Whether the <see cref="SpriteBatch"/>'s
+    ///   <see cref="Microsoft.Xna.Framework.Graphics.SpriteSortMode"/> should be overridden.
+    /// </summary>
+    /// <seealso cref="SortMode"/>
+    public bool HasSortMode { get; private set; }
+
+    /// <summary>
+    ///   Whether the <see cref="SpriteBatch"/>'s
+    ///   <see cref="Microsoft.Xna.Framework.Graphics.BlendState"/> should be overridden.
+    /// </summary>
+    /// <seealso cref="BlendState"/>
+    public bool HasBlendState { get; private set; }
+
+    /// <summary>
+    ///   Whether the <see cref="SpriteBatch"/>'s
+    ///   <see cref="Microsoft.Xna.Framework.Graphics.SamplerState"/> should be overridden.
+    /// </summary>
+    /// <seealso cref="SamplerState"/>
+    public bool HasSamplerState { get; private set; }
+
+    /// <summary>
+    ///   Whether the <see cref="SpriteBatch"/>'s
+    ///   <see cref="Microsoft.Xna.Framework.Graphics.DepthStencilState"/> should be overridden.
+    /// </summary>
+    /// <seealso cref="DepthStencilState"/>
+    public bool HasDepthStencilState { get; private set; }
+
+    /// <summary>
+    ///   Whether the <see cref="SpriteBatch"/>'s
+    ///   <see cref="Microsoft.Xna.Framework.Graphics.RasterizerState"/> should be overridden.
+    /// </summary>
+    /// <seealso cref="RasterizerState"/>
+    public bool HasRasterizerState { get; private set; }
+
+    /// <summary>
+    ///   Whether the <see cref="SpriteBatch"/>'s custom
+    ///   <see cref="Microsoft.Xna.Framework.Graphics.Effect"/> should be overridden.
+    /// </summary>
+    /// <seealso cref="CustomEffect"/>
+    public bool HasCustomEffect { get; private set; }
+
+    /// <summary>
+    ///   Whether the <see cref="SpriteBatch"/>'s transformation
+    ///   <see cref="Microsoft.Xna.Framework.Matrix"/> should be overridden.
+    /// </summary>
+    /// <seealso cref="TransformMatrix"/>
+    public bool HasTransformMatrix { get; private set; }
+
+    /// <summary>
+    ///   Whether to swap the current <see cref="Microsoft.Xna.Framework.Graphics.RenderTarget2D"/>
+    ///   in-between <see cref="SpriteBatch"/>es.
+    /// </summary>
+    /// <seealso cref="RenderTarget"/>
+    public bool HasRenderTarget { get; private set; }
+
+
+    /// <summary>
+    ///   The <see cref="Microsoft.Xna.Framework.Graphics.SpriteSortMode"/> that the new
+    ///   <see cref="SpriteBatch"/> should use.
+    /// </summary>
+    /// <remarks>
+    ///    Contains a value when <see cref="HasSortMode"/> is <c>true</c>; <c>null</c> otherwise.
+    /// </remarks>
+    public SpriteSortMode? SortMode { get; private set; }
+
+    /// <summary>
+    ///   The <see cref="Microsoft.Xna.Framework.Graphics.BlendState"/> that the new
+    ///   <see cref="SpriteBatch"/> should use.
+    /// </summary>
+    /// <remarks>
+    ///    Contains a value when <see cref="HasBlendState"/> is <c>true</c>; <c>null</c> otherwise.
+    /// </remarks>
+    [MaybeNull]
+    public BlendState BlendState { get; private set; }
+
+    /// <summary>
+    ///   The <see cref="Microsoft.Xna.Framework.Graphics.SamplerState"/> that the new
+    ///   <see cref="SpriteBatch"/> should use.
+    /// </summary>
+    /// <remarks>
+    ///    Contains a value when <see cref="HasSamplerState"/> is <c>true</c>; <c>null</c> otherwise.
+    /// </remarks>
+    [MaybeNull]
+    public SamplerState SamplerState { get; private set; }
+
+    /// <summary>
+    ///   The <see cref="Microsoft.Xna.Framework.Graphics.DepthStencilState"/> that the new
+    ///   <see cref="SpriteBatch"/> should use.
+    /// </summary>
+    /// <remarks>
+    ///    Contains a value when <see cref="HasDepthStencilState"/> is <c>true</c>; <c>null</c> otherwise.
+    /// </remarks>
+    [MaybeNull]
+    public DepthStencilState DepthStencilState { get; private set; }
+
+    /// <summary>
+    ///   The <see cref="Microsoft.Xna.Framework.Graphics.RasterizerState"/> that the new
+    ///   <see cref="SpriteBatch"/> should use.
+    /// </summary>
+    /// <remarks>
+    ///    Contains a value when <see cref="HasRasterizerState"/> is <c>true</c>; <c>null</c> otherwise.
+    /// </remarks>
+    [MaybeNull]
+    public RasterizerState RasterizerState { get; private set; }
+
+    /// <summary>
+    ///   The custom <see cref="Microsoft.Xna.Framework.Graphics.Effect"/> that the new
+    ///   <see cref="SpriteBatch"/> should use.
+    /// </summary>
+    /// <remarks>
+    ///    Contains a value when <see cref="HasCustomEffect"/> is <c>true</c>; <c>null</c> otherwise.
+    /// </remarks>
+    [MaybeNull]
+    public Effect CustomEffect { get; private set; }
+
+    /// <summary>
+    ///   The transformation <see cref="Microsoft.Xna.Framework.Matrix"/> that the new
+    ///   <see cref="SpriteBatch"/> should use.
+    /// </summary>
+    /// <remarks>
+    ///    Contains a value when <see cref="HasTransformMatrix"/> is <c>true</c>; <c>null</c> otherwise.
+    /// </remarks>
+    public Matrix? TransformMatrix { get; private set; }
+
+    /// <summary>
+    ///   The <see cref="Microsoft.Xna.Framework.Graphics.RenderTarget2D"/> that should be swapped to
+    ///   in-between <see cref="SpriteBatch"/>es.
+    /// </summary>
+    /// <remarks>
+    ///    Contains a value when <see cref="HasRenderTarget"/> is <c>true</c>; <c>null</c> otherwise.
+    /// </remarks>
+    [MaybeNull]
+    public RenderTarget2D RenderTarget { get; private set; }
+
+
+    // the defaults are the same as the ones in SpriteBatch.Begin
+
+    /// <summary>
+    ///   Override the new <see cref="SpriteBatch"/>'s <see cref="Microsoft.Xna.Framework.Graphics.SpriteSortMode"/>.
+    /// </summary>
+    /// <param name="sortMode">
+    ///   The new sort mode.
+    /// </param>
+    public TemporarySpriteBatchBuilder WithSortMode(SpriteSortMode sortMode)
+    {
+        HasSortMode = true;
+        SortMode = sortMode;
+        return this;
+    }
+
+    /// <summary>
+    ///   Override the new <see cref="SpriteBatch"/>'s <see cref="Microsoft.Xna.Framework.Graphics.BlendState"/>.
+    /// </summary>
+    /// <param name="blendState">
+    ///   The new blend state. If <c>null</c>, defaults to <see cref="Microsoft.Xna.Framework.Graphics.BlendState.AlphaBlend"/>.
+    /// </param>
+    public TemporarySpriteBatchBuilder WithBlendState([MaybeNull] BlendState blendState)
+    {
+        HasBlendState = true;
+        BlendState = blendState ?? BlendState.AlphaBlend;
+        return this;
+    }
+
+    /// <summary>
+    ///   Override the new <see cref="SpriteBatch"/>'s <see cref="Microsoft.Xna.Framework.Graphics.SamplerState"/>.
+    /// </summary>
+    /// <param name="samplerState">
+    ///   The new sampler state. If <c>null</c>, defaults to <see cref="Microsoft.Xna.Framework.Graphics.SamplerState.LinearClamp"/>.
+    /// </param>
+    public TemporarySpriteBatchBuilder WithSamplerState([MaybeNull] SamplerState samplerState)
+    {
+        HasSamplerState = true;
+        SamplerState = samplerState ?? SamplerState.LinearClamp;
+        return this;
+    }
+
+    /// <summary>
+    ///   Override the new <see cref="SpriteBatch"/>'s <see cref="Microsoft.Xna.Framework.Graphics.DepthStencilState"/>.
+    /// </summary>
+    /// <param name="depthStencilState">
+    ///   The new depth stencil state. If <c>null</c>, defaults to <see cref="Microsoft.Xna.Framework.Graphics.DepthStencilState.None"/>.
+    /// </param>
+    public TemporarySpriteBatchBuilder WithDepthStencilState([MaybeNull] DepthStencilState depthStencilState)
+    {
+        HasDepthStencilState = true;
+        DepthStencilState = depthStencilState ?? DepthStencilState.None;
+        return this;
+    }
+
+    /// <summary>
+    ///   Override the new <see cref="SpriteBatch"/>'s <see cref="Microsoft.Xna.Framework.Graphics.RasterizerState"/>.
+    /// </summary>
+    /// <param name="rasterizerState">
+    ///   The new rasterizer state. If <c>null</c>, defaults to <see cref="Microsoft.Xna.Framework.Graphics.RasterizerState.CullCounterClockwise"/>.
+    /// </param>
+    public TemporarySpriteBatchBuilder WithRasterizerState([MaybeNull] RasterizerState rasterizerState)
+    {
+        HasRasterizerState = true;
+        RasterizerState = rasterizerState ?? RasterizerState.CullCounterClockwise;
+        return this;
+    }
+
+    /// <summary>
+    ///   Override the new <see cref="SpriteBatch"/>'s custom <see cref="Microsoft.Xna.Framework.Graphics.Effect"/>.
+    /// </summary>
+    /// <param name="customEffect">
+    ///   The new custom effect or <c>null</c> if none should be used.
+    /// </param>
+    public TemporarySpriteBatchBuilder WithCustomEffect([MaybeNull] Effect customEffect)
+    {
+        HasCustomEffect = true;
+        CustomEffect = customEffect;
+        return this;
+    }
+
+    /// <summary>
+    ///   Override the new <see cref="SpriteBatch"/>'s transformation <see cref="Microsoft.Xna.Framework.Matrix"/>.
+    /// </summary>
+    /// <param name="transformMatrix">
+    ///   The new transformation matrix.
+    /// </param>
+    public TemporarySpriteBatchBuilder WithTransformMatrix(Matrix transformMatrix)
+    {
+        HasTransformMatrix = true;
+        TransformMatrix = transformMatrix;
+        return this;
+    }
+
+    /// <summary>
+    ///   Override the <see cref="RenderTarget2D"/> in-between <see cref="SpriteBatch"/>es.
+    /// </summary>
+    /// <param name="renderTarget">
+    ///   The new render target or <c>null</c> to refer to the screen.
+    /// </param>
+    public TemporarySpriteBatchBuilder WithRenderTarget([MaybeNull] RenderTarget2D renderTarget)
+    {
+        HasRenderTarget = true;
+        RenderTarget = renderTarget;
+        return this;
+    }
+
+    /// <summary>
+    ///   Restart the <see cref="SpriteBatch"/> with the configured properties.
+    /// </summary>
+    /// <returns>
+    ///   A <see cref="TemporarySpriteBatch"/> that will restore the previous <see cref="SpriteBatch"/> properties
+    ///   when disposed. Remember to put it in a <c>using</c> block.
+    /// </returns>
+    public TemporarySpriteBatch Use()
+        => new(
+            HasSortMode, SortMode,
+            HasBlendState, BlendState,
+            HasSamplerState, SamplerState,
+            HasDepthStencilState, DepthStencilState,
+            HasRasterizerState, RasterizerState,
+            HasCustomEffect, CustomEffect,
+            HasTransformMatrix, TransformMatrix,
+            HasRenderTarget, RenderTarget
+        );
+}

--- a/Celeste.Mod.mm/Mod/Helpers/TemporarySpriteBatchBuilder.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/TemporarySpriteBatchBuilder.cs
@@ -1,6 +1,7 @@
-﻿using Microsoft.Xna.Framework;
+﻿#nullable enable
+
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Celeste.Mod.Helpers;
 
@@ -43,29 +44,25 @@ public sealed class TemporarySpriteBatchBuilder
     ///   The <see cref="Microsoft.Xna.Framework.Graphics.BlendState"/> that the new
     ///   <see cref="SpriteBatch"/> should use, or <c>null</c> if the old value should be preserved.
     /// </summary>
-    [MaybeNull]
-    public BlendState BlendState { get; private set; }
+    public BlendState? BlendState { get; private set; }
 
     /// <summary>
     ///   The <see cref="Microsoft.Xna.Framework.Graphics.SamplerState"/> that the new
     ///   <see cref="SpriteBatch"/> should use, or <c>null</c> if the old value should be preserved.
     /// </summary>
-    [MaybeNull]
-    public SamplerState SamplerState { get; private set; }
+    public SamplerState? SamplerState { get; private set; }
 
     /// <summary>
     ///   The <see cref="Microsoft.Xna.Framework.Graphics.DepthStencilState"/> that the new
     ///   <see cref="SpriteBatch"/> should use, or <c>null</c> if the old value should be preserved.
     /// </summary>
-    [MaybeNull]
-    public DepthStencilState DepthStencilState { get; private set; }
+    public DepthStencilState? DepthStencilState { get; private set; }
 
     /// <summary>
     ///   The <see cref="Microsoft.Xna.Framework.Graphics.RasterizerState"/> that the new
     ///   <see cref="SpriteBatch"/> should use, or <c>null</c> if the old value should be preserved.
     /// </summary>
-    [MaybeNull]
-    public RasterizerState RasterizerState { get; private set; }
+    public RasterizerState? RasterizerState { get; private set; }
 
     /// <summary>
     ///   The custom <see cref="Microsoft.Xna.Framework.Graphics.Effect"/> that the new
@@ -75,8 +72,7 @@ public sealed class TemporarySpriteBatchBuilder
     ///    When <see cref="HasCustomEffect"/> is <c>false</c>, the old value will be preserved
     ///    and this property will always be <c>null</c>.
     /// </remarks>
-    [MaybeNull]
-    public Effect CustomEffect { get; private set; }
+    public Effect? CustomEffect { get; private set; }
 
     /// <summary>
     ///   The transformation <see cref="Microsoft.Xna.Framework.Matrix"/> that the new
@@ -92,8 +88,7 @@ public sealed class TemporarySpriteBatchBuilder
     ///    When <see cref="HasRenderTarget"/> is <c>false</c>, no render target changes will be done
     ///    and this property will always be <c>null</c>.
     /// </remarks>
-    [MaybeNull]
-    public RenderTarget2D RenderTarget { get; private set; }
+    public RenderTarget2D? RenderTarget { get; private set; }
 
 
     // the defaults are the same as the ones in SpriteBatch.Begin
@@ -116,7 +111,7 @@ public sealed class TemporarySpriteBatchBuilder
     /// <param name="blendState">
     ///   The new blend state. If <c>null</c>, defaults to <see cref="Microsoft.Xna.Framework.Graphics.BlendState.AlphaBlend"/>.
     /// </param>
-    public TemporarySpriteBatchBuilder WithBlendState([MaybeNull] BlendState blendState)
+    public TemporarySpriteBatchBuilder WithBlendState(BlendState? blendState)
     {
         BlendState = blendState ?? BlendState.AlphaBlend;
         return this;
@@ -128,7 +123,7 @@ public sealed class TemporarySpriteBatchBuilder
     /// <param name="samplerState">
     ///   The new sampler state. If <c>null</c>, defaults to <see cref="Microsoft.Xna.Framework.Graphics.SamplerState.LinearClamp"/>.
     /// </param>
-    public TemporarySpriteBatchBuilder WithSamplerState([MaybeNull] SamplerState samplerState)
+    public TemporarySpriteBatchBuilder WithSamplerState(SamplerState? samplerState)
     {
         SamplerState = samplerState ?? SamplerState.LinearClamp;
         return this;
@@ -140,7 +135,7 @@ public sealed class TemporarySpriteBatchBuilder
     /// <param name="depthStencilState">
     ///   The new depth stencil state. If <c>null</c>, defaults to <see cref="Microsoft.Xna.Framework.Graphics.DepthStencilState.None"/>.
     /// </param>
-    public TemporarySpriteBatchBuilder WithDepthStencilState([MaybeNull] DepthStencilState depthStencilState)
+    public TemporarySpriteBatchBuilder WithDepthStencilState(DepthStencilState? depthStencilState)
     {
         DepthStencilState = depthStencilState ?? DepthStencilState.None;
         return this;
@@ -152,7 +147,7 @@ public sealed class TemporarySpriteBatchBuilder
     /// <param name="rasterizerState">
     ///   The new rasterizer state. If <c>null</c>, defaults to <see cref="Microsoft.Xna.Framework.Graphics.RasterizerState.CullCounterClockwise"/>.
     /// </param>
-    public TemporarySpriteBatchBuilder WithRasterizerState([MaybeNull] RasterizerState rasterizerState)
+    public TemporarySpriteBatchBuilder WithRasterizerState(RasterizerState? rasterizerState)
     {
         RasterizerState = rasterizerState ?? RasterizerState.CullCounterClockwise;
         return this;
@@ -164,7 +159,7 @@ public sealed class TemporarySpriteBatchBuilder
     /// <param name="customEffect">
     ///   The new custom effect or <c>null</c> if none should be used.
     /// </param>
-    public TemporarySpriteBatchBuilder WithCustomEffect([MaybeNull] Effect customEffect)
+    public TemporarySpriteBatchBuilder WithCustomEffect(Effect? customEffect)
     {
         HasCustomEffect = true;
         CustomEffect = customEffect;
@@ -189,7 +184,7 @@ public sealed class TemporarySpriteBatchBuilder
     /// <param name="renderTarget">
     ///   The new render target or <c>null</c> to refer to the screen.
     /// </param>
-    public TemporarySpriteBatchBuilder WithRenderTarget([MaybeNull] RenderTarget2D renderTarget)
+    public TemporarySpriteBatchBuilder WithRenderTarget(RenderTarget2D? renderTarget)
     {
         HasRenderTarget = true;
         RenderTarget = renderTarget;

--- a/Celeste.Mod.mm/Mod/Helpers/TemporarySpriteBatchBuilder.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/TemporarySpriteBatchBuilder.cs
@@ -13,8 +13,8 @@ namespace Celeste.Mod.Helpers;
 ///   and restart the <see cref="SpriteBatch"/> with custom properties.<br/>
 ///   When done, the <see cref="SpriteBatch"/> is ended, the previous <see cref="RenderTarget2D"/> is restored and the
 ///   old <see cref="SpriteBatch"/> is resumed.<br/>
-///   <br/>
-///   Note: Restarting a spritebatch flushes it to the GPU, which is costly.
+///   <b>Note: Restarting a spritebatch flushes it to the GPU.</b>
+///   While the cost is not that significant, it's best to avoid restarting the spritebatch too often per frame.
 /// </remarks>
 public sealed class TemporarySpriteBatchBuilder
 {


### PR DESCRIPTION
Adds a helper `TemporarySpriteBatch` type to easily interrupt an existing `SpriteBatch`, optionally swap in a `RenderTarget2D`, and start a new `SpriteBatch`.
When disposed, the new `SpriteBatch` is ended, the old `RenderTarget2D` is restored and the previous `SpriteBatch` is resumed.

~~Also bumps the language version to C# 13, as this is necessary for ref structs to implement interfaces.~~
~~We already need .NET 9 to compile Everest, so we might as well make use of C# 13.~~

**EDIT**: Implicitly implementing `IDisposable` lets us go back to `<LangVersion>` 12, so the version bump isn't necessary. Ideally we should implement `IDisposable` but this will work for now, until we jump to .NET 10.