### PR TITLE
Intern BinaryPacker.Element and EntityData values, and PlaybackData animation ids.

### DIFF
--- a/Celeste.Mod.mm/Mod/Helpers/InternHelper.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/InternHelper.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Celeste.Mod.Helpers;
+
+/// <summary>
+/// Helper class for interning boxed representations of simple types, used extensively in EntityData and BinaryPacker elements.
+/// </summary>
+public static class InternHelper {
+    private static readonly object True = true;
+    private static readonly object False = false;
+    
+    /// <summary>
+    /// Returns a boxed representation of the given value, cached between calls.
+    /// </summary>
+    public static object Intern(bool value) => value ? True : False;
+    
+    /// <summary>
+    /// Returns a boxed representation of the given value, cached between calls.
+    /// Be careful when using this method on arbitrary values, as once interned, the value will never get un-interned and will leak memory.
+    /// Use only when you can prove it's beneficial to do so.
+    /// </summary>
+    public static object Intern(int value) => InternHelper<int>.Intern(value);
+    
+    /// <summary>
+    /// Returns a boxed representation of the given value, cached between calls.
+    /// Be careful when using this method on arbitrary values, as once interned, the value will never get un-interned and will leak memory.
+    /// Use only when you can prove it's beneficial to do so.
+    /// </summary>
+    public static object Intern(float value) => InternHelper<float>.Intern(value);
+    
+    /// <summary>
+    /// Tries to intern the given value if deemed profitable.
+    /// Returns either the interned value, or the original if no interning occured.
+    /// Be careful when using this method on arbitrary values, as once interned, the value will never get un-interned and will leak memory.
+    /// Use only when you can prove it's beneficial to do so.
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(value))]
+    public static object TryIntern(object value) {
+        if (value is int i)
+            return InternHelper<int>.Intern(i);
+        if (value is float f)
+            return InternHelper<float>.Intern(f);
+        if (value is bool b)
+            return Intern(b);
+        if (value is string s)
+            return string.Intern(s);
+
+        return value;
+    }
+}
+
+internal static class InternHelper<T> {
+    private static readonly Dictionary<T, object> Cache = new();
+    
+    public static object Intern(T value) {
+        return Cache.TryGetValue(value, out object result) ? result : Cache[value] = value;
+    }
+}

--- a/Celeste.Mod.mm/Mod/Helpers/InternHelper.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/InternHelper.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Celeste.Mod.Helpers;
@@ -51,9 +51,9 @@ public static class InternHelper {
 }
 
 internal static class InternHelper<T> {
-    private static readonly Dictionary<T, object> Cache = new();
+    private static readonly ConcurrentDictionary<T, object> Cache = new();
     
     public static object Intern(T value) {
-        return Cache.TryGetValue(value, out object result) ? result : Cache[value] = value;
+        return Cache.GetOrAdd(value, static x => x);
     }
 }

--- a/Celeste.Mod.mm/Patches/BinaryPacker.cs
+++ b/Celeste.Mod.mm/Patches/BinaryPacker.cs
@@ -1,6 +1,7 @@
 ﻿#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
 #pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
 
+using Celeste.Mod.Helpers;
 using MonoMod;
 using System.Collections.Generic;
 using System.IO;
