### PR TITLE
Fix MiniInstaller not copying FNA.dll into its workspace

### DIFF
--- a/MiniInstaller/Program.cs
+++ b/MiniInstaller/Program.cs
@@ -91,6 +91,8 @@ namespace MiniInstaller {
 
                 DepCalls.LoadModders();
 
+                File.Copy(Path.Combine(Globals.PathGame, "FNA.dll"), moddedFNA, overwrite: true);
+
                 // DepCalls.ConvertToNETCore also converts dependencies, so FNA will also be copied to the workspace
                 DepCalls.ConvertToNETCore(Path.Combine(Globals.PathOrig, "Celeste.exe"), moddedCeleste);
 


### PR DESCRIPTION
MiniInstaller wouldn't copy over FNA.dll into its workspace. Seems to be a Windows thing. Small fix though.