### PR TITLE
Extend documentation throughout the code base

### DIFF
--- a/lib-stripped/Celeste.xml
+++ b/lib-stripped/Celeste.xml
@@ -449,14 +449,48 @@ How these should be structured is poorly documented, so if having nested members
             Attributes for this entity.
             </summary>
         </member>
-    </members>
+      </members>
       <members name="EntityID">
         <member name="T:Celeste.EntityID">
             <summary>
             A semi-unique id consisting of the level name and entity id (<see cref="T:System.Int32"/>).
             </summary>
         </member>
-    </members>
+        <member name="M:Celeste.EntityID.None">
+          <summary>
+            Representation of a "null" Entity ID.<br/>
+            Should not be modified directly, and instead copied to a local variable.
+          </summary>
+        </member>
+        <member name="M:Celeste.EntityID.Level">
+          <summary>
+            The name of the level in which the Entity is placed.
+          </summary>
+        </member>
+        <member name="M:Celeste.EntityID.ID">
+          <summary>
+            The numeric ID assigned to the Entity upon placement.
+          </summary>
+        </member>
+        <member name="P:Celeste.EntityID.Key">
+          <summary>
+            Combination of the level name and numeric ID as a single key in the format "level:id".
+          </summary>
+        </member>
+        <member name="M:Celeste.EntityID.#ctor(System.String,System.Int32)">
+          <summary>
+            Construct an Entity ID with the given level name and numeric ID.
+          </summary>
+        </member>
+        <member name="M:Celeste.EntityID.ToString">
+          <summary>
+            Returns the <see cref="P:Celeste.EntityID.Key"/> of this Entity ID.
+          </summary>
+        </member>
+        <member name="M:Celeste.EntityID.GetHashCode">
+          <inheritdoc/>
+        </member>
+      </members>
       
       <members name="CutsceneEntity">
         <member name="T:Celeste.CutsceneEntity">
@@ -674,7 +708,54 @@ How these should be structured is poorly documented, so if having nested members
             Lerp from right to left of the trigger.
             </summary>
         </member>
+      </members>
     </members>
+    <members name="Tags">
+      <members name="Tags">
+        <member name="T:Celeste.Tags">
+          <summary>
+            Provides <see cref="T:Monocle.BitTag"/> tags used by Entities throughout the game.
+          </summary>
+        </member>
+        <member name="M:Celeste.Tags.PauseUpdate">
+          <summary>
+            Tag used for Entities which should also update when the <see cref="T:Celeste.Level"/> is paused or frozen.
+          </summary>
+        </member>
+        <member name="M:Celeste.Tags.FrozenUpdate">
+          <summary>
+            Tag used for Entities which should also update when the <see cref="T:Celeste.Level"/> is in a frozen state.<br/>
+            This state is separate but similar to pausing, used for certain cutscenes, e.g. collecting all strawberry seeds, collecting a Heart Gem.<br/>
+            It is not to be confused with <see cref="M:Celeste.Celeste.Freeze(System.Single)"/>, which freezes the entire scene.
+          </summary>
+        </member>
+        <member name="M:Celeste.Tags.TransitionUpdate">
+          <summary>
+            Tag used for Entities which should also update during level transitions.
+          </summary>
+        </member>
+        <member name="M:Celeste.Tags.HUD">
+          <summary>
+            Tag used for Entities to be rendered at HUD level.<br/>
+            Uses a 1920 x 1080 pixel space instead of 320 x 180 as in the <see cref="T:Celeste.Level"/> scene.
+          </summary>
+        </member>
+        <member name="M:Celeste.Tags.Persistent">
+          <summary>
+            Tag used for Entities which should not be unloaded during level transitions.
+          </summary>
+        </member>
+        <member name="M:Celeste.Tags.Global">
+          <summary>
+            Tag used for Entities which should not be unloaded throughout the entire session.
+          </summary>
+        </member>
+        <member name="M:Celeste.Tags.Initialize">
+          <summary>
+            Initialises the tags. Called once in <see cref="M:Celeste.Celeste.Initialize"/>.
+          </summary>
+        </member>
+      </members>
     </members>
     <members name="Components">
       <members name="Listeners">

--- a/lib-stripped/Celeste.xml
+++ b/lib-stripped/Celeste.xml
@@ -1693,6 +1693,104 @@ How these should be structured is poorly documented, so if having nested members
       </member>
      </members>
     <members name="Entity">
