### PR TITLE
Prevent inlining of Player.RefillStamina

### DIFF
--- a/Celeste.Mod.mm/Patches/Player.cs
+++ b/Celeste.Mod.mm/Patches/Player.cs
@@ -340,6 +340,10 @@ namespace Celeste {
         [MonoModIgnore]
         [ForceNoInlining]
         private extern ParticleType DustParticleFromSurfaceIndex(int index);
+
+        [MonoModIgnore]
+        [ForceNoInlining]
+        private new extern void RefillStamina();
     }
 
     public static class PlayerExt {


### PR DESCRIPTION
`On.Celeste.Player.RefillStamina` seems to be a frequent enough use case... and with how the method is literally `Stamina = 110f;`, it's easily getting inlined _and_ it's not automatically slapped with NoInlining. I ran into inlining issues with Extended Variants, and the force-no-inlining-at-runtime method didn't help.