### PR TITLE
Fix MiniInstaller not copying FNA.dll into its workspace

### DIFF
--- a/MiniInstaller/Program.cs
+++ b/MiniInstaller/Program.cs
@@ -91,7 +91,7 @@ namespace MiniInstaller {
 
                 DepCalls.LoadModders();
 
-                File.Copy(Path.Combine(Globals.PathGame, "FNA.dll"), moddedFNA, overwrite: true);
+                File.Copy(Path.Combine(Globals.PathGame, "everest-lib/FNA.dll"), moddedFNA, overwrite: true);
 
                 // DepCalls.ConvertToNETCore also converts dependencies, so FNA will also be copied to the workspace
                 DepCalls.ConvertToNETCore(Path.Combine(Globals.PathOrig, "Celeste.exe"), moddedCeleste);

--- a/MiniInstaller/Program.cs
+++ b/MiniInstaller/Program.cs
@@ -91,7 +91,9 @@ namespace MiniInstaller {
 
                 DepCalls.LoadModders();
 
-                File.Copy(Path.Combine(Globals.PathGame, "everest-lib/FNA.dll"), moddedFNA, overwrite: true);
+                string libFNA = Path.Combine(Globals.PathGame, "everest-lib/FNA.dll");
+                if (File.Exists(libFNA))
+                    File.Copy(libFNA, moddedFNA, overwrite: true);
 
                 // DepCalls.ConvertToNETCore also converts dependencies, so FNA will also be copied to the workspace
                 DepCalls.ConvertToNETCore(Path.Combine(Globals.PathOrig, "Celeste.exe"), moddedCeleste);

--- a/MiniInstaller/Program.cs
+++ b/MiniInstaller/Program.cs
@@ -91,6 +91,8 @@ namespace MiniInstaller {
 
                 DepCalls.LoadModders();
 
+                File.Copy(Path.Combine(Globals.PathGame, "FNA.dll"), moddedFNA, overwrite: true);
+
                 // DepCalls.ConvertToNETCore also converts dependencies, so FNA will also be copied to the workspace
                 DepCalls.ConvertToNETCore(Path.Combine(Globals.PathOrig, "Celeste.exe"), moddedCeleste);
 


### PR DESCRIPTION
MiniInstaller expected FNA on XNA install, so just grab it from everest-lib/ instead