### PR TITLE
rework LegacyHook IsLegacyMMCaller

### DIFF
--- a/Celeste.Mod.mm/Mod/Helpers/LegacyMonoMod/HookEndpointManager.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/LegacyMonoMod/HookEndpointManager.cs
@@ -28,29 +28,27 @@ namespace Celeste.Mod.Helpers.LegacyMonoMod {
             return false;
         }
 
-        private static bool IsLegacyMMCaller() {
-            foreach (StackFrame frame in new StackTrace().GetFrames())
-                if (frame.HasMethod() && frame.GetMethod()?.DeclaringType?.Assembly is Assembly asm && AssemblyLoadContext.GetLoadContext(asm) is EverestModuleAssemblyContext ctx)
-                    // Check if the mod was relinked from legacy MonoMod
-                    return !ctx.ModuleMeta.IsNetCoreOnlyMod || asm.CustomAttributes.Any(attr => attr.AttributeType == typeof(RelinkedMonoModLegacyAttribute));
-                    
+        private static bool IsLegacyMMCaller(Delegate method) {
+            if (method.Method?.DeclaringType?.Assembly is Assembly asm && AssemblyLoadContext.GetLoadContext(asm) is EverestModuleAssemblyContext ctx)
+                // Check if the mod was relinked from legacy MonoMod
+                return !ctx.ModuleMeta.IsNetCoreOnlyMod || asm.CustomAttributes.Any(attr => attr.AttributeType == typeof(RelinkedMonoModLegacyAttribute));
+
             return false;
         }
 
-        private static bool IsCoreModCaller() {
-            foreach (StackFrame frame in new StackTrace().GetFrames())
-                if (frame.HasMethod() && frame.GetMethod()?.DeclaringType?.Assembly is Assembly asm && AssemblyLoadContext.GetLoadContext(asm) is EverestModuleAssemblyContext ctx)
-                    return ctx.ModuleMeta.IsNetCoreOnlyMod;
-                    
+        private static bool IsCoreModCaller(Delegate method) {
+            if (method.Method?.DeclaringType?.Assembly is Assembly asm && AssemblyLoadContext.GetLoadContext(asm) is EverestModuleAssemblyContext ctx)
+                return ctx.ModuleMeta.IsNetCoreOnlyMod;
+
             return false;
         }
 
         public static void Add<T>(MethodBase method, Delegate hookDelegate) where T : Delegate => Add(method, hookDelegate);
         public static void Add(MethodBase method, Delegate hookDelegate) {
-            if (IsEverestInternalMethod(method) && IsCoreModCaller())
+            if (IsEverestInternalMethod(method) && IsCoreModCaller(hookDelegate))
                 throw new InvalidOperationException("Core mods may not add hooks to Everest internal methods");
 
-            Hook hook = new Hook(method, hookDelegate, LegacyDetourContext.GetCurrentDetourConfig(false, IsLegacyMMCaller()));
+            Hook hook = new Hook(method, hookDelegate, LegacyDetourContext.GetCurrentDetourConfig(false, IsLegacyMMCaller(hookDelegate)));
             if (Hooks.TryAdd((method, hookDelegate), hook))
                 return;
             hook.Dispose();
@@ -62,7 +60,7 @@ namespace Celeste.Mod.Helpers.LegacyMonoMod {
 
         public static void Remove<T>(MethodBase method, Delegate hookDelegate) where T : Delegate => Remove(method, hookDelegate);
         public static void Remove(MethodBase method, Delegate hookDelegate) {
-            if (IsEverestInternalMethod(method) && IsCoreModCaller())
+            if (IsEverestInternalMethod(method) && IsCoreModCaller(hookDelegate))
                 throw new InvalidOperationException("Core mods may not remove hooks from Everest internal methods");
 
             if (Hooks.TryRemove((method, hookDelegate), out Hook hook))
@@ -71,10 +69,10 @@ namespace Celeste.Mod.Helpers.LegacyMonoMod {
 
         public static void Modify<T>(MethodBase method, Delegate callback) where T : Delegate => Modify(method, callback);
         public static void Modify(MethodBase method, Delegate callback) {
-            if (IsEverestInternalMethod(method) && IsCoreModCaller())
+            if (IsEverestInternalMethod(method) && IsCoreModCaller(callback))
                 throw new InvalidOperationException("Core mods may not add hooks to Everest internal methods");
 
-            ILHook hook = new ILHook(method, (ILContext.Manipulator) callback, LegacyDetourContext.GetCurrentDetourConfig(true, IsLegacyMMCaller()));
+            ILHook hook = new ILHook(method, (ILContext.Manipulator) callback, LegacyDetourContext.GetCurrentDetourConfig(true, IsLegacyMMCaller(callback)));
             if (ILHooks.TryAdd((method, callback), hook))
                 return;
 
@@ -85,7 +83,7 @@ namespace Celeste.Mod.Helpers.LegacyMonoMod {
 
         public static void Unmodify<T>(MethodBase method, Delegate callback) => Unmodify(method, callback);
         public static void Unmodify(MethodBase method, Delegate callback) {
-            if (IsEverestInternalMethod(method) && IsCoreModCaller())
+            if (IsEverestInternalMethod(method) && IsCoreModCaller(callback))
                 throw new InvalidOperationException("Core mods may not remove hooks from Everest internal methods");
 
             if (ILHooks.TryRemove((method, callback), out ILHook hook))


### PR DESCRIPTION
relying on the stacktrace is not efficient and not safe.

jit may do tail call optimization, which can remove methods it should check from the stacktrace.

--------

this branch doesn't check StackTrace, instead it simply checks hookDelegate a hook uses.

downside:

will someone use some hook helper from other mods?