### PR TITLE
Fix wrongly used `value` in enum handling in the settings menu

### DIFF
--- a/Celeste.Mod.mm/Mod/Module/EverestModule.cs
+++ b/Celeste.Mod.mm/Mod/Module/EverestModule.cs
@@ -753,6 +753,7 @@ namespace Celeste.Mod {
                     for (int i = 0; i < enumValues.Length; i++) {
                         if (enumValues.GetValue(i).Equals(value)) {
                             valueIndex = i;
+                            break;
                         }
                     }
                     string enumNamePrefix = $"{nameDefaultPrefix}{prop.Name.ToLowerInvariant()}_";

--- a/Celeste.Mod.mm/Mod/Module/EverestModule.cs
+++ b/Celeste.Mod.mm/Mod/Module/EverestModule.cs
@@ -746,10 +746,15 @@ namespace Celeste.Mod {
                             );
                         });
                 }
-                else if (propType.IsEnum)
-                {
+                else if (propType.IsEnum) {
                     Array enumValues = Enum.GetValues(propType);
-                    Array.Sort((int[]) enumValues);
+                    Array.Sort(enumValues);
+                    int valueIndex = 0; // Default to the first option if the value is not found
+                    for (int i = 0; i < enumValues.Length; i++) {
+                        if (enumValues.GetValue(i).Equals(value)) {
+                            valueIndex = i;
+                        }
+                    }
                     string enumNamePrefix = $"{nameDefaultPrefix}{prop.Name.ToLowerInvariant()}_";
                     item =
                         new TextMenu.Slider(name, (i) => {
@@ -758,8 +763,8 @@ namespace Celeste.Mod {
                                 $"{enumNamePrefix}{enumName.ToLowerInvariant()}".DialogCleanOrNull() ??
                                 $"modoptions_{propType.Name.ToLowerInvariant()}_{enumName.ToLowerInvariant()}".DialogCleanOrNull() ??
                                 enumName;
-                        }, 0, enumValues.Length - 1, (int) value)
-                        .Change(v => prop.SetValue(settingsObject, v));
+                        }, 0, enumValues.Length - 1, valueIndex)
+                        .Change(v => prop.SetValue(settingsObject, enumValues.GetValue(v)));
                 }
                 else if (propType == typeof(string))
                 {


### PR DESCRIPTION
The default handling of `Enum` as a setting mixed the value and the index of the value, causing enums which do not have the values auto assigned in c# to misbehave.
This was first reported with an enum like following:
```c#
public enum MyEnum {
    Option1 = 0x1,
    Option2 = 0xff,
}

public MyEnum MyEnumSetting { get; set; } = MyEnum.Option2;
```
where the settings menu showed `Option1` right after adding the setting to the class. This is due to mixing an internal index with the enum value.
Furthermore, it also saved the wrong values in the yaml, due to it using the internal index, rather than the proper value associated with the selected enum value. 