### PR TITLE
TileGrid public Tile type

### DIFF
--- a/Celeste.Mod.mm/Patches/Autotiler.cs
+++ b/Celeste.Mod.mm/Patches/Autotiler.cs
@@ -11,7 +11,6 @@ using MonoMod.Utils;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Xml;
 
 namespace Celeste {

--- a/Celeste.Mod.mm/Patches/Autotiler.cs
+++ b/Celeste.Mod.mm/Patches/Autotiler.cs
@@ -606,9 +606,9 @@ namespace MonoMod {
             TypeDefinition autotiler = context.Method.DeclaringType;
 
             // char Celeste.Autotiler/TerrainType::ID
-            FieldReference f_terrainTypeID = autotiler.NestedTypes.First(t => t.Name == "TerrainType").FindField("ID");
+            FieldReference f_TerrainType_ID = autotiler.NestedTypes.First(t => t.Name == "TerrainType").FindField("ID");
             // char Celeste.Autotiler/Tiles::ID
-            FieldReference f_tilesID = autotiler.NestedTypes.First(t => t.Name == "Tiles").FindField("ID");
+            FieldReference f_Tiles_ID = autotiler.NestedTypes.First(t => t.Name == "Tiles").FindField("ID");
 
             cursor.GotoNext(MoveType.After, instr => instr.MatchStloc(5));
             cursor.GotoNext(MoveType.After, instr => instr.MatchStloc(4));
@@ -617,8 +617,8 @@ namespace MonoMod {
 
             cursor.EmitLdloc(4); // tiles (Celeste.Autotiler/Tiles)
             cursor.EmitLdarg1(); // data (Celeste.Autotiler/TerrainType)
-            cursor.EmitLdfld(f_terrainTypeID); // data.ID (char)
-            cursor.EmitStfld(f_tilesID);
+            cursor.EmitLdfld(f_TerrainType_ID); // data.ID (char)
+            cursor.EmitStfld(f_Tiles_ID);
         }
     }
 }

--- a/Celeste.Mod.mm/Patches/Autotiler.cs
+++ b/Celeste.Mod.mm/Patches/Autotiler.cs
@@ -62,7 +62,7 @@ namespace Celeste {
                         for (int num = Math.Min(i + 50, startX + tilesX); k < num; k++) {
                             int l = j;
                             for (int num2 = Math.Min(j + 50, startY + tilesY); l < num2; l++) {
-                                char tile = TileIdHandler(mapData, k, l, forceFill, forceID, behaviour);
+                                char tile = TileHandler(mapData, k, l, forceFill, forceID, behaviour).ID;
                                 tileGrid.TileIds[k - startX, l - startY] = tile;
                             }
                         }
@@ -71,17 +71,13 @@ namespace Celeste {
             } else {
                 for (int m = startX; m < startX + tilesX; m++) {
                     for (int n = startY; n < startY + tilesY; n++) {
-                        char tile2 = TileIdHandler(null, m, n, forceFill, forceID, behaviour);
+                        char tile2 = TileHandler(null, m, n, forceFill, forceID, behaviour).ID;
                         tileGrid.TileIds[m - startX, n - startY] = tile2;
                     }
                 }
             }
 
             return result;
-        }
-
-        private char TileIdHandler(VirtualMap<char> mapData, int x, int y, Rectangle forceFill, char forceID, Behaviour behaviour) {
-            return GetTile(mapData, x, y, forceFill, forceID, behaviour);
         }
 
         [PatchAutotilerReadInto]