@@ -16,6 +17,28 @@ namespace Celeste {
         [ProxyFileCalls] // ... except for proxying all System.IO.File.* calls to Celeste.Mod.FileProxy.*
         public static extern BinaryPacker.Element FromBinary(string filename);
 
+        /// <remarks>
+        /// EntityData will unbox some objects stored in BinaryPacker.Element and store them in a dedicated field.
+        /// We should only intern values that this will not happen to, otherwise we'll keep around a ton of unused ints interned.
+        /// From testing, not doing this causes ~31k ints to get interned but not used beyond loading in Strawberry Jam.
+        /// Delaying interning until EntityData is also not great, as stylegrounds use BinaryPacker.Element directly,
+        /// and as such would not get interned. In SJ, that amounts to ~27k uninterned ints.
+        ///
+        /// This compromise provided the best memory usage from testing, leading to ~11k ints allocated after game load,
+        /// most coming from unrelated sources.
+        /// </remarks>
+        private static bool IsKeyLikelyToGetUnboxedByEntityData(string key) {
+            return key is "x" or "y" or "id" or "width" or "height";
+        }
+
+        private static object InternIfUnlikelyToUnbox<T>(string key, T value) where T : struct {
+            if (IsKeyLikelyToGetUnboxedByEntityData(key)) {
+                return value;
+            }
+
+            return InternHelper<T>.Intern(value);
+        }
+        
         // optimise the method
         [MonoModReplace]
         private static BinaryPacker.Element ReadElement(BinaryReader reader) {
@@ -30,12 +53,16 @@ namespace Celeste {
                 string key = stringLookup[reader.ReadInt16()];
                 byte type = reader.ReadByte();
 
+                // We'll intern boxed values for booleans, integers and floats.
+                // Most values repeat very frequently inside maps (for example from copy-pasted spinners),
+                // so we benefit greatly even if some values might be cached unnecessarily.
+                // Since map data is loaded globally and almost never unloaded, the cost of unnecessary caching is very low.
                 object obj = type switch {
-                    0 => reader.ReadBoolean(),
-                    1 => Convert.ToInt32(reader.ReadByte(), CultureInfo.InvariantCulture),
-                    2 => Convert.ToInt32(reader.ReadInt16(), CultureInfo.InvariantCulture),
-                    3 => reader.ReadInt32(),
-                    4 => reader.ReadSingle(),
+                    0 => InternHelper.Intern(reader.ReadBoolean()),
+                    1 => InternIfUnlikelyToUnbox(key, Convert.ToInt32(reader.ReadByte(), CultureInfo.InvariantCulture)),
+                    2 => InternIfUnlikelyToUnbox(key, Convert.ToInt32(reader.ReadInt16(), CultureInfo.InvariantCulture)),
+                    3 => InternIfUnlikelyToUnbox(key, reader.ReadInt32()),
+                    4 => InternIfUnlikelyToUnbox(key, reader.ReadSingle()),
                     5 => stringLookup[reader.ReadInt16()],
                     6 => reader.ReadString(),
                     7 => ReadRunLengthEncoded(reader),

--- a/Celeste.Mod.mm/Patches/LevelData.cs
+++ b/Celeste.Mod.mm/Patches/LevelData.cs
@@ -1,5 +1,6 @@
 #pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
 
+using Celeste.Mod.Helpers;
 using Microsoft.Xna.Framework;
 using System;
 using Mono.Cecil;
@@ -49,7 +50,8 @@ namespace Celeste {
         [MonoModReplace]
         private EntityData CreateEntityData(BinaryPacker.Element entity) {
             EntityData entityData = new() {
-                Name = entity.Name,
+                // While Name comes from a lookup table, it's still duplicated between multiple .bin files.
+                Name = string.Intern(entity.Name),
                 Level = this
             };
             
@@ -86,7 +88,15 @@ namespace Celeste {
                             // but auto-resizing from passing a capacity too small would probably make it too big anyway.
                             entityData.Values ??= new Dictionary<string, object>(entity.Attributes.Count - 3);
                             
-                            entityData.Values.Add(key, value);
+                            // We'll intern boxed values here.
+                            // Most values repeat very frequently inside maps (for example from copy-pasted custom entities),
+                            // so we benefit greatly even if some values might be cached unnecessarily.
+                            // Since map data is loaded globally and almost never unloaded, the cost of unnecessary caching is very low.
+                            // While BinaryPacker already interned most values, those which come from MapDataProcessors
+                            // would be left uninterned, wasting memory.
+                            // We'll also intern keys, which, while they come from a lookup table already,
+                            // still get duplicated between different .bin files.
+                            entityData.Values.Add(string.Intern(key), InternHelper.TryIntern(value));
                             break;
                         }
                     }

--- a/Celeste.Mod.mm/Patches/LevelData.cs
+++ b/Celeste.Mod.mm/Patches/LevelData.cs
@@ -88,15 +88,9 @@ namespace Celeste {
                             // but auto-resizing from passing a capacity too small would probably make it too big anyway.
                             entityData.Values ??= new Dictionary<string, object>(entity.Attributes.Count - 3);
                             
-                            // We'll intern boxed values here.
-                            // Most values repeat very frequently inside maps (for example from copy-pasted custom entities),
-                            // so we benefit greatly even if some values might be cached unnecessarily.
-                            // Since map data is loaded globally and almost never unloaded, the cost of unnecessary caching is very low.
-                            // While BinaryPacker already interned most values, those which come from MapDataProcessors
-                            // would be left uninterned, wasting memory.
-                            // We'll also intern keys, which, while they come from a lookup table already,
+                            // We'll intern keys, which, while they come from a lookup table already,
                             // still get duplicated between different .bin files.
-                            entityData.Values.Add(string.Intern(key), InternHelper.TryIntern(value));
+                            entityData.Values.Add(string.Intern(key), value);
                             break;
                         }
                     }

--- a/Celeste.Mod.mm/Patches/PlaybackData.cs
+++ b/Celeste.Mod.mm/Patches/PlaybackData.cs
@@ -1,11 +1,15 @@
 ﻿#pragma warning disable CS0626 // Method, operator, or accessor is marked external and has no attributes on it
 #pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
 
+using Celeste;
 using Celeste.Mod;
-using Celeste.Mod.Helpers;
 using Microsoft.Xna.Framework;
+using Mono.Cecil;
 using Monocle;
 using MonoMod;
+using MonoMod.Cil;
+using MonoMod.InlineRT;
+using MonoMod.Utils;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -73,6 +77,7 @@ namespace Celeste {
             }
         }
 
+        [PatchChaserStateImport]
         public static extern List<Player.ChaserState> orig_Import(byte[] buffer);
         public static List<Player.ChaserState> Import(byte[] buffer) {
             try {
@@ -129,5 +134,36 @@ namespace Celeste {
             }
         }
 
+    }
+}
+
+namespace MonoMod {
+    /// <summary>
+    /// Patch the ChaserState.Import method to intern animation id strings, to reduce duplicate strings in memory.
+    /// </summary>
+    [MonoModCustomMethodAttribute(nameof(MonoModRules.PatchChaserStateImport))]
+    class PatchChaserStateImport : Attribute {
+    }
+
+    static partial class MonoModRules {
+
+        public static void PatchChaserStateImport(ILContext context, CustomAttribute attrib) {
+            MethodReference m_String_Intern = MonoModRule.Modder.Module.ImportReference(
+                MonoModRule.Modder.FindType("System.String").Resolve()
+                    .FindMethod("System.String Intern(System.String)")
+            );
+            
+            /*
+             * - chaserState.Animation = binaryReader.ReadString();
+             * + chaserState.Animation = string.Intern(binaryReader.ReadString());
+             */
+            ILCursor cursor = new ILCursor(context);
+            cursor.GotoNext(MoveType.After, 
+                instr => instr.MatchCallOrCallvirt("System.IO.BinaryReader", nameof(BinaryReader.ReadString)),
+                              instr => instr.MatchStfld("Celeste.Player/ChaserState", nameof(Player.ChaserState.Animation)));
+
+            cursor.Index--; // Go before the stfld
+            cursor.EmitCall(m_String_Intern);
+        }
     }
 }


### PR DESCRIPTION
Saves ~50MB RAM and reduces allocated object count by ~2 millions with Strawberry Jam.

More results starting from here: https://discord.com/channels/403698615446536203/429775439423209472/1533091706080067657