### PR TITLE
make animationSpeed decalregistry handler accept floats

### DIFF
--- a/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/AnimationSpeedDecalRegistryHandler.cs
+++ b/Celeste.Mod.mm/Mod/Registry/DecalRegistryHandlers/AnimationSpeedDecalRegistryHandler.cs
@@ -1,14 +1,14 @@
 ﻿using System.Xml;
 
-namespace Celeste.Mod.Registry.DecalRegistryHandlers; 
+namespace Celeste.Mod.Registry.DecalRegistryHandlers;
 
 internal sealed class AnimationSpeedDecalRegistryHandler : DecalRegistryHandler {
-    private int? _value;
-    
+    private float? _value;
+
     public override string Name => "animationSpeed";
-    
+
     public override void Parse(XmlAttributeCollection xml) {
-        _value = GetNullable<int>(xml, "value");
+        _value = GetNullable<float>(xml, "value");
     }
 
     public override void ApplyTo(Decal decal) {


### PR DESCRIPTION
the underlying field is a `float`, so the handler should also accept floats

also fixed some whitespace