--- a/Celeste.Mod.mm/Patches/Autotiler.cs
+++ b/Celeste.Mod.mm/Patches/Autotiler.cs
@@ -47,7 +47,6 @@ namespace Celeste {
             Generated result = orig_Generate(mapData, startX, startY, tilesX, tilesY, forceSolid, forceID, behaviour);
 
             patch_TileGrid tileGrid = result.TileGrid as patch_TileGrid;
-            tileGrid.TileIds = new VirtualMap<char>(tilesX, tilesY);
             Rectangle forceFill = Rectangle.Empty;
             if (forceSolid) {
                 forceFill = new Rectangle(startX, startY, tilesX, tilesY);

--- a/Celeste.Mod.mm/Patches/Autotiler.cs
+++ b/Celeste.Mod.mm/Patches/Autotiler.cs
@@ -577,6 +577,9 @@ namespace MonoMod {
                 cursor.EmitLdfld(f_tilesTextures.DeclaringType.Resolve().FindField("ID"));
                 // [,] = ...
                 cursor.EmitCallvirt(m_virtualMapset_Item);
+
+                // advance past the current match
+                cursor.Index++;
             }
         }
 

--- a/Celeste.Mod.mm/Patches/Autotiler.cs
+++ b/Celeste.Mod.mm/Patches/Autotiler.cs
@@ -11,6 +11,7 @@ using MonoMod.Utils;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Xml;
 
 namespace Celeste {
@@ -42,43 +43,9 @@ namespace Celeste {
             return orig_GenerateOverlay(id, x, y, tilesX, tilesY, mapData);
         }
 
-        private extern Generated orig_Generate(VirtualMap<char> mapData, int startX, int startY, int tilesX, int tilesY, bool forceSolid, char forceID, Behaviour behaviour);
-        private Generated Generate(VirtualMap<char> mapData, int startX, int startY, int tilesX, int tilesY, bool forceSolid, char forceID, Behaviour behaviour) {
-            Generated result = orig_Generate(mapData, startX, startY, tilesX, tilesY, forceSolid, forceID, behaviour);
-
-            patch_TileGrid tileGrid = result.TileGrid as patch_TileGrid;
-            Rectangle forceFill = Rectangle.Empty;
-            if (forceSolid) {
-                forceFill = new Rectangle(startX, startY, tilesX, tilesY);
-            }
-            if (mapData != null) {
-                for (int i = startX; i < startX + tilesX; i += 50) {
-                    for (int j = startY; j < startY + tilesY; j += 50) {
-                        if (!mapData.AnyInSegmentAtTile(i, j)) {
-                            j = j / 50 * 50;
-                            continue;
-                        }
-                        int k = i;
-                        for (int num = Math.Min(i + 50, startX + tilesX); k < num; k++) {
-                            int l = j;
-                            for (int num2 = Math.Min(j + 50, startY + tilesY); l < num2; l++) {
-                                char tile = TileHandler(mapData, k, l, forceFill, forceID, behaviour).ID;
-                                tileGrid.TileIds[k - startX, l - startY] = tile;
-                            }
-                        }
-                    }
-                }
-            } else {
-                for (int m = startX; m < startX + tilesX; m++) {
-                    for (int n = startY; n < startY + tilesY; n++) {
-                        char tile2 = TileHandler(null, m, n, forceFill, forceID, behaviour).ID;
-                        tileGrid.TileIds[m - startX, n - startY] = tile2;
-                    }
-                }
-            }
-
-            return result;
-        }
+        [MonoModIgnore]
+        [PatchAutotilerGenerate]
+        private extern Generated Generate(VirtualMap<char> mapData, int startX, int startY, int tilesX, int tilesY, bool forceSolid, char forceID, Behaviour behaviour);
 
         [PatchAutotilerReadInto]
         private extern void orig_ReadInto(patch_TerrainType data, Tileset tileset, XmlElement xml);
@@ -545,6 +512,9 @@ namespace MonoMod {
     [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchAutotilerCtor))]
     class PatchAutotilerCtorAttribute : Attribute { }
 
+    [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchAutotilerGenerate))]
+    class PatchAutotilerGenerateAttribute : Attribute { }
+
     [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchAutotilerReadInto))]
     class PatchAutotilerReadIntoAttribute : Attribute { }
 
