### PR TITLE
Fix `CassetteListener.EntityAdded` to use `Level.ShouldCreateCassetteManager`

### DIFF
--- a/Celeste.Mod.mm/Mod/Entities/CassetteListener.cs
+++ b/Celeste.Mod.mm/Mod/Entities/CassetteListener.cs
@@ -143,8 +143,8 @@ namespace Celeste.Mod.Entities {
                 level.CassetteBlockTempo = Tempo;
             }
 
-            // duplicates functionality of Level.ShouldCreateCassetteManager
-            if (!(level.Session.Area.Mode != AreaMode.Normal || !level.Session.Cassette)) {
+            // if we shouldn't create a cassette manager, don't
+            if (!((patch_Level) level)._ShouldCreateCassetteManager) {
                 return;
             }
 

--- a/Celeste.Mod.mm/Patches/Level.cs
+++ b/Celeste.Mod.mm/Patches/Level.cs
@@ -46,6 +46,11 @@ namespace Celeste {
 
         public SubHudRenderer SubHudRenderer;
 
+        // we want to expose `ShouldCreateCassetteManager` to `CassetteListener` without modifying its visibility, so create an internal property that forwards to it
+        [MonoModIgnore]
+        private bool ShouldCreateCassetteManager { get; }
+        internal bool _ShouldCreateCassetteManager => ShouldCreateCassetteManager;
+
         public class LoadOverride {
 
             public Player NextLoadedPlayer = null;


### PR DESCRIPTION
This PR makes `CassetteListener.EntityAdded` use `Level.ShouldCreateCassetteManager` directly when checking whether to add a `CassetteBlockManager`, instead of duplicating the logic. This makes mods hooking `ShouldCreateCassetteManager` (e.g. custom cassette blocks, most notably Quantum Mechanics' wonky cassette blocks) work properly with cassette listeners, as previously this would have required a hook into Everest.