### PR TITLE
Support ctrl+backspace in OuiMapSearch

### DIFF
--- a/Celeste.Mod.mm/Mod/UI/OuiMapSearch.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiMapSearch.cs
@@ -175,7 +175,12 @@ namespace Celeste.Mod.UI {
             } else if (c == (char) 8) {
                 // Backspace - trim.
                 if (search.Length > 0) {
-                    search = search.Substring(0, search.Length - 1);
+                    if (MInput.Keyboard.CurrentState.IsKeyDown(Keys.LeftControl)
+                    || MInput.Keyboard.CurrentState.IsKeyDown(Keys.RightControl)) {
+                        search = "";
+                    } else {
+                        search = search.Substring(0, search.Length - 1);
+                    }
                     Audio.Play(SFX.ui_main_rename_entry_backspace);
                     goto ValidButton;
                 } else {

--- a/Celeste.Mod.mm/Mod/UI/OuiMapSearch.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiMapSearch.cs
@@ -177,7 +177,11 @@ namespace Celeste.Mod.UI {
                 if (search.Length > 0) {
                     if (MInput.Keyboard.CurrentState.IsKeyDown(Keys.LeftControl)
                     || MInput.Keyboard.CurrentState.IsKeyDown(Keys.RightControl)) {
-                        search = "";
+                        int idx = search.Length - 1;
+                        while (idx >= 0 && char.IsWhiteSpace(search[idx])) idx--;
+                        while (idx >= 0 && !char.IsWhiteSpace(search[idx])) idx--;
+                        search = search.Substring(0, idx+1);
+                        
                     } else {
                         search = search.Substring(0, search.Length - 1);
                     }


### PR DESCRIPTION
When removing text in the `OuiMapSearch`, allow to press the `Ctrl` key to clear the remaining text. 

Closes #1062.