@@ -563,6 +533,52 @@ namespace MonoMod {
             cursor.EmitLdloc3(); // char c (the tileset id)
             cursor.EmitLdarg1(); // string filename (the xml path)
             cursor.EmitCallvirt(m_throwOnDuplicateId);
+        }
+
+        public static void PatchAutotilerGenerate(ILContext context, CustomAttribute attrib) {
+            ILCursor cursor = new(context);
+
+            int x = 0;
+            int y = 0;
+            int tiles = 0;
+            FieldReference f_tileGridTiles = null;
+            FieldReference f_tilesTextures = null;
+            MethodReference m_virtualMapset_Item = null;
+            // tileGrid.Tiles[{x} - startX, {y} - startY] = Calc.Random...({tiles}.Textures);
+            while (cursor.TryGotoNext(
+                instr => instr.MatchLdloc0(),
+                instr => instr.MatchLdfld(out f_tileGridTiles),
+                instr => instr.MatchLdloc(out x),
+                instr => instr.MatchLdarg2(),
+                instr => instr.MatchSub(),
+                instr => instr.MatchLdloc(out y),
+                instr => instr.MatchLdarg3(),
+                instr => instr.MatchSub(),
+                instr => instr.MatchLdsfld(typeof(Calc), nameof(Calc.Random)),
+                instr => instr.MatchLdloc(out tiles),
+                instr => instr.MatchLdfld(out f_tilesTextures),
+                instr => instr.MatchCall(out _),
+                instr => instr.MatchCallvirt(out m_virtualMapset_Item))) 
+            {
+                // tileGrid.TileIds[{x} - startX, {y} - startY] = {tiles}.ID;
+
+                // tileGrid.TileIds
+                cursor.EmitLdloc0();
+                cursor.EmitLdfld(f_tileGridTiles.DeclaringType.Resolve().FindField(nameof(patch_TileGrid.TileIds)));
+                // x - startX
+                cursor.EmitLdloc(x);
+                cursor.EmitLdarg2();
+                cursor.EmitSub();
+                // y - startY
+                cursor.EmitLdloc(y);
+                cursor.EmitLdarg3();
+                cursor.EmitSub();
+                // tiles.ID;
+                cursor.EmitLdloc(tiles);
+                cursor.EmitLdfld(f_tilesTextures.DeclaringType.Resolve().FindField("ID"));
+                // [,] = ...
+                cursor.EmitCallvirt(m_virtualMapset_Item);
+            }
         }
 
         public static void PatchAutotilerReadInto(ILContext context, CustomAttribute attrib) {

--- a/Celeste.Mod.mm/Patches/Autotiler.cs
+++ b/Celeste.Mod.mm/Patches/Autotiler.cs
@@ -537,9 +537,9 @@ namespace MonoMod {
         public static void PatchAutotilerGenerate(ILContext context, CustomAttribute attrib) {
             ILCursor cursor = new(context);
 
-            int x = 0;
-            int y = 0;
-            int tiles = 0;
+            int loc_x = 0;
+            int loc_y = 0;
+            int loc_tiles = 0;
             FieldReference f_tileGridTiles = null;
             FieldReference f_tilesTextures = null;
             MethodReference m_virtualMapset_Item = null;
@@ -547,14 +547,14 @@ namespace MonoMod {
             while (cursor.TryGotoNext(
                 instr => instr.MatchLdloc0(),
                 instr => instr.MatchLdfld(out f_tileGridTiles),
-                instr => instr.MatchLdloc(out x),
+                instr => instr.MatchLdloc(out loc_x),
                 instr => instr.MatchLdarg2(),
                 instr => instr.MatchSub(),
-                instr => instr.MatchLdloc(out y),
+                instr => instr.MatchLdloc(out loc_y),
                 instr => instr.MatchLdarg3(),
                 instr => instr.MatchSub(),
                 instr => instr.MatchLdsfld(out _),
-                instr => instr.MatchLdloc(out tiles),
+                instr => instr.MatchLdloc(out loc_tiles),
                 instr => instr.MatchLdfld(out f_tilesTextures),
                 instr => instr.MatchCall(out _),
                 instr => instr.MatchCallvirt(out m_virtualMapset_Item))) 
@@ -565,15 +565,15 @@ namespace MonoMod {
                 cursor.EmitLdloc0();
                 cursor.EmitLdfld(f_tileGridTiles.DeclaringType.Resolve().FindField("TileIds"));
                 // x - startX
-                cursor.EmitLdloc(x);
+                cursor.EmitLdloc(loc_x);
                 cursor.EmitLdarg2();
                 cursor.EmitSub();
                 // y - startY
-                cursor.EmitLdloc(y);
+                cursor.EmitLdloc(loc_y);
                 cursor.EmitLdarg3();
                 cursor.EmitSub();
                 // tiles.ID;
-                cursor.EmitLdloc(tiles);
+                cursor.EmitLdloc(loc_tiles);
                 cursor.EmitLdfld(f_tilesTextures.DeclaringType.Resolve().FindField("ID"));
                 // [,] = ...
                 cursor.EmitCallvirt(m_virtualMapset_Item);

--- a/Celeste.Mod.mm/Patches/Autotiler.cs
+++ b/Celeste.Mod.mm/Patches/Autotiler.cs
@@ -542,7 +542,24 @@ namespace MonoMod {
             int loc_tiles = 0;
             FieldReference f_tileGridTiles = null;
             FieldReference f_tilesTextures = null;
-            MethodReference m_virtualMapset_Item = null;
+
+            // cecil my beloved
+            // (i wasted like 3 hours figuring this out, only to find out i was like 1 step away from getting it right)
+
+            // Monocle.VirtualMap`1
+            TypeDefinition t_VirtualMap = context.Module.GetType("Monocle.VirtualMap`1");
+
+            // Monocle.VirtualMap`1<char>
+            GenericInstanceType t_VirtualMap_Char = new(t_VirtualMap);
+            t_VirtualMap_Char.GenericArguments.Add(context.Module.TypeSystem.Char);
+
+            // Monocle.VirtualMap`1<char>::set_Item(int32, int32, !0)
+            MethodReference m_VirtualMap_Char_set_Item = new MethodReference("set_Item", context.Module.TypeSystem.Void, t_VirtualMap_Char);
+            m_VirtualMap_Char_set_Item.Parameters.Add(new ParameterDefinition(context.Module.TypeSystem.Int32));
+            m_VirtualMap_Char_set_Item.Parameters.Add(new ParameterDefinition(context.Module.TypeSystem.Int32));
+            m_VirtualMap_Char_set_Item.Parameters.Add(new ParameterDefinition(t_VirtualMap.GenericParameters[0]));
+            m_VirtualMap_Char_set_Item.HasThis = true;
+
             // tileGrid.Tiles[{x} - startX, {y} - startY] = ...({tiles}.Textures);
             while (cursor.TryGotoNext(
                 instr => instr.MatchLdloc0(),
@@ -553,11 +570,11 @@ namespace MonoMod {
                 instr => instr.MatchLdloc(out loc_y),
                 instr => instr.MatchLdarg3(),
                 instr => instr.MatchSub(),
-                instr => instr.MatchLdsfld(out _),
+                instr => instr.MatchLdsfld("Monocle.Calc", "Random"),
                 instr => instr.MatchLdloc(out loc_tiles),
                 instr => instr.MatchLdfld(out f_tilesTextures),
-                instr => instr.MatchCall(out _),
-                instr => instr.MatchCallvirt(out m_virtualMapset_Item))) 
+                instr => instr.MatchCall("Monocle.Calc", "Choose"),
+                instr => instr.MatchCallvirt("Monocle.VirtualMap`1<Monocle.MTexture>", "set_Item")))
             {
                 // tileGrid.TileIds[{x} - startX, {y} - startY] = {tiles}.ID;
 
@@ -576,7 +593,7 @@ namespace MonoMod {
                 cursor.EmitLdloc(loc_tiles);
                 cursor.EmitLdfld(f_tilesTextures.DeclaringType.Resolve().FindField("ID"));
                 // [,] = ...
-                cursor.EmitCallvirt(m_virtualMapset_Item);
+                cursor.EmitCallvirt(m_VirtualMap_Char_set_Item);
 
                 // advance past the current match
                 cursor.Index++;

--- a/Celeste.Mod.mm/Patches/Autotiler.cs
+++ b/Celeste.Mod.mm/Patches/Autotiler.cs
@@ -10,6 +10,7 @@ using MonoMod.Cil;
 using MonoMod.Utils;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Xml;
 
 namespace Celeste {
@@ -84,6 +85,7 @@ namespace Celeste {
             return GetTile(mapData, x, y, forceFill, forceID, behaviour);
         }
 
+        [PatchAutotilerReadInto]
         private extern void orig_ReadInto(patch_TerrainType data, Tileset tileset, XmlElement xml);
         private void ReadInto(patch_TerrainType data, Tileset tileset, XmlElement xml) {
             if (xml.HasAttr("scanWidth")) {
@@ -110,7 +112,7 @@ namespace Celeste {
 
                 data.CustomFills = new List<patch_Tiles>();
                 for (int i = 0; i < fills.Count; i++)
-                    data.CustomFills.Add(new patch_Tiles());
+                    data.CustomFills.Add(new patch_Tiles() { ID = data.ID });
             }
 
             if (data.CustomFills == null && data.ScanWidth == 3 && data.ScanHeight == 3 && !xml.HasChild("define")) // ReadIntoCustomTemplate can handle vanilla templates but meh
@@ -169,6 +171,7 @@ namespace Celeste {
                             patch_Masked masked = new patch_Masked();
                             masked.Mask = new byte[data.ScanWidth * data.ScanHeight];
                             tiles = masked.Tiles;
+                            tiles.ID = data.ID;
 
                             try {
                                 // Allows for spacer characters like '-' in the xml
@@ -311,6 +314,7 @@ namespace Celeste {
             if (!lookup.TryGetValue(tile, out patch_TerrainType terrainType)) {
                 Logger.Error("Autotiler", $"Undefined tile id '{tile}' at ({x}, {y})");
                 return new patch_Tiles {
+                    ID = tile,
                     Textures = { ((patch_Atlas) GFX.Game).GetFallback() },
                 };
             }
@@ -498,6 +502,9 @@ namespace Celeste {
             public void ctor(char id) {
                 orig_ctor(id);
 
+                Center.ID = id;
+                Padded.ID = id;
+
                 IgnoreExceptions = new HashSet<char>();
 
                 whitelists = new Dictionary<byte, string>();
@@ -514,8 +521,9 @@ namespace Celeste {
         }
 
         // Required because Tiles is private.
-        [MonoModIgnore]
         private class patch_Tiles {
+            public char ID;
+
             public List<MTexture> Textures;
             public List<string> OverlapSprites;
             public bool HasOverlays;
@@ -542,6 +550,9 @@ namespace MonoMod {
     [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchAutotilerCtor))]
     class PatchAutotilerCtorAttribute : Attribute { }
 
+    [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchAutotilerReadInto))]
+    class PatchAutotilerReadIntoAttribute : Attribute { }
+
     static partial class MonoModRules {
         public static void PatchAutotilerCtor(ILContext context, CustomAttribute attrib) {
             ILCursor cursor = new(context);
@@ -557,6 +568,27 @@ namespace MonoMod {
             cursor.EmitLdloc3(); // char c (the tileset id)
             cursor.EmitLdarg1(); // string filename (the xml path)
             cursor.EmitCallvirt(m_throwOnDuplicateId);
+        }
+
+        public static void PatchAutotilerReadInto(ILContext context, CustomAttribute attrib) {
+            ILCursor cursor = new(context);
+
+            TypeDefinition autotiler = context.Method.DeclaringType;
+
+            // char Celeste.Autotiler/TerrainType::ID
+            FieldReference f_terrainTypeID = autotiler.NestedTypes.First(t => t.Name == "TerrainType").FindField("ID");
+            // char Celeste.Autotiler/Tiles::ID
+            FieldReference f_tilesID = autotiler.NestedTypes.First(t => t.Name == "Tiles").FindField("ID");
+
+            cursor.GotoNext(MoveType.After, instr => instr.MatchStloc(5));
+            cursor.GotoNext(MoveType.After, instr => instr.MatchStloc(4));
+
+            // tiles.ID = data.ID;
+
+            cursor.EmitLdloc(4); // tiles (Celeste.Autotiler/Tiles)
+            cursor.EmitLdarg1(); // data (Celeste.Autotiler/TerrainType)
+            cursor.EmitLdfld(f_terrainTypeID); // data.ID (char)
+            cursor.EmitStfld(f_tilesID);
         }
     }
 }

--- a/Celeste.Mod.mm/Patches/Autotiler.cs
+++ b/Celeste.Mod.mm/Patches/Autotiler.cs
@@ -41,6 +41,49 @@ namespace Celeste {
             return orig_GenerateOverlay(id, x, y, tilesX, tilesY, mapData);
         }
 
+        private extern Generated orig_Generate(VirtualMap<char> mapData, int startX, int startY, int tilesX, int tilesY, bool forceSolid, char forceID, Behaviour behaviour);
+        private Generated Generate(VirtualMap<char> mapData, int startX, int startY, int tilesX, int tilesY, bool forceSolid, char forceID, Behaviour behaviour) {
+            Generated result = orig_Generate(mapData, startX, startY, tilesX, tilesY, forceSolid, forceID, behaviour);
+
+            patch_TileGrid tileGrid = result.TileGrid as patch_TileGrid;
+            tileGrid.TileIds = new VirtualMap<char>(tilesX, tilesY);
+            Rectangle forceFill = Rectangle.Empty;
+            if (forceSolid) {
+                forceFill = new Rectangle(startX, startY, tilesX, tilesY);
+            }
+            if (mapData != null) {
+                for (int i = startX; i < startX + tilesX; i += 50) {
+                    for (int j = startY; j < startY + tilesY; j += 50) {
+                        if (!mapData.AnyInSegmentAtTile(i, j)) {
+                            j = j / 50 * 50;
+                            continue;
+                        }
+                        int k = i;
+                        for (int num = Math.Min(i + 50, startX + tilesX); k < num; k++) {
+                            int l = j;
+                            for (int num2 = Math.Min(j + 50, startY + tilesY); l < num2; l++) {
+                                char tile = TileIdHandler(mapData, k, l, forceFill, forceID, behaviour);
+                                tileGrid.TileIds[k - startX, l - startY] = tile;
+                            }
+                        }
+                    }
+                }
+            } else {
+                for (int m = startX; m < startX + tilesX; m++) {
+                    for (int n = startY; n < startY + tilesY; n++) {
+                        char tile2 = TileIdHandler(null, m, n, forceFill, forceID, behaviour);
+                        tileGrid.TileIds[m - startX, n - startY] = tile2;
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        private char TileIdHandler(VirtualMap<char> mapData, int x, int y, Rectangle forceFill, char forceID, Behaviour behaviour) {
+            return GetTile(mapData, x, y, forceFill, forceID, behaviour);
+        }
+
         private extern void orig_ReadInto(patch_TerrainType data, Tileset tileset, XmlElement xml);
         private void ReadInto(patch_TerrainType data, Tileset tileset, XmlElement xml) {
             if (xml.HasAttr("scanWidth")) {

--- a/Celeste.Mod.mm/Patches/Autotiler.cs
+++ b/Celeste.Mod.mm/Patches/Autotiler.cs
@@ -537,11 +537,17 @@ namespace MonoMod {
         public static void PatchAutotilerGenerate(ILContext context, CustomAttribute attrib) {
             ILCursor cursor = new(context);
 
+            TypeDefinition autotiler = context.Method.DeclaringType;
+
             int loc_x = 0;
             int loc_y = 0;
             int loc_tiles = 0;
-            FieldReference f_tileGridTiles = null;
-            FieldReference f_tilesTextures = null;
+
+            // Monocle.VirtualMap`1<char> Monocle.TileGrid::TileIds
+            FieldDefinition f_TileGrid_TileIds = context.Module.GetType("Monocle.TileGrid").FindField("TileIds");
+
+            // char Celeste.Autotiler/Tiles::ID
+            FieldDefinition f_Tiles_ID = autotiler.NestedTypes.First(t => t.Name == "Tiles").FindField("ID");
 
             // cecil my beloved
             // (i wasted like 3 hours figuring this out, only to find out i was like 1 step away from getting it right)
@@ -560,10 +566,10 @@ namespace MonoMod {
             m_VirtualMap_Char_set_Item.Parameters.Add(new ParameterDefinition(t_VirtualMap.GenericParameters[0]));
             m_VirtualMap_Char_set_Item.HasThis = true;
 
-            // tileGrid.Tiles[{x} - startX, {y} - startY] = ...({tiles}.Textures);
+            // tileGrid.Tiles[{x} - startX, {y} - startY] = Calc.Random.Choose({tiles}.Textures);
             while (cursor.TryGotoNext(
                 instr => instr.MatchLdloc0(),
-                instr => instr.MatchLdfld(out f_tileGridTiles),
+                instr => instr.MatchLdfld("Monocle.TileGrid", "Tiles"),
                 instr => instr.MatchLdloc(out loc_x),
                 instr => instr.MatchLdarg2(),
                 instr => instr.MatchSub(),
@@ -572,7 +578,7 @@ namespace MonoMod {
                 instr => instr.MatchSub(),
                 instr => instr.MatchLdsfld("Monocle.Calc", "Random"),
                 instr => instr.MatchLdloc(out loc_tiles),
-                instr => instr.MatchLdfld(out f_tilesTextures),
+                instr => instr.MatchLdfld("Celeste.Autotiler.Tiles", "Textures"),
                 instr => instr.MatchCall("Monocle.Calc", "Choose"),
                 instr => instr.MatchCallvirt("Monocle.VirtualMap`1<Monocle.MTexture>", "set_Item")))
             {
@@ -580,7 +586,7 @@ namespace MonoMod {
 
                 // tileGrid.TileIds
                 cursor.EmitLdloc0();
-                cursor.EmitLdfld(f_tileGridTiles.DeclaringType.Resolve().FindField("TileIds"));
+                cursor.EmitLdfld(f_TileGrid_TileIds);
                 // x - startX
                 cursor.EmitLdloc(loc_x);
                 cursor.EmitLdarg2();
@@ -591,7 +597,7 @@ namespace MonoMod {
                 cursor.EmitSub();
                 // tiles.ID;
                 cursor.EmitLdloc(loc_tiles);
-                cursor.EmitLdfld(f_tilesTextures.DeclaringType.Resolve().FindField("ID"));
+                cursor.EmitLdfld(f_Tiles_ID);
                 // [,] = ...
                 cursor.EmitCallvirt(m_VirtualMap_Char_set_Item);
 

--- a/Celeste.Mod.mm/Patches/Autotiler.cs
+++ b/Celeste.Mod.mm/Patches/Autotiler.cs
@@ -543,7 +543,7 @@ namespace MonoMod {
             FieldReference f_tileGridTiles = null;
             FieldReference f_tilesTextures = null;
             MethodReference m_virtualMapset_Item = null;
-            // tileGrid.Tiles[{x} - startX, {y} - startY] = Calc.Random...({tiles}.Textures);
+            // tileGrid.Tiles[{x} - startX, {y} - startY] = ...({tiles}.Textures);
             while (cursor.TryGotoNext(
                 instr => instr.MatchLdloc0(),
                 instr => instr.MatchLdfld(out f_tileGridTiles),
@@ -553,7 +553,7 @@ namespace MonoMod {
                 instr => instr.MatchLdloc(out y),
                 instr => instr.MatchLdarg3(),
                 instr => instr.MatchSub(),
-                instr => instr.MatchLdsfld(typeof(Calc), nameof(Calc.Random)),
+                instr => instr.MatchLdsfld(out _),
                 instr => instr.MatchLdloc(out tiles),
                 instr => instr.MatchLdfld(out f_tilesTextures),
                 instr => instr.MatchCall(out _),
@@ -563,7 +563,7 @@ namespace MonoMod {
 
                 // tileGrid.TileIds
                 cursor.EmitLdloc0();
-                cursor.EmitLdfld(f_tileGridTiles.DeclaringType.Resolve().FindField(nameof(patch_TileGrid.TileIds)));
+                cursor.EmitLdfld(f_tileGridTiles.DeclaringType.Resolve().FindField("TileIds"));
                 // x - startX
                 cursor.EmitLdloc(x);
                 cursor.EmitLdarg2();

--- a/Celeste.Mod.mm/Patches/Monocle/TileGrid.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/TileGrid.cs
@@ -4,6 +4,8 @@ using Microsoft.Xna.Framework;
 namespace Monocle {
     class patch_TileGrid : TileGrid {
 
+        public VirtualMap<char> TileIds;
+
         public patch_TileGrid() : base(0, 0, 0, 0) {
             // no-op. MonoMod ignores this - we only need this to make the compiler shut up.
         }

--- a/Celeste.Mod.mm/Patches/Monocle/TileGrid.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/TileGrid.cs
@@ -50,5 +50,15 @@ namespace Monocle {
                 renderPos.Y = position.Y + clippedRenderTiles.Top * tileHeight;
             }
         }
+
+        public char TilesetIdAt(Vector2 readPosition) {
+            Vector2 position = Entity.Position + Position;
+            int num = (int) ((readPosition.X - position.X) / 8f);
+            int num2 = (int) ((readPosition.Y - position.Y) / 8f);
+            if (num >= 0 && num2 >= 0 && num < TilesX && num2 < TilesY) {
+                return TileIds[num, num2];
+            }
+            return default;
+        }
     }
 }

--- a/Celeste.Mod.mm/Patches/Monocle/TileGrid.cs
+++ b/Celeste.Mod.mm/Patches/Monocle/TileGrid.cs
@@ -1,5 +1,8 @@
-﻿using Celeste;
+﻿#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
+
+using Celeste;
 using Microsoft.Xna.Framework;
+using MonoMod;
 
 namespace Monocle {
     class patch_TileGrid : TileGrid {
@@ -8,6 +11,13 @@ namespace Monocle {
 
         public patch_TileGrid() : base(0, 0, 0, 0) {
             // no-op. MonoMod ignores this - we only need this to make the compiler shut up.
+        }
+
+        public extern void orig_ctor(int tileWidth, int tileHeight, int tilesX, int tilesY);
+        [MonoModConstructor]
+        public void ctor(int tileWidth, int tileHeight, int tilesX, int tilesY) {
+            orig_ctor(tileWidth, tileHeight, tilesX, tilesY);
+            TileIds = new VirtualMap<char>(tilesX, tilesY);
         }
 
         // improve tile grid rendering performance


### PR DESCRIPTION
This PR modifies the Autotiler/Tiles and TileGrid classes so TileGrid inherently keeps a reference to the tileset id that was used to fill that portion of the grid, as well as a method to get an id at a position from that grid. This is done in an effort to access the specific tileset on contact for further optionability based on tileset id instead of only via sound index.