### PR TITLE
Internise asset format strings

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Content.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Content.cs
@@ -667,7 +667,7 @@ namespace Celeste.Mod {
                 if (format.Length < 1)
                     return file;
 
-                format = format[1..];
+                format = string.Intern(format[1..]);
 
                 ReadOnlySpan<char> fileSpan = file.AsSpan();
                 int fileSeparator = fileSpan.LastIndexOf('/') + 1;

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Content.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Content.cs
@@ -667,6 +667,7 @@ namespace Celeste.Mod {
                 if (format.Length < 1)
                     return file;
 
+                // Slicing "format" creates a new unique instance, which creates a lot duplicated strings of the same file ending if we have a lot of assets loaded. Better to intern it here
                 format = string.Intern(format[1..]);
 
                 ReadOnlySpan<char> fileSpan = file.AsSpan();


### PR DESCRIPTION
This line specifically seems to cause ~90k instances of the string "png" to be duplicated when loading with SSC enabled. Interning it should save around 3mb of wasted RAM. Free memory, download now