### PR TITLE
prevent `ParticleType` instances from being kept alive forever

### DIFF
--- a/Celeste.Mod.mm/Patches/Monocle/ParticleType.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/ParticleType.cs
@@ -1,0 +1,41 @@
+using MonoMod;
+using System;
+using System.Collections.Generic;
+using Mono.Cecil;
+using MonoMod.Cil;
+
+namespace Monocle {
+    class patch_ParticleType : ParticleType
+    {
+        [Obsolete("Unused. ParticleType instances are not added automatically.")]
+        private static List<ParticleType> AllTypes;
+
+        [MonoModIgnore]
+        [MonoModConstructor]
+        [PatchParticleTypeCtor]
+        public extern void ctor();
+
+        [MonoModIgnore]
+        [MonoModConstructor]
+        [PatchParticleTypeCtor]
+        public extern void ctor(ParticleType copyFrom);
+    }
+}
+
+namespace MonoMod {
+    /// <summary>
+    ///   Patches the <see cref="Monocle.ParticleType"/> constructor to prevent it from adding all instances to an unused static list, which would keep them all alive forever.
+    /// </summary>
+    [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchParticleTypeCtor))]
+    class PatchParticleTypeCtorAttribute : Attribute { }
+
+    static partial class MonoModRules {
+        public static void PatchParticleTypeCtor(ILContext context, CustomAttribute attrib) {
+            ILCursor cursor = new(context);
+
+            // remove the `AllTypes.Add(this);` call
+            cursor.GotoNext(MoveType.Before, instr => instr.MatchLdsfld("Monocle.ParticleType", "AllTypes"));
+            cursor.RemoveRange(3);
+        }
+    }
+}


### PR DESCRIPTION
Currently, the constructors for `Monocle.ParticleType` add all created instances to a private static `AllTypes` list, which is never used anywhere else. While this is fine in vanilla, this causes minor issues for mods which create new `ParticleType`s on the fly (e.g. to allow customization through `EntityData`, etc), as all created instances will be kept alive forever.

This PR fixes this by removing the `AllTypes.Add(this)` calls from both constructors, and also applies an `[Obsolete]` attribute to the list itself.