### PR TITLE
Fix "start vanilla Celeste" on Steam macOS

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/BOOT.cs
+++ b/Celeste.Mod.mm/Mod/Everest/BOOT.cs
@@ -268,8 +268,10 @@ namespace Celeste.Mod {
             // Revert native library path to prevent accidentally messing with vanilla
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 SetDllDirectory(null);
-            else
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 Environment.SetEnvironmentVariable("LD_LIBRARY_PATH", null);
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                Environment.SetEnvironmentVariable("DYLD_LIBRARY_PATH", null);
             
             // Don't clear FNA vars to preserve FNA compat mode
             StartCelesteProcess(Path.Combine(AppContext.BaseDirectory, "orig"), clearFNAEnv: false);


### PR DESCRIPTION
I don't know much about that wizardry but according to my testing it seems to work

- Steam: holding right at the title screen works, running from Olympus works
- Steam with appid.txt: holding right at the title screen relaunches Everest
- itch: holding right at the title screen closes the game, but running from Olympus works

