### PR TITLE
Allow different cutscenes to play at the same time

### DIFF
--- a/Celeste.Mod.mm/Mod/Entities/DialogCutscene.cs
+++ b/Celeste.Mod.mm/Mod/Entities/DialogCutscene.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 
 namespace Celeste.Mod.Entities {
+    [Tracked]
     public class DialogCutscene : CutsceneEntity {
 
         private Player player;
@@ -43,6 +44,13 @@ namespace Celeste.Mod.Entities {
                 player.StateMachine.State = Player.StDummy;
                 RemoveSelf();
             }
+        }
+
+        public static bool IsInProgress(string dialogID) {
+            foreach (DialogCutscene dialogCutscene in Engine.Scene.Tracker.GetEntities<DialogCutscene>()) {
+                if (dialogCutscene.dialogID == dialogID) return true;
+            }
+            return false;
         }
 
     }

--- a/Celeste.Mod.mm/Mod/Entities/DialogCutsceneTrigger.cs
+++ b/Celeste.Mod.mm/Mod/Entities/DialogCutsceneTrigger.cs
@@ -58,8 +58,8 @@ namespace Celeste.Mod.Entities {
             if (ignoreIntroState && ((patch_Player) player).IsIntroState)
                 return;
 
-            // don't activate if some dialog is already in progress
-            if (level.Tracker.GetEntity<Textbox>() is not null)
+            // don't activate if the same dialog is already in progress
+            if (DialogCutscene.IsInProgress(dialogEntry))
                 return;
 
             triggered = true;

--- a/Celeste.Mod.mm/Mod/Entities/DialogCutsceneTrigger.cs
+++ b/Celeste.Mod.mm/Mod/Entities/DialogCutsceneTrigger.cs
@@ -1,40 +1,77 @@
-﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework;
+using Monocle;
 
 namespace Celeste.Mod.Entities {
+    [Tracked]
     [CustomEntity("everest/dialogTrigger", "dialog/dialogtrigger", "cavern/dialogtrigger")]
     public class DialogCutsceneTrigger : Trigger {
 
         private string dialogEntry;
         private bool triggered;
         private EntityID id;
-        private bool onlyOnce;
+        private bool noRespawnAfterUse;
+        private bool triggerOnlyOnce;
+        private bool ignoreIntroState;
         private bool endLevel;
         private int deathCount;
 
         public DialogCutsceneTrigger(EntityData data, Vector2 offset, EntityID entId)
             : base(data, offset) {
             dialogEntry = data.Attr("dialogId");
-            onlyOnce = data.Bool("onlyOnce", true);
+            noRespawnAfterUse = data.Bool("onlyOnce", true); // don't rename the EntityData name for backwards compat
+            triggerOnlyOnce = data.Bool("triggerOnlyOnce", true);
+            ignoreIntroState = data.Bool("ignoreIntroState", false);
             endLevel = data.Bool("endLevel", false);
             deathCount = data.Int("deathCount", -1);
             triggered = false;
             id = entId;
         }
 
+        // do not remove OnEnter! doing so will break maps that rely on third-party triggers to start dialog cutscenes.
+        // vanilla naturally calls OnEnter and OnStay in the same frame when entering the trigger,
+        // which would mean that we don't need the OnEnter method.
+        // however, sj's "in filtration" uses a Trigger Trigger (CrystallineHelper) to start a dialog cutscene;
+        // it only calls OnEnter and not OnStay, so removing OnEnter will make the dialog not appear and cause a tas desync!
         public override void OnEnter(Player player) {
-            if (triggered || (Scene as Level).Session.GetFlag("DoNotLoad" + id) ||
-                (deathCount >= 0 && SceneAs<Level>().Session.DeathsInCurrentLevel != deathCount)) {
+            TriggerCutscene(player);
+        }
 
+        public override void OnStay(Player player) {
+            TriggerCutscene(player);
+        }
+
+        public override void OnLeave(Player player) {
+            if (!triggerOnlyOnce)
+                triggered = false;
+        }
+
+        private void TriggerCutscene(Player player) {
+            if (Scene is not Level level)
                 return;
-            }
+
+            if (triggered)
+                return;
+
+            if (deathCount >= 0 && level.Session.DeathsInCurrentLevel != deathCount)
+                return;
+
+            if (ignoreIntroState && ((patch_Player) player).IsIntroState)
+                return;
+
+            // don't activate if some dialog is already in progress
+            if (level.Tracker.GetEntity<Textbox>() is not null)
+                return;
 
             triggered = true;
 
             Scene.Add(new DialogCutscene(dialogEntry, player, endLevel));
 
-            if (onlyOnce)
-                (Scene as Level).Session.SetFlag("DoNotLoad" + id, true); // Sets flag to not load
+            if (noRespawnAfterUse) {
+                // this flag is unused in vanilla and Everest, but mods may still make use of it,
+                // so it remains here for backwards compatibility
+                level.Session.SetFlag("DoNotLoad" + id, true);
+                level.Session.DoNotLoad.Add(id);
+            }
         }
-
     }
 }


### PR DESCRIPTION
The whole reason why #999 is held in beta since forever (4 months? wow) is that triggering multiple cutscenes at once was used... by TASers I think? The compromise is to block triggering of the cutscene if _a duplicate of it_ (as in, the same dialog, unless I missed something) is already running, not if _any_ cutscene is running.