### PR TITLE
add more useful fields to InvisibleBarrier

### DIFF
--- a/Celeste.Mod.mm/Patches/InvisibleBarrier.cs
+++ b/Celeste.Mod.mm/Patches/InvisibleBarrier.cs
@@ -13,6 +13,8 @@ namespace Celeste {
                 Remove(Get<ClimbBlocker>());
 
             SurfaceSoundIndex = data.Int("surfaceIndex", SurfaceSoundIndex);
+
+            AllowStaticMovers = data.Bool("allowStaticMovers", true);
         }
 
     }

--- a/Celeste.Mod.mm/Patches/InvisibleBarrier.cs
+++ b/Celeste.Mod.mm/Patches/InvisibleBarrier.cs
@@ -1,0 +1,19 @@
+using Microsoft.Xna.Framework;
+using MonoMod;
+
+namespace Celeste {
+    class patch_InvisibleBarrier : InvisibleBarrier {
+
+        [MonoModConstructor]
+        [MonoModReplace]
+        public patch_InvisibleBarrier(EntityData data, Vector2 offset)
+            : base(data.Position + offset, data.Width, data.Height) {
+
+            if (data.Bool("allowClimbing", false))
+                Remove(Get<ClimbBlocker>());
+
+            SurfaceSoundIndex = data.Int("surfaceIndex", SurfaceSoundIndex);
+        }
+
+    }
+}


### PR DESCRIPTION
seems useful

note the actual default soundindex is `Grass = 33` (apparently for bird nest reasons). a more sensible editor default would be `0` which is silent.

basic loenn plugin for testing:
```lua
local invisibleBarrier = {}

invisibleBarrier.name = "invisibleBarrier"
invisibleBarrier.fillColor = {0.4, 0.4, 0.4, 0.8}
invisibleBarrier.borderColor = {0.0, 0.0, 0.0, 0.0}
invisibleBarrier.placements = {
    name = "invisible_barrier",
    data = {
        width = 8,
        height = 8,
        allowClimbing = false, -- If disabled, blocks all climbing when the player is horizontally next to the barrier.
        surfaceIndex = 0, -- Footstep sound when walking on the barrier (or climbing, if enabled).
		allowStaticMovers = true -- If disabled, static movers like spikes won't attach to the barrier.
    }
}

return invisibleBarrier
```