### PR TITLE
loader speedup: Cache archive metadata and assembly entries

### DIFF
--- a/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
@@ -194,6 +194,7 @@ namespace Celeste.Mod {
 
                 EverestSplashHandler.SetSplashLoadingModCount(files.Length + dirs.Length);
 
+                LoaderMetadataCache.Initialize(PathCache);
                 LoaderChecksumCache.Initialize(PathCache);
                 foreach (string file in files) {
                     LoadZip(Path.Combine(PathMods, file));
@@ -201,6 +202,7 @@ namespace Celeste.Mod {
                 foreach (string dir in dirs) {
                     LoadDir(Path.Combine(PathMods, dir));
                 }
+                LoaderMetadataCache.Flush();
 
                 enforceOptionalDependencies = false;
                 Logger.Info("loader", "Loading mods with unsatisfied optional dependencies (if any)");
@@ -266,48 +268,28 @@ namespace Celeste.Mod {
                 Logger.Verbose("loader", $"Loading mod .zip: {archive}");
 
                 EverestModuleMetadata[] multimetas = null;
-
                 IgnoreList ignoreList = null;
 
-                bool metaParsed = false;
-
-                using (ZipArchive zip = ZipFile.OpenRead(archive)) {
-                    foreach (ZipArchiveEntry entry in zip.Entries) {
-                        if (entry.FullName is "everest.yaml" or "everest.yml") {
-                            if (metaParsed) {
-                                Logger.Warn("loader", $"{archive} has both everest.yaml and everest.yml. Ignoring {entry.FullName}.");
-                                continue;
-                            }
-                            using (Stream stream = entry.Open())
-                            using (StreamReader reader = new StreamReader(stream)) {
-                                try {
-                                    if (!reader.EndOfStream) {
-                                        multimetas = YamlHelper.Deserializer.Deserialize<EverestModuleMetadata[]>(reader);
-                                        foreach (EverestModuleMetadata multimeta in multimetas) {
-                                            multimeta.PathArchive = archive;
-                                            multimeta.PostParse();
-                                        }
-                                    }
-                                } catch (Exception e) {
-                                    Logger.Warn("loader", $"Failed parsing {entry.FullName} in {archive}: {e}");
-                                    FilesWithMetadataLoadFailures.Add(archive);
-                                }
-                            }
-                            metaParsed = true;
-                            continue;
+                LoaderMetadataCache.ZipMetadata cached;
+                if (!LoaderMetadataCache.TryGet(archive, out cached)) {
+                    cached = LoaderMetadataCache.ReadArchive(archive);
+                    LoaderMetadataCache.Store(archive, cached);
+                }
+                if (cached.HasBothMetadataFiles)
+                    Logger.Warn("loader", $"{archive} has both everest.yaml and everest.yml. Ignoring the second file.");
+                if (cached.IgnoreLines != null)
+                    ignoreList = new IgnoreList(cached.IgnoreLines);
+                if (!string.IsNullOrEmpty(cached.Yaml)) {
+                    try {
+                        using StringReader reader = new StringReader(cached.Yaml);
+                        multimetas = YamlHelper.Deserializer.Deserialize<EverestModuleMetadata[]>(reader);
+                        foreach (EverestModuleMetadata multimeta in multimetas) {
+                            multimeta.PathArchive = archive;
+                            multimeta.PostParse();
                         }
-                        
-                        if (entry.FullName == ".everestignore") {
-                            List<string> lines = new List<string>();
-                            using (Stream stream = entry.Open())
-                            using (StreamReader reader = new StreamReader(stream)) {
-                                while (!reader.EndOfStream) {
-                                    lines.Add(reader.ReadLine());
-                                }
-                            }
-                            ignoreList = new IgnoreList(lines);
-                            continue;
-                        }
+                    } catch (Exception e) {
+                        Logger.Warn("loader", $"Failed parsing everest metadata in {archive}: {e}");
+                        FilesWithMetadataLoadFailures.Add(archive);
                     }
                 }
 

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Loader.cs
@@ -194,6 +194,7 @@ namespace Celeste.Mod {
 
                 EverestSplashHandler.SetSplashLoadingModCount(files.Length + dirs.Length);
 
+                LoaderChecksumCache.Initialize(PathCache);
                 foreach (string file in files) {
                     LoadZip(Path.Combine(PathMods, file));
                 }
@@ -204,6 +205,7 @@ namespace Celeste.Mod {
                 enforceOptionalDependencies = false;
                 Logger.Info("loader", "Loading mods with unsatisfied optional dependencies (if any)");
                 Everest.CheckDependenciesOfDelayedMods();
+                LoaderChecksumCache.Flush();
 
                 EverestSplashHandler.AllModsLoaded();
 

--- a/Celeste.Mod.mm/Mod/Everest/Everest.Relinker.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.Relinker.cs
@@ -18,7 +18,7 @@ namespace Celeste.Mod {
             /// <summary>
             /// The current Celeste.exe's checksum.
             /// </summary>
-            public static string GameChecksum => _GameChecksum = (_GameChecksum ?? Everest.GetChecksum(Assembly.GetAssembly(typeof(Relinker)).Location).ToHexadecimalString());
+            public static string GameChecksum => _GameChecksum = (_GameChecksum ?? Everest.GetCachedChecksum(Assembly.GetAssembly(typeof(Relinker)).Location).ToHexadecimalString());
             private static string _GameChecksum;
 
             /// <summary>

--- a/Celeste.Mod.mm/Mod/Everest/Everest.cs
+++ b/Celeste.Mod.mm/Mod/Everest/Everest.cs
@@ -147,15 +147,21 @@ namespace Celeste.Mod {
         }
 
         /// <summary>
+        /// Get a checksum through the startup loader's persistent stat-validated cache.
+        /// Falls back to a direct calculation before the cache is initialized.
+        /// </summary>
+        internal static byte[] GetCachedChecksum(string path) => LoaderChecksumCache.GetChecksum(path);
+
+        /// <summary>
         /// Get the checksum for a given mod. Might not be determined by the entire mod content.
         /// </summary>
         /// <param name="meta">The mod.</param>
         /// <returns>A checksum.</returns>
         public static byte[] GetChecksum(EverestModuleMetadata meta) {
             if (!string.IsNullOrEmpty(meta.PathArchive))
-                return GetChecksum(meta.PathArchive);
+                return GetCachedChecksum(meta.PathArchive);
             if (!string.IsNullOrEmpty(meta.DLL))
-                return GetChecksum(meta.DLL);
+                return GetCachedChecksum(meta.DLL);
             return new byte[0];
         }
 

--- a/Celeste.Mod.mm/Mod/Everest/LoaderChecksumCache.cs
+++ b/Celeste.Mod.mm/Mod/Everest/LoaderChecksumCache.cs
@@ -1,0 +1,121 @@
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Celeste.Mod {
+    /// <summary>
+    /// Persistent, stat-validated file checksum cache used by the startup loader.
+    /// </summary>
+    internal static class LoaderChecksumCache {
+        private const int HashHexLength = sizeof(ulong) * 2;
+
+        private sealed class ChecksumEntry {
+            public long Length { get; set; }
+            public long LastWriteUtcTicks { get; set; }
+            public string Hash { get; set; }
+        }
+
+        private readonly record struct FileFingerprint(string Path, long Length, long LastWriteUtcTicks);
+
+        private static readonly object Sync = new object();
+        private static Dictionary<string, ChecksumEntry> entries =
+            new Dictionary<string, ChecksumEntry>(StringComparer.OrdinalIgnoreCase);
+        private static string cachePath;
+        private static bool dirty;
+
+        internal static void Initialize(string pathCache) {
+            lock (Sync) {
+                cachePath = Path.Combine(pathCache, "everest-checksums-v1.json");
+                entries = new Dictionary<string, ChecksumEntry>(StringComparer.OrdinalIgnoreCase);
+                dirty = false;
+
+                if (!File.Exists(cachePath))
+                    return;
+
+                try {
+                    Dictionary<string, ChecksumEntry> loaded =
+                        JsonConvert.DeserializeObject<Dictionary<string, ChecksumEntry>>(File.ReadAllText(cachePath));
+                    if (loaded != null)
+                        entries = new Dictionary<string, ChecksumEntry>(loaded, StringComparer.OrdinalIgnoreCase);
+                } catch (Exception e) {
+                    Logger.Warn("loader", $"Ignoring invalid checksum cache: {e.Message}");
+                }
+            }
+        }
+
+        internal static byte[] GetChecksum(string path) {
+            lock (Sync) {
+                if (cachePath == null)
+                    return Calculate(path);
+
+                for (int attempt = 0; attempt < 3; attempt++) {
+                    FileFingerprint fingerprint = GetFingerprint(path);
+                    if (entries.TryGetValue(fingerprint.Path, out ChecksumEntry entry)
+                        && entry.Length == fingerprint.Length
+                        && entry.LastWriteUtcTicks == fingerprint.LastWriteUtcTicks) {
+                        try {
+                            if (entry.Hash?.Length == HashHexLength)
+                                return Convert.FromHexString(entry.Hash);
+                        } catch (FormatException) { }
+                        entries.Remove(fingerprint.Path);
+                        dirty = true;
+                    }
+
+                    byte[] hash;
+                    try {
+                        // Do not cache a hash while another process has the file open for writing.
+                        hash = Calculate(fingerprint.Path, FileShare.Read);
+                    } catch (IOException) {
+                        continue;
+                    }
+                    if (GetFingerprint(fingerprint.Path).Equals(fingerprint)) {
+                        entries[fingerprint.Path] = new ChecksumEntry {
+                            Length = fingerprint.Length,
+                            LastWriteUtcTicks = fingerprint.LastWriteUtcTicks,
+                            Hash = hash.ToHexadecimalString()
+                        };
+                        dirty = true;
+                        return hash;
+                    }
+                }
+
+                return Calculate(path);
+            }
+        }
+
+        internal static void Flush() {
+            lock (Sync) {
+                if (cachePath == null || !dirty)
+                    return;
+
+                string temporary = $"{cachePath}.{Environment.ProcessId}.tmp";
+                try {
+                    File.WriteAllText(temporary, JsonConvert.SerializeObject(entries, Formatting.None));
+                    File.Move(temporary, cachePath, true);
+                    dirty = false;
+                } catch (Exception e) {
+                    Logger.Warn("loader", $"Failed saving checksum cache: {e.Message}");
+                    try {
+                        File.Delete(temporary);
+                    } catch { }
+                }
+            }
+        }
+
+        private static FileFingerprint GetFingerprint(string path) {
+            FileInfo info = new FileInfo(path);
+            return new FileFingerprint(info.FullName, info.Length, info.LastWriteTimeUtc.Ticks);
+        }
+
+        private static byte[] Calculate(string path) {
+            return Calculate(path, FileShare.ReadWrite | FileShare.Delete);
+        }
+
+        private static byte[] Calculate(string path, FileShare share) {
+            using FileStream stream = new FileStream(path, FileMode.Open, FileAccess.Read, share,
+                bufferSize: 128 * 1024, FileOptions.SequentialScan);
+            return Everest.ComputeHash(stream);
+        }
+    }
+}

--- a/Celeste.Mod.mm/Mod/Everest/LoaderMetadataCache.cs
+++ b/Celeste.Mod.mm/Mod/Everest/LoaderMetadataCache.cs
@@ -1,0 +1,146 @@
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+
+namespace Celeste.Mod {
+    internal static class LoaderMetadataCache {
+        private static readonly bool Enabled = Environment.GetEnvironmentVariable("EVEREST_METADATA_CACHE") != "0";
+
+        internal sealed class ZipMetadata {
+            public long Length { get; set; }
+            public long LastWriteUtcTicks { get; set; }
+            public string Yaml { get; set; }
+            public List<string> IgnoreLines { get; set; }
+            public List<string> AssemblyEntries { get; set; }
+            public bool HasBothMetadataFiles { get; set; }
+        }
+
+        private sealed class CacheDocument {
+            public int Version { get; set; } = 1;
+            public Dictionary<string, ZipMetadata> Entries { get; set; } =
+                new Dictionary<string, ZipMetadata>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        private static readonly object Sync = new object();
+        private static CacheDocument document = new CacheDocument();
+        private static string cachePath;
+        private static bool dirty;
+
+        internal static void Initialize(string pathCache) {
+            cachePath = Path.Combine(pathCache, "everest-metadata-cache-v1.json");
+            document = new CacheDocument();
+            dirty = false;
+            if (!Enabled || !File.Exists(cachePath))
+                return;
+
+            try {
+                document = JsonConvert.DeserializeObject<CacheDocument>(File.ReadAllText(cachePath)) ?? new CacheDocument();
+                if (document.Version != 1 || document.Entries == null) {
+                    document = new CacheDocument();
+                } else {
+                    // Newtonsoft doesn't preserve comparers, so restore case-insensitive lookups.
+                    document.Entries = new Dictionary<string, ZipMetadata>(document.Entries, StringComparer.OrdinalIgnoreCase);
+                }
+            } catch (Exception e) {
+                Logger.Warn("loader", $"Ignoring invalid metadata cache: {e.Message}");
+                document = new CacheDocument();
+            }
+        }
+
+        internal static bool TryGet(string archive, out ZipMetadata metadata) {
+            metadata = null;
+            if (!Enabled || string.IsNullOrEmpty(archive))
+                return false;
+
+            FileInfo info = new FileInfo(archive);
+            lock (Sync) {
+                if (!document.Entries.TryGetValue(info.FullName, out ZipMetadata cached)
+                    || cached == null
+                    || cached.Length != info.Length
+                    || cached.LastWriteUtcTicks != info.LastWriteTimeUtc.Ticks
+                    || cached.AssemblyEntries == null)
+                    return false;
+                metadata = cached;
+                return true;
+            }
+        }
+
+        internal static bool TryContainsAssemblyEntry(string archive, string path, out bool contains) {
+            contains = false;
+            if (!TryGet(archive, out ZipMetadata metadata))
+                return false;
+            string normalized = path.Replace('\\', '/');
+            contains = metadata.AssemblyEntries.Any(s => s.Equals(normalized, StringComparison.OrdinalIgnoreCase));
+            return true;
+        }
+
+        internal static ZipMetadata ReadArchive(string archive) {
+            FileInfo info = new FileInfo(archive);
+            ZipMetadata result = new ZipMetadata {
+                Length = info.Length,
+                LastWriteUtcTicks = info.LastWriteTimeUtc.Ticks,
+                AssemblyEntries = new List<string>()
+            };
+            bool foundMetadata = false;
+            using ZipArchive zip = ZipFile.OpenRead(archive);
+            foreach (ZipArchiveEntry entry in zip.Entries) {
+                string name = entry.FullName;
+                if (name.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)
+                    || name.EndsWith(".pdb", StringComparison.OrdinalIgnoreCase))
+                    result.AssemblyEntries.Add(name.Replace('\\', '/'));
+
+                if (name is "everest.yaml" or "everest.yml") {
+                    if (foundMetadata) {
+                        result.HasBothMetadataFiles = true;
+                        continue;
+                    }
+                    using Stream stream = entry.Open();
+                    using StreamReader reader = new StreamReader(stream);
+                    result.Yaml = reader.ReadToEnd();
+                    foundMetadata = true;
+                } else if (name == ".everestignore") {
+                    using Stream stream = entry.Open();
+                    using StreamReader reader = new StreamReader(stream);
+                    result.IgnoreLines = new List<string>();
+                    while (!reader.EndOfStream)
+                        result.IgnoreLines.Add(reader.ReadLine());
+                }
+            }
+            return result;
+        }
+
+        internal static void Store(string archive, ZipMetadata metadata) {
+            if (!Enabled)
+                return;
+            lock (Sync) {
+                document.Entries[new FileInfo(archive).FullName] = metadata;
+                dirty = true;
+            }
+        }
+
+        internal static void Flush() {
+            if (!Enabled)
+                return;
+
+            lock (Sync) {
+                if (!dirty)
+                    return;
+
+                string temporary = cachePath + ".tmp";
+                try {
+                    File.WriteAllText(temporary, JsonConvert.SerializeObject(document, Formatting.None));
+                    File.Move(temporary, cachePath, true);
+                    dirty = false;
+                } catch (Exception e) {
+                    Logger.Warn("loader", $"Failed saving metadata cache: {e.Message}");
+                    try {
+                        File.Delete(temporary);
+                    } catch { }
+                }
+            }
+        }
+    }
+}

--- a/Celeste.Mod.mm/Mod/Module/EverestModuleAssemblyContext.cs
+++ b/Celeste.Mod.mm/Mod/Module/EverestModuleAssemblyContext.cs
@@ -191,10 +191,10 @@ namespace Celeste.Mod {
                 checksums.Add(ModuleMeta.Hash.ToHexadecimalString());
             } else if (!string.IsNullOrEmpty(ModuleMeta.PathDirectory)) {
                 // There's no overhead for accessing the files of directory mods, so just calculate the checksum directly
-                checksums.Add(Everest.GetChecksum(path).ToHexadecimalString());
+                checksums.Add(Everest.GetCachedChecksum(path).ToHexadecimalString());
 
                 if (symPath != null)
-                    checksums.Add(Everest.GetChecksum(symPath).ToHexadecimalString());
+                    checksums.Add(Everest.GetCachedChecksum(symPath).ToHexadecimalString());
             } else
                 throw new UnreachableException();
         }
@@ -203,7 +203,7 @@ namespace Celeste.Mod {
             if (!string.IsNullOrEmpty(ModuleMeta.PathArchive)) {
                 return ModuleMeta.Hash.ToHexadecimalString();
             } else if (!string.IsNullOrEmpty(ModuleMeta.PathDirectory)) {
-                return Everest.GetChecksum(path).ToHexadecimalString();
+                return Everest.GetCachedChecksum(path).ToHexadecimalString();
             } else throw new UnreachableException();
         }
 

--- a/Celeste.Mod.mm/Mod/Module/EverestModuleAssemblyContext.cs
+++ b/Celeste.Mod.mm/Mod/Module/EverestModuleAssemblyContext.cs
@@ -381,6 +381,10 @@ namespace Celeste.Mod {
         /// <param name="asmName">The assembly name, or null for the default</param>
         /// <returns></returns>
         public Assembly LoadAssemblyFromModPath(string path, string asmName = null) {
+            if (LoaderMetadataCache.TryContainsAssemblyEntry(ModuleMeta.PathArchive, path, out bool exists)
+                && !exists)
+                return null;
+
             lock (LOCK) {
                 if (isDisposed)
                     throw new ObjectDisposedException(nameof(EverestModuleAssemblyContext));


### PR DESCRIPTION
this should be merged after #1155
Cache everest.yml so that we don't have to open the zip for metadata and for checkig if one assembly exists each time