### PR TITLE
Fall back to mirrors on any exception when downloading mods

### DIFF
--- a/Celeste.Mod.mm/Mod/UI/AutoModUpdater.cs
+++ b/Celeste.Mod.mm/Mod/UI/AutoModUpdater.cs
@@ -9,7 +9,6 @@ using System.IO;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Security.Authentication;
 
 namespace Celeste.Mod.UI {
     public class AutoModUpdater : Scene {
@@ -143,7 +142,7 @@ namespace Celeste.Mod.UI {
                             ModUpdaterHelper.VerifyChecksum(update, zipPath);
 
                             break; // out of the loop
-                        } catch (Exception e) when (e is WebException or TimeoutException or IOException or AuthenticationException) {
+                        } catch (Exception e) {
                             downloadException = e;
                             Logger.Warn("AutoModUpdater", $"Download from {url} failed, trying another mirror");
                             Logger.LogDetailed(e);

--- a/Celeste.Mod.mm/Mod/UI/AutoModUpdater.cs
+++ b/Celeste.Mod.mm/Mod/UI/AutoModUpdater.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Security.Authentication;
 
 namespace Celeste.Mod.UI {
     public class AutoModUpdater : Scene {
@@ -142,7 +143,7 @@ namespace Celeste.Mod.UI {
                             ModUpdaterHelper.VerifyChecksum(update, zipPath);
 
                             break; // out of the loop
-                        } catch (Exception e) when (e is WebException or TimeoutException or IOException) {
+                        } catch (Exception e) when (e is WebException or TimeoutException or IOException or AuthenticationException) {
                             downloadException = e;
                             Logger.Warn("AutoModUpdater", $"Download from {url} failed, trying another mirror");
                             Logger.LogDetailed(e);

--- a/Celeste.Mod.mm/Mod/UI/OuiDependencyDownloader.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiDependencyDownloader.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Security.Authentication;
 
 namespace Celeste.Mod.UI {
     class OuiDependencyDownloader : OuiLoggedProgress {
@@ -475,7 +474,7 @@ namespace Celeste.Mod.UI {
                         LogLine(Dialog.Clean("DEPENDENCYDOWNLOADER_VERIFYING_CHECKSUM"));
                         ModUpdaterHelper.VerifyChecksum(mod, downloadDestination);
                         break; // out of the loop
-                    } catch (Exception e) when (e is WebException or TimeoutException or IOException or AuthenticationException) {
+                    } catch (Exception e) {
                         downloadException = e;
                         Logger.Warn("OuiDependencyDownloader", $"Download failed, trying another mirror");
                         Logger.LogDetailed(e);

--- a/Celeste.Mod.mm/Mod/UI/OuiDependencyDownloader.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiDependencyDownloader.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Security.Authentication;
 
 namespace Celeste.Mod.UI {
     class OuiDependencyDownloader : OuiLoggedProgress {
@@ -474,7 +475,7 @@ namespace Celeste.Mod.UI {
                         LogLine(Dialog.Clean("DEPENDENCYDOWNLOADER_VERIFYING_CHECKSUM"));
                         ModUpdaterHelper.VerifyChecksum(mod, downloadDestination);
                         break; // out of the loop
-                    } catch (Exception e) when (e is WebException or TimeoutException or IOException) {
+                    } catch (Exception e) when (e is WebException or TimeoutException or IOException or AuthenticationException) {
                         downloadException = e;
                         Logger.Warn("OuiDependencyDownloader", $"Download failed, trying another mirror");
                         Logger.LogDetailed(e);

--- a/Celeste.Mod.mm/Mod/UI/OuiModUpdateList.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiModUpdateList.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Threading.Tasks;
+using System.Security.Authentication;
 
 namespace Celeste.Mod.UI {
     class OuiModUpdateList : Oui, OuiModOptions.ISubmenu {
@@ -360,7 +361,7 @@ namespace Celeste.Mod.UI {
 
                     ModUpdaterHelper.VerifyChecksum(update, zipPath);
                     break; // out of the loop
-                } catch (Exception e) when (e is WebException or TimeoutException) {
+                } catch (Exception e) when (e is WebException or TimeoutException or IOException or AuthenticationException) {
                     downloadException = e;
                     Logger.Warn("OuiModUpdateList", $"Download from {url} failed, trying another mirror.");
                     Logger.LogDetailed(e);

--- a/Celeste.Mod.mm/Mod/UI/OuiModUpdateList.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiModUpdateList.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Threading.Tasks;
-using System.Security.Authentication;
 
 namespace Celeste.Mod.UI {
     class OuiModUpdateList : Oui, OuiModOptions.ISubmenu {
@@ -361,7 +360,7 @@ namespace Celeste.Mod.UI {
 
                     ModUpdaterHelper.VerifyChecksum(update, zipPath);
                     break; // out of the loop
-                } catch (Exception e) when (e is WebException or TimeoutException or IOException or AuthenticationException) {
+                } catch (Exception e) {
                     downloadException = e;
                     Logger.Warn("OuiModUpdateList", $"Download from {url} failed, trying another mirror.");
                     Logger.LogDetailed(e);


### PR DESCRIPTION
Someone in modding_help ran into this

```
System.Security.Authentication.AuthenticationException: Authentication failed because the remote party sent a TLS alert: 'AccessDenied'.
```

Turns out they had a security thing blocking files.gamebanana.com, and Everest didn't fall back to a mirror, because this exception is not part of the caught exceptions (`TimeoutException`, `WebException` or `IOException`). 

This PR makes Everest fall back to a mirror on any exception like Olympus, most errors come from networking anyway.