### PR TITLE
add allowStaticMovers field to SeekerBarrier

### DIFF
--- a/Celeste.Mod.mm/Patches/SeekerBarrier.cs
+++ b/Celeste.Mod.mm/Patches/SeekerBarrier.cs
@@ -9,8 +9,13 @@ using System;
 
 namespace Celeste {
     public class patch_SeekerBarrier : SeekerBarrier {
-        public patch_SeekerBarrier(EntityData data, Vector2 offset) : base(data, offset) {
-            // no-op. MonoMod ignores this - we only need this to make the compiler shut up.
+
+        [MonoModConstructor]
+        [MonoModReplace]
+        public patch_SeekerBarrier(EntityData data, Vector2 offset)
+            : base(data.Position + offset, data.Width, data.Height) {
+
+            AllowStaticMovers = data.Bool("allowStaticMovers", true);
         }
 
         [MonoModIgnore]


### PR DESCRIPTION
basic loenn plugin for testing:

```lua
local seekerBarrier = {}

seekerBarrier.name = "seekerBarrier"
seekerBarrier.depth = 0
seekerBarrier.color = {0.25, 0.25, 0.25, 0.8}
seekerBarrier.placements = {
    name = "seeker_barrier",
    alternativeName = "jellyfish_barrier",
    data = {
        width = 8,
        height = 8,
        allowStaticMovers = true -- If disabled, static movers like spikes won't attach to the barrier.
    }
}


return seekerBarrier
```