+      <member name="T:Monocle.Entity">
+        <summary>
+          Represents an object in the Scene, as well as a collection of Components.
+        </summary>
+      </member>
+      <member name="M:Monocle.Entity.Active">
+        <summary>
+          Whether this Entity should update every frame.
+        </summary>
+      </member>
+      <member name="M:Monocle.Entity.Visible">
+        <summary>
+          Whether this Entity should render to the screen.
+        </summary>
+      </member>
+      <member name="M:Monocle.Entity.Collidable">
+        <summary>
+          Whether this Entity should be detected in collision checks.
+        </summary>
+      </member>
+      <member name="M:Monocle.Entity.Position">
+        <summary>
+          The position of this Entity in global coordinates.
+        </summary>
+      </member>
+      <member name="M:Monocle.Entity.tag">
+        <summary>
+          Backing field for <see cref="P:Monocle.Entity.Tag"/>.<br/>
+          This field should not be directly modified. Use <see cref="P:Monocle.Entity.Tag"/> instead.
+        </summary>
+      </member>
+      <member name="M:Monocle.Entity.collider">
+        <summary>
+          Backing field for <see cref="P:Monocle.Entity.Collider"/>.<br/>
+          This field should not be directly modified. Use <see cref="P:Monocle.Entity.Collider"/> instead.
+        </summary>
+      </member>
+      <member name="M:Monocle.Entity.depth">
+        <summary>
+          Backing field that holds the integral depth value of this Entity.<br/>
+          This field should not be directly modified. Use <see cref="P:Monocle.Entity.Depth"/> instead.
+        </summary>
+      </member>
+      <member name="M:Monocle.Entity.actualDepth">
+        <summary>
+          Backing field that holds the actual depth value of this Entity.<br/>
+          This field should not be directly modified. Use <see cref="P:Monocle.Entity.Depth"/> instead.
+        </summary>
+      </member>
+      <member name="P:Monocle.Entity.Scene">
+        <summary>
+          The Scene that contains this Entity.<br/>
+          Set when the Entity is added, and null when it is removed.
+        </summary>
+      </member>
+      <member name="P:Monocle.Entity.Components">
+        <summary>
+          The list of Components that this Entity contains.
+        </summary>
+      </member>
+      <member name="P:Monocle.Entity.Depth">
+        <summary>
+          The update / render priority of this Entity.<br/>
+          Lower values will make this entity update later, and render in front of other entities.
+        </summary>
+      </member>
+      <member name="P:Monocle.Entity.X">
+        <summary>
+          The global X position of this Entity.
+        </summary>
+      </member>
+      <member name="P:Monocle.Entity.Y">
+        <summary>
+          The global Y position of this Entity.
+        </summary>
+      </member>
+      <member name="P:Monocle.Entity.Collider">
+        <summary>
+          Defines a region on this Entity used for collision checks.
+        </summary>
+      </member>
+      <member name="P:Monocle.Entity.Tag">
+        <summary>
+          The bit tags applied to this Entity.<br/>
+          Combine tags using the | operator.<br/>
+          See <see cref="T:Celeste.Tags"/> for the tags used throughout Celeste.
+        </summary>
+      </member>
+      <member name="M:Monocle.Entity.#ctor(Microsoft.Xna.Framework.Vector2)">
+        <summary>
+          Create an Entity at the given global coordinates.
+        </summary>
+      </member>
+      <member name="M:Monocle.Entity.#ctor()">
+        <summary>
+          Create an Entity at the global origin point (0, 0).
+        </summary>
+      </member>
       <member name="M:Monocle.Entity.SceneBegin(Monocle.Scene)">
         <summary>
           Called when the containing Scene Begins.
@@ -1742,6 +1840,11 @@ How these should be structured is poorly documented, so if having nested members
       <member name="M:Monocle.Entity.HandleGraphicsReset">
         <summary>
           Called when the graphics device resets. When this happens, any RenderTargets or other contents of VRAM will be wiped and need to be regenerated.
+        </summary>
+      </member>
+      <member name="M:Monocle.Entity.RemoveSelf">
+        <summary>
+          Remove this entity from the Scene.
         </summary>
       </member>
       <member name="M:Monocle.Entity.Add(Monocle.Component)">

--- a/lib-stripped/Celeste.xml
+++ b/lib-stripped/Celeste.xml
@@ -726,7 +726,7 @@ How these should be structured is poorly documented, so if having nested members
           <summary>
             Tag used for Entities which should also update when the <see cref="T:Celeste.Level"/> is in a frozen state.<br/>
             This state is separate but similar to pausing, used for certain cutscenes, e.g. collecting all strawberry seeds, collecting a Heart Gem.<br/>
-            It is not to be confused with <see cref="M:Celeste.Celeste.Freeze(System.Single)"/>, which freezes the entire scene.
+            Not to be confused with <see cref="M:Celeste.Celeste.Freeze(System.Single)"/>, which freezes the entire section of the engine that updates the current scene.
           </summary>
         </member>
         <member name="M:Celeste.Tags.TransitionUpdate">
@@ -737,7 +737,7 @@ How these should be structured is poorly documented, so if having nested members
         <member name="M:Celeste.Tags.HUD">
           <summary>
             Tag used for Entities to be rendered at HUD level.<br/>
-            Uses a 1920 x 1080 pixel space instead of 320 x 180 as in the <see cref="T:Celeste.Level"/> scene.
+            This makes them use a 1920 x 1080 pixel space instead of 320 x 180 as in the <see cref="T:Celeste.Level"/> scene.
           </summary>
         </member>
         <member name="M:Celeste.Tags.Persistent">
@@ -752,7 +752,12 @@ How these should be structured is poorly documented, so if having nested members
         </member>
         <member name="M:Celeste.Tags.Initialize">
           <summary>
-            Initialises the tags. Called once in <see cref="M:Celeste.Celeste.Initialize"/>.
+            Initialises the tags. Called only once in <see cref="M:Celeste.Celeste.Initialize"/>.
+          </summary>
+        </member>
+        <member name="M:Celeste.Tags.orig_Initialize">
+          <summary>
+            Vanilla method of <see cref="M:Celeste.Tags.Initialize"/>.
           </summary>
         </member>
       </members>


### PR DESCRIPTION
this PR adds some more documentation for classes and members throughout the Celeste code base, potentially useful for code modders and anyone reading through the decompilation.
not finished yet, but currently open for review and any suggestions