### PR TITLE
Build mirror URLs using the MirrorName field of everest_update.yaml

### DIFF
--- a/Celeste.Mod.mm/Mod/Helpers/ModUpdateInfo.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/ModUpdateInfo.cs
@@ -7,7 +7,6 @@ namespace Celeste.Mod.Helpers {
         public virtual int LastUpdate { get; set; }
         public virtual string URL { get; set; }
         public virtual List<string> xxHash { get; set; }
-        public virtual string GameBananaType { get; set; }
-        public virtual int GameBananaId { get; set; }
+        public virtual string MirrorName { get; set; }
     }
 }

--- a/Celeste.Mod.mm/Mod/Helpers/ModUpdaterHelper.cs
+++ b/Celeste.Mod.mm/Mod/Helpers/ModUpdaterHelper.cs
@@ -251,25 +251,12 @@ namespace Celeste.Mod.Helpers {
             return overrideName ?? modNameRaw.SpacedPascalCase();
         }
 
-        public static IEnumerable GetAllMirrorUrls(string url) {
-            return getAllMirrorUrls(url);
-        }
-
         // Make sure to keep this in sync with
         // - https://github.com/EverestAPI/Olympus/blob/main/sharp/CmdUpdateAllMods.cs :: getAllMirrorUrls
         // - https://github.com/maddie480/RandomStuffWebsite/blob/main/front-vue/src/components/ModListItem.vue :: getMirrorLink
-        private static IEnumerable<string> getAllMirrorUrls(string url) {
-            uint gbid = 0;
-            if ((url.StartsWith("http://gamebanana.com/dl/") && !uint.TryParse(url.Substring("http://gamebanana.com/dl/".Length), out gbid)) ||
-                (url.StartsWith("https://gamebanana.com/dl/") && !uint.TryParse(url.Substring("https://gamebanana.com/dl/".Length), out gbid)) ||
-                (url.StartsWith("http://gamebanana.com/mmdl/") && !uint.TryParse(url.Substring("http://gamebanana.com/mmdl/".Length), out gbid)) ||
-                (url.StartsWith("https://gamebanana.com/mmdl/") && !uint.TryParse(url.Substring("https://gamebanana.com/mmdl/".Length), out gbid)))
-                gbid = 0;
-
-            if (gbid == 0) {
-                yield return url;
-                yield break;
-            }
+        public static IEnumerable<string> GetAllMirrorUrls(ModUpdateInfo mod) {
+            string url = mod.URL;
+            string mirrorName = mod.MirrorName;
 
             foreach (string mirrorId in CoreModule.Settings.MirrorPreferences.Split(',')) {
                 switch (mirrorId) {
@@ -278,19 +265,19 @@ namespace Celeste.Mod.Helpers {
                         break;
 
                     case "jade":
-                        yield return $"https://celestemodupdater.0x0a.de/banana-mirror/{gbid}.zip";
+                        yield return $"https://celestemodupdater.0x0a.de/banana-mirror/{mirrorName}.zip";
                         break;
 
                     case "wegfan":
-                        yield return $"https://celeste.weg.fan/api/v2/download/gamebanana-files/{gbid}";
+                        yield return $"https://celeste.weg.fan/api/v2/download/gamebanana-files/{mirrorName}";
                         break;
 
                     case "otobot":
-                        yield return $"https://banana-mirror-mods.celestemods.com/{gbid}.zip";
+                        yield return $"https://banana-mirror-mods.celestemods.com/{mirrorName}.zip";
                         break;
 
                     case "risingsunlight":
-                        yield return $"https://library.risingsunlight.dev/celeste/mods/{gbid}.zip";
+                        yield return $"https://library.risingsunlight.dev/celeste/mods/{mirrorName}.zip";
                         break;
                 }
             }

--- a/Celeste.Mod.mm/Mod/UI/AutoModUpdater.cs
+++ b/Celeste.Mod.mm/Mod/UI/AutoModUpdater.cs
@@ -129,7 +129,7 @@ namespace Celeste.Mod.UI {
 
                     Exception downloadException = null;
 
-                    foreach (string url in ModUpdaterHelper.GetAllMirrorUrls(update.URL)) {
+                    foreach (string url in ModUpdaterHelper.GetAllMirrorUrls(update)) {
                         try {
                             downloadException = null;
 

--- a/Celeste.Mod.mm/Mod/UI/OuiDependencyDownloader.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiDependencyDownloader.cs
@@ -459,7 +459,7 @@ namespace Celeste.Mod.UI {
 
                 Exception downloadException = null;
 
-                foreach (string url in ModUpdaterHelper.GetAllMirrorUrls(mod.URL)) {
+                foreach (string url in ModUpdaterHelper.GetAllMirrorUrls(mod)) {
                     try {
                         downloadException = null;
                         LogLine(string.Format(Dialog.Get("DEPENDENCYDOWNLOADER_DOWNLOADING"), mod.Name, url));

--- a/Celeste.Mod.mm/Mod/UI/OuiModUpdateList.cs
+++ b/Celeste.Mod.mm/Mod/UI/OuiModUpdateList.cs
@@ -351,7 +351,7 @@ namespace Celeste.Mod.UI {
 
             Exception downloadException = null;
 
-            foreach (string url in ModUpdaterHelper.GetAllMirrorUrls(update.URL)) {
+            foreach (string url in ModUpdaterHelper.GetAllMirrorUrls(update)) {
                 try {
                     downloadException = null;
 


### PR DESCRIPTION
... instead of using rad URL substrings that are sure to break if the URLs deviate from the current GameBanana formats in any way.

This mirrors (🥁) the change made in https://github.com/EverestAPI/Olympus/commit/a193d0c46c273711bfbdc8a3ca45af402122c3